### PR TITLE
Added exportFormat parameter to LLMChatView

### DIFF
--- a/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
+++ b/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
@@ -160,12 +160,12 @@ struct LLMDemoView: View {
 
 The ``LLMChatView`` and ``LLMChatViewSchema`` present a basic chat views that enables users to chat with a Spezi LLM in a typical chat-like fashion. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 The ``LLMChatViewSchema`` takes an ``LLMSchema`` instance to define which LLM in what configuration should be used for the text inference.
-The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional ChatView/ChatExportFormat that defines the format of the to-be-exported SpeziChat/Chat (can be any of .pdf, .text, .json, or .none, defaults to .pdf).
+The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional `ChatView/ChatExportFormat` that defines the format of the to-be-exported `SpeziChat/Chat` (can be any of `.pdf`, `.text`, `.json`, or `.none`, defaults to `.pdf`).
 
 > Tip: The ``LLMChatView`` and ``LLMChatViewSchema`` build on top of the [SpeziChat package](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation).
     For more details, please refer to the DocC documentation of the [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview).
 
-> Tip: By defuault, the ``LLMChatView`` presents a share button in the toolbar that exports the current SpeziChat/Chat. To remove this element and disable export functionality, pass .none for the exportFormat parameter in ``LLMChatView/init(session:exportFormat:)``.
+> Tip: By defuault, the ``LLMChatView`` presents a share button in the toolbar that exports the current `SpeziChat/Chat`. To remove this element and disable export functionality, pass `.none` for the `exportFormat` parameter in ``LLMChatView/init(session:exportFormat:)``.
 
 #### Usage
 

--- a/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
+++ b/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
@@ -160,7 +160,7 @@ struct LLMDemoView: View {
 
 The ``LLMChatView`` and ``LLMChatViewSchema`` present a basic chat views that enables users to chat with a Spezi LLM in a typical chat-like fashion. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 The ``LLMChatViewSchema`` takes an ``LLMSchema`` instance to define which LLM in what configuration should be used for the text inference.
-The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional ``ChatView.ChatExportFormat`` that defines the format of the to-be-exported ``Chat`` (can be any of .pdf, .text, .json, or .none, defaults to .pdf).
+The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional ``ChatView/ChatExportFormat`` that defines the format of the to-be-exported ``Chat`` (can be any of .pdf, .text, .json, or .none, defaults to .pdf).
 
 > Tip: The ``LLMChatView`` and ``LLMChatViewSchema`` build on top of the [SpeziChat package](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation).
     For more details, please refer to the DocC documentation of the [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview).

--- a/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
+++ b/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
@@ -158,14 +158,14 @@ struct LLMDemoView: View {
 
 ### LLM Chat View
 
-The ``LLMChatView`` and ``LLMChatViewSchema`` present a basic chat views that enables users to chat with a Spezi LLM in a typical chat-like fashion. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
+The ``LLMChatView`` and ``LLMChatViewSchema`` present basic chat views that enable users to chat with a Spezi LLM in a typical chat-like fashion. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 The ``LLMChatViewSchema`` takes an ``LLMSchema`` instance to define which LLM in what configuration should be used for the text inference.
-The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional `ChatView/ChatExportFormat` that defines the format of the to-be-exported `SpeziChat/Chat` (can be any of `.pdf`, `.text`, `.json`, or `.none`, defaults to `.pdf`).
+The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional `ChatView/ChatExportFormat` that defines the format of the to-be-exported `SpeziChat/Chat` (can be any of `.pdf`, `.text`, `.json`, or `.none`, defaults to `.none`).
 
 > Tip: The ``LLMChatView`` and ``LLMChatViewSchema`` build on top of the [SpeziChat package](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation).
     For more details, please refer to the DocC documentation of the [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview).
 
-> Tip: By defuault, the ``LLMChatView`` presents a share button in the toolbar that exports the current `SpeziChat/Chat`. To remove this element and disable export functionality, pass `.none` for the `exportFormat` parameter in ``LLMChatView/init(session:exportFormat:)``.
+> Tip: By default, the ``LLMChatView`` presents no share button in the toolbar that exports the current `SpeziChat/Chat`. To add this element or change the export functionality, pass the desired export format for the `exportFormat` parameter in ``LLMChatView/init(session:exportFormat:)``.
 
 #### Usage
 

--- a/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
+++ b/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
@@ -160,10 +160,12 @@ struct LLMDemoView: View {
 
 The ``LLMChatView`` and ``LLMChatViewSchema`` present a basic chat views that enables users to chat with a Spezi LLM in a typical chat-like fashion. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 The ``LLMChatViewSchema`` takes an ``LLMSchema`` instance to define which LLM in what configuration should be used for the text inference.
-The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context.
+The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional ``ChatView.ChatExportFormat`` that defines the format of the to-be-exported ``Chat`` (can be any of .pdf, .text, .json, or .none, defaults to .pdf).
 
 > Tip: The ``LLMChatView`` and ``LLMChatViewSchema`` build on top of the [SpeziChat package](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation).
     For more details, please refer to the DocC documentation of the [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview).
+
+> Tip: By defuault, the ``LLMChatView`` presents a share button in the toolbar that exports the current ``Chat``. To remove this element and disable export functionality, pass ``.none`` for the exportFormat parameter in the ``LLMChatView`` initialization.
 
 #### Usage
 

--- a/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
+++ b/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
@@ -160,12 +160,12 @@ struct LLMDemoView: View {
 
 The ``LLMChatView`` and ``LLMChatViewSchema`` present a basic chat views that enables users to chat with a Spezi LLM in a typical chat-like fashion. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 The ``LLMChatViewSchema`` takes an ``LLMSchema`` instance to define which LLM in what configuration should be used for the text inference.
-The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional ``ChatView/ChatExportFormat`` that defines the format of the to-be-exported ``Chat`` (can be any of .pdf, .text, .json, or .none, defaults to .pdf).
+The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional ChatView/ChatExportFormat that defines the format of the to-be-exported SpeziChat/Chat (can be any of .pdf, .text, .json, or .none, defaults to .pdf).
 
 > Tip: The ``LLMChatView`` and ``LLMChatViewSchema`` build on top of the [SpeziChat package](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation).
     For more details, please refer to the DocC documentation of the [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview).
 
-> Tip: By defuault, the ``LLMChatView`` presents a share button in the toolbar that exports the current ``Chat``. To remove this element and disable export functionality, pass ``.none`` for the exportFormat parameter in the ``LLMChatView`` initialization.
+> Tip: By defuault, the ``LLMChatView`` presents a share button in the toolbar that exports the current SpeziChat/Chat. To remove this element and disable export functionality, pass .none for the exportFormat parameter in ``LLMChatView/init(session:exportFormat:)``.
 
 #### Usage
 

--- a/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
+++ b/Sources/SpeziLLM/SpeziLLM.docc/SpeziLLM.md
@@ -160,7 +160,7 @@ struct LLMDemoView: View {
 
 The ``LLMChatView`` and ``LLMChatViewSchema`` present basic chat views that enable users to chat with a Spezi LLM in a typical chat-like fashion. The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 The ``LLMChatViewSchema`` takes an ``LLMSchema`` instance to define which LLM in what configuration should be used for the text inference.
-The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional `ChatView/ChatExportFormat` that defines the format of the to-be-exported `SpeziChat/Chat` (can be any of `.pdf`, `.text`, `.json`, or `.none`, defaults to `.none`).
+The ``LLMChatView`` is passed an ``LLMSession`` that represents the LLM in execution containing state and context, and an optional `ChatView/ChatExportFormat` that defines the format of the to-be-exported `SpeziChat/Chat` (can be any of `.pdf`, `.text`, `.json`).
 
 > Tip: The ``LLMChatView`` and ``LLMChatViewSchema`` build on top of the [SpeziChat package](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation).
     For more details, please refer to the DocC documentation of the [`ChatView`](https://swiftpackageindex.com/stanfordspezi/spezichat/documentation/spezichat/chatview).

--- a/Sources/SpeziLLM/Views/LLMChatView.swift
+++ b/Sources/SpeziLLM/Views/LLMChatView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 /// Chat view that enables users to interact with an LLM based on an ``LLMSession``.
 ///
-/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional ``SpeziChat/ChatView/ChatExportFormat`` as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``. The ``SpeziChat/ChatView/ChatExportFormat`` defaults to .pdf, and can be any of .pdf, .text, .json, or .none.
+/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional ChatView/ChatExportFormat as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``. The ChatView/ChatExportFormat defaults to .pdf, and can be any of .pdf, .text, .json, or .none.
 ///
 /// The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 ///
@@ -28,7 +28,7 @@ import SwiftUI
 /// The next code examples demonstrate how to use the ``LLMChatView`` with ``LLMSession``s.
 ///
 /// The ``LLMChatView`` must be passed a ``LLMSession``, meaning a ready-to-use LLM, resulting in the need for the developer to manually allocate the ``LLMSession`` via the ``LLMRunner`` and ``LLMSchema`` (which includes state management).
-/// The ``LLMChatView`` may also be passed a ``ChatView/ChatExportFormat`` to determine the export format of the to-be-exported ``Chat``. This parameter may be omitted, in which case the format will be ``.pdf``. If ``.none`` is passed, no share button will be displayed in the toolbar.
+/// The ``LLMChatView`` may also be passed a ChatView/ChatExportFormat to determine the export format of the to-be-exported SpeziChat/Chat. This parameter may be omitted, in which case the format will be .pdf. If .none is passed, no share button will be displayed in the toolbar.
 ///
 /// In order to simplify the usage of an ``LLMSession``, SpeziLLM provides the ``LLMSessionProvider`` property wrapper that conveniently instantiates an ``LLMSchema`` to an ``LLMSession``.
 /// The `@LLMSessionProvider` wrapper abstracts away the necessity to use the ``LLMRunner`` from the SwiftUI `Environment` within a `.task()` view modifier to instantiate the ``LLMSession``.
@@ -58,7 +58,7 @@ public struct LLMChatView<Session: LLMSession>: View {
         llm.state.representation == .processing
     }
     
-    /// Defines the export format of the to-be-exported ``Chat``
+    /// Defines the export format of the to-be-exported SpeziChat/Chat
     private let exportFormat: ChatView.ChatExportFormat
     
     public var body: some View {
@@ -96,9 +96,7 @@ public struct LLMChatView<Session: LLMSession>: View {
     ///
     /// - Parameters:
     ///   - session: A `Binding` of a  ``LLMSession`` that contains the ready-to-use LLM to generate outputs based on user input.
-    ///   - exportFormat: An optional ``ChatView.ChatExportFormat`` that defines the format of the to-be-exported ``Chat``
-    ///         - Can be .pdf, .json, .text, or .none (default is .pdf)
-    ///         -  If .none, the chatview will present no export button in the toolbar
+    ///   - exportFormat: An optional ChatView/ChatExportFormat that defines the format of the to-be-exported SpeziChat/Chat (defaults to .pdf)
     public init(session: Binding<Session>, exportFormat: ChatView.ChatExportFormat = .pdf) {
         self._llm = session
         self.exportFormat = exportFormat

--- a/Sources/SpeziLLM/Views/LLMChatView.swift
+++ b/Sources/SpeziLLM/Views/LLMChatView.swift
@@ -28,9 +28,8 @@ import SwiftUI
 /// The next code examples demonstrate how to use the ``LLMChatView`` with ``LLMSession``s.
 ///
 /// The ``LLMChatView`` must be passed a ``LLMSession``, meaning a ready-to-use LLM, resulting in the need for the developer to manually allocate the ``LLMSession`` via the ``LLMRunner`` and ``LLMSchema`` (which includes state management).
-/// The ``LLMChatView`` may also be passed a `ChatView/ChatExportFormat` to enable the chat export functionality and define the format of the to-be-exported `SpeziChat/Chat`.
-/// The `ChatView/ChatExportFormat` defaults to `.none`; possible export formats are `.pdf`, `.text`, and `.json`.
-/// 
+/// The ``LLMChatView`` may also be passed a `ChatView/ChatExportFormat` to enable the chat export functionality and define the format of the to-be-exported `SpeziChat/Chat`; possible export formats are `.pdf`, `.text`, and `.json`.
+///
 /// In order to simplify the usage of an ``LLMSession``, SpeziLLM provides the ``LLMSessionProvider`` property wrapper that conveniently instantiates an ``LLMSchema`` to an ``LLMSession``.
 /// The `@LLMSessionProvider` wrapper abstracts away the necessity to use the ``LLMRunner`` from the SwiftUI `Environment` within a `.task()` view modifier to instantiate the ``LLMSession``.
 /// In addition, state handling becomes easier, as one doesn't have to deal with the optionality of the ``LLMSession`` anymore.
@@ -53,14 +52,13 @@ import SwiftUI
 public struct LLMChatView<Session: LLMSession>: View {
     /// The LLM in execution, as defined by the ``LLMSchema``.
     @Binding private var llm: Session
-    
     /// Indicates if the input field is disabled.
     @MainActor private var inputDisabled: Bool {
         llm.state.representation == .processing
     }
-    
     /// Defines the export format of the to-be-exported `SpeziChat/Chat`
-    private let exportFormat: ChatView.ChatExportFormat
+    private let exportFormat: ChatView.ChatExportFormat?
+    
     
     public var body: some View {
         ChatView(
@@ -98,7 +96,10 @@ public struct LLMChatView<Session: LLMSession>: View {
     /// - Parameters:
     ///   - session: A `Binding` of a  ``LLMSession`` that contains the ready-to-use LLM to generate outputs based on user input.
     ///   - exportFormat: An optional `ChatView/ChatExportFormat` to enable the chat export functionality and define the format of the to-be-exported `SpeziChat/Chat`.
-    public init(session: Binding<Session>, exportFormat: ChatView.ChatExportFormat = .none) {
+    public init(
+        session: Binding<Session>,
+        exportFormat: ChatView.ChatExportFormat? = nil
+    ) {
         self._llm = session
         self.exportFormat = exportFormat
     }

--- a/Sources/SpeziLLM/Views/LLMChatView.swift
+++ b/Sources/SpeziLLM/Views/LLMChatView.swift
@@ -28,6 +28,7 @@ import SwiftUI
 /// The next code examples demonstrate how to use the ``LLMChatView`` with ``LLMSession``s.
 ///
 /// The ``LLMChatView`` must be passed a ``LLMSession``, meaning a ready-to-use LLM, resulting in the need for the developer to manually allocate the ``LLMSession`` via the ``LLMRunner`` and ``LLMSchema`` (which includes state management).
+/// The ``LLMChatView`` may also be passed a ``ChatView.ChatExportFormat?`` to determine the export format of the to-be-exported ``Chat``. This parameter may be omitted, in which case the ``exportFormat`` will be ``.pdf``. If ``.none`` is passed, no share button will be displayed in the toolbar.
 ///
 /// In order to simplify the usage of an ``LLMSession``, SpeziLLM provides the ``LLMSessionProvider`` property wrapper that conveniently instantiates an ``LLMSchema`` to an ``LLMSession``.
 /// The `@LLMSessionProvider` wrapper abstracts away the necessity to use the ``LLMRunner`` from the SwiftUI `Environment` within a `.task()` view modifier to instantiate the ``LLMSession``.
@@ -42,7 +43,7 @@ import SwiftUI
 ///     @State var muted = true
 ///
 ///     var body: some View {
-///         LLMChatView(session: $llm)
+///         LLMChatView(session: $llm, exportFormat: .none)
 ///             .speak(llm.context, muted: muted)
 ///             .speechToolbarButton(muted: $muted)
 ///     }

--- a/Sources/SpeziLLM/Views/LLMChatView.swift
+++ b/Sources/SpeziLLM/Views/LLMChatView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 /// Chat view that enables users to interact with an LLM based on an ``LLMSession``.
 ///
-/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional ChatView/ChatExportFormat as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``. The ChatView/ChatExportFormat defaults to .pdf, and can be any of .pdf, .text, .json, or .none.
+/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional `ChatView/ChatExportFormat` as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``. The `ChatView/ChatExportFormat` defaults to `.pdf`, and can be any of `.pdf`, `.text`, `.json`, or `.none`.
 ///
 /// The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 ///
@@ -28,7 +28,7 @@ import SwiftUI
 /// The next code examples demonstrate how to use the ``LLMChatView`` with ``LLMSession``s.
 ///
 /// The ``LLMChatView`` must be passed a ``LLMSession``, meaning a ready-to-use LLM, resulting in the need for the developer to manually allocate the ``LLMSession`` via the ``LLMRunner`` and ``LLMSchema`` (which includes state management).
-/// The ``LLMChatView`` may also be passed a ChatView/ChatExportFormat to determine the export format of the to-be-exported SpeziChat/Chat. This parameter may be omitted, in which case the format will be .pdf. If .none is passed, no share button will be displayed in the toolbar.
+/// The ``LLMChatView`` may also be passed a `ChatView/ChatExportFormat` to determine the export format of the to-be-exported `SpeziChat/Chat`. This parameter may be omitted, in which case the format will be `.pdf`. If `.none` is passed, no share button will be displayed in the toolbar.
 ///
 /// In order to simplify the usage of an ``LLMSession``, SpeziLLM provides the ``LLMSessionProvider`` property wrapper that conveniently instantiates an ``LLMSchema`` to an ``LLMSession``.
 /// The `@LLMSessionProvider` wrapper abstracts away the necessity to use the ``LLMRunner`` from the SwiftUI `Environment` within a `.task()` view modifier to instantiate the ``LLMSession``.
@@ -58,7 +58,7 @@ public struct LLMChatView<Session: LLMSession>: View {
         llm.state.representation == .processing
     }
     
-    /// Defines the export format of the to-be-exported SpeziChat/Chat
+    /// Defines the export format of the to-be-exported `SpeziChat/Chat`
     private let exportFormat: ChatView.ChatExportFormat
     
     public var body: some View {
@@ -96,7 +96,7 @@ public struct LLMChatView<Session: LLMSession>: View {
     ///
     /// - Parameters:
     ///   - session: A `Binding` of a  ``LLMSession`` that contains the ready-to-use LLM to generate outputs based on user input.
-    ///   - exportFormat: An optional ChatView/ChatExportFormat that defines the format of the to-be-exported SpeziChat/Chat (defaults to .pdf)
+    ///   - exportFormat: An optional `ChatView/ChatExportFormat` that defines the format of the to-be-exported `SpeziChat/Chat` (defaults to `.pdf`)
     public init(session: Binding<Session>, exportFormat: ChatView.ChatExportFormat = .pdf) {
         self._llm = session
         self.exportFormat = exportFormat

--- a/Sources/SpeziLLM/Views/LLMChatView.swift
+++ b/Sources/SpeziLLM/Views/LLMChatView.swift
@@ -57,12 +57,14 @@ public struct LLMChatView<Session: LLMSession>: View {
         llm.state.representation == .processing
     }
     
+    /// Defines the export format of the ``Chat``
+    private let exportFormat: ChatView.ChatExportFormat?
     
     public var body: some View {
         ChatView(
             $llm.context,
             disableInput: inputDisabled,
-            exportFormat: .pdf,
+            exportFormat: exportFormat,
             messagePendingAnimation: .automatic
         )
             .viewStateAlert(state: llm.state)
@@ -92,9 +94,13 @@ public struct LLMChatView<Session: LLMSession>: View {
     /// Creates a ``LLMChatView`` with a `Binding` of a ``LLMSession`` that provides developers with a basic chat view to interact with a Spezi LLM.
     ///
     /// - Parameters:
-    ///   - model: A `Binding` of a  ``LLMSession`` that contains the ready-to-use LLM to generate outputs based on user input.
-    public init(session: Binding<Session>) {
+    ///   - session: A `Binding` of a  ``LLMSession`` that contains the ready-to-use LLM to generate outputs based on user input.
+    ///   - exportFormat: An optional ``ChatView.ChatExportFormat`` that defines the format of the to-be-exported ``Chat``
+    ///         - Can be .pdf, .json, .text, or .none (default is .pdf)
+    ///         -  If .none, the chatview will present no export button in the toolbar
+    public init(session: Binding<Session>, exportFormat: ChatView.ChatExportFormat? = .pdf) {
         self._llm = session
+        self.exportFormat = exportFormat
     }
 }
 

--- a/Sources/SpeziLLM/Views/LLMChatView.swift
+++ b/Sources/SpeziLLM/Views/LLMChatView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 /// Chat view that enables users to interact with an LLM based on an ``LLMSession``.
 ///
-/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional ``ChatView.ChatExportFormat?`` as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``. The ``ChatView.ChatExportFormat?`` defaults to .pdf, and can be any of .pdf, .text, .json, or .none.
+/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional ``ChatView.ChatExportFormat`` as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``. The ``ChatView.ChatExportFormat`` defaults to .pdf, and can be any of .pdf, .text, .json, or .none.
 ///
 /// The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 ///
@@ -28,7 +28,7 @@ import SwiftUI
 /// The next code examples demonstrate how to use the ``LLMChatView`` with ``LLMSession``s.
 ///
 /// The ``LLMChatView`` must be passed a ``LLMSession``, meaning a ready-to-use LLM, resulting in the need for the developer to manually allocate the ``LLMSession`` via the ``LLMRunner`` and ``LLMSchema`` (which includes state management).
-/// The ``LLMChatView`` may also be passed a ``ChatView.ChatExportFormat?`` to determine the export format of the to-be-exported ``Chat``. This parameter may be omitted, in which case the ``exportFormat`` will be ``.pdf``. If ``.none`` is passed, no share button will be displayed in the toolbar.
+/// The ``LLMChatView`` may also be passed a ``ChatView.ChatExportFormat`` to determine the export format of the to-be-exported ``Chat``. This parameter may be omitted, in which case the ``exportFormat`` will be ``.pdf``. If ``.none`` is passed, no share button will be displayed in the toolbar.
 ///
 /// In order to simplify the usage of an ``LLMSession``, SpeziLLM provides the ``LLMSessionProvider`` property wrapper that conveniently instantiates an ``LLMSchema`` to an ``LLMSession``.
 /// The `@LLMSessionProvider` wrapper abstracts away the necessity to use the ``LLMRunner`` from the SwiftUI `Environment` within a `.task()` view modifier to instantiate the ``LLMSession``.
@@ -58,8 +58,8 @@ public struct LLMChatView<Session: LLMSession>: View {
         llm.state.representation == .processing
     }
     
-    /// Defines the export format of the ``Chat``
-    private let exportFormat: ChatView.ChatExportFormat?
+    /// Defines the export format of the to-be-exported ``Chat``
+    private let exportFormat: ChatView.ChatExportFormat
     
     public var body: some View {
         ChatView(
@@ -99,7 +99,7 @@ public struct LLMChatView<Session: LLMSession>: View {
     ///   - exportFormat: An optional ``ChatView.ChatExportFormat`` that defines the format of the to-be-exported ``Chat``
     ///         - Can be .pdf, .json, .text, or .none (default is .pdf)
     ///         -  If .none, the chatview will present no export button in the toolbar
-    public init(session: Binding<Session>, exportFormat: ChatView.ChatExportFormat? = .pdf) {
+    public init(session: Binding<Session>, exportFormat: ChatView.ChatExportFormat = .pdf) {
         self._llm = session
         self.exportFormat = exportFormat
     }

--- a/Sources/SpeziLLM/Views/LLMChatView.swift
+++ b/Sources/SpeziLLM/Views/LLMChatView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 /// Chat view that enables users to interact with an LLM based on an ``LLMSession``.
 ///
-/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional `ChatView/ChatExportFormat` as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``. The `ChatView/ChatExportFormat` defaults to `.pdf`, and can be any of `.pdf`, `.text`, `.json`, or `.none`.
+/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional `ChatView/ChatExportFormat` as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``.
 ///
 /// The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 ///
@@ -28,8 +28,9 @@ import SwiftUI
 /// The next code examples demonstrate how to use the ``LLMChatView`` with ``LLMSession``s.
 ///
 /// The ``LLMChatView`` must be passed a ``LLMSession``, meaning a ready-to-use LLM, resulting in the need for the developer to manually allocate the ``LLMSession`` via the ``LLMRunner`` and ``LLMSchema`` (which includes state management).
-/// The ``LLMChatView`` may also be passed a `ChatView/ChatExportFormat` to determine the export format of the to-be-exported `SpeziChat/Chat`. This parameter may be omitted, in which case the format will be `.pdf`. If `.none` is passed, no share button will be displayed in the toolbar.
-///
+/// The ``LLMChatView`` may also be passed a `ChatView/ChatExportFormat` to enable the chat export functionality and define the format of the to-be-exported `SpeziChat/Chat`.
+/// The `ChatView/ChatExportFormat` defaults to `.none`; possible export formats are `.pdf`, `.text`, and `.json`.
+/// 
 /// In order to simplify the usage of an ``LLMSession``, SpeziLLM provides the ``LLMSessionProvider`` property wrapper that conveniently instantiates an ``LLMSchema`` to an ``LLMSession``.
 /// The `@LLMSessionProvider` wrapper abstracts away the necessity to use the ``LLMRunner`` from the SwiftUI `Environment` within a `.task()` view modifier to instantiate the ``LLMSession``.
 /// In addition, state handling becomes easier, as one doesn't have to deal with the optionality of the ``LLMSession`` anymore.
@@ -43,7 +44,7 @@ import SwiftUI
 ///     @State var muted = true
 ///
 ///     var body: some View {
-///         LLMChatView(session: $llm, exportFormat: .none)
+///         LLMChatView(session: $llm, exportFormat: .pdf)
 ///             .speak(llm.context, muted: muted)
 ///             .speechToolbarButton(muted: $muted)
 ///     }
@@ -96,8 +97,8 @@ public struct LLMChatView<Session: LLMSession>: View {
     ///
     /// - Parameters:
     ///   - session: A `Binding` of a  ``LLMSession`` that contains the ready-to-use LLM to generate outputs based on user input.
-    ///   - exportFormat: An optional `ChatView/ChatExportFormat` that defines the format of the to-be-exported `SpeziChat/Chat` (defaults to `.pdf`)
-    public init(session: Binding<Session>, exportFormat: ChatView.ChatExportFormat = .pdf) {
+    ///   - exportFormat: An optional `ChatView/ChatExportFormat` to enable the chat export functionality and define the format of the to-be-exported `SpeziChat/Chat`.
+    public init(session: Binding<Session>, exportFormat: ChatView.ChatExportFormat = .none) {
         self._llm = session
         self.exportFormat = exportFormat
     }

--- a/Sources/SpeziLLM/Views/LLMChatView.swift
+++ b/Sources/SpeziLLM/Views/LLMChatView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 /// Chat view that enables users to interact with an LLM based on an ``LLMSession``.
 ///
-/// The ``LLMChatView`` takes an ``LLMSession`` instance as parameter within the ``LLMChatView/init(session:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``.
+/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional ``ChatView.ChatExportFormat?`` as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``. The ``ChatView.ChatExportFormat?`` defaults to .pdf, and can be any of .pdf, .text, .json, or .none.
 ///
 /// The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 ///

--- a/Sources/SpeziLLM/Views/LLMChatView.swift
+++ b/Sources/SpeziLLM/Views/LLMChatView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 /// Chat view that enables users to interact with an LLM based on an ``LLMSession``.
 ///
-/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional ``ChatView.ChatExportFormat`` as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``. The ``ChatView.ChatExportFormat`` defaults to .pdf, and can be any of .pdf, .text, .json, or .none.
+/// The ``LLMChatView`` takes an ``LLMSession`` instance and an optional ``SpeziChat/ChatView/ChatExportFormat`` as parameters within the ``LLMChatView/init(session:exportFormat:)``. The ``LLMSession`` is the executable version of the LLM containing context and state as defined by the ``LLMSchema``. The ``SpeziChat/ChatView/ChatExportFormat`` defaults to .pdf, and can be any of .pdf, .text, .json, or .none.
 ///
 /// The input can be either typed out via the iOS keyboard or provided as voice input and transcribed into written text.
 ///
@@ -28,7 +28,7 @@ import SwiftUI
 /// The next code examples demonstrate how to use the ``LLMChatView`` with ``LLMSession``s.
 ///
 /// The ``LLMChatView`` must be passed a ``LLMSession``, meaning a ready-to-use LLM, resulting in the need for the developer to manually allocate the ``LLMSession`` via the ``LLMRunner`` and ``LLMSchema`` (which includes state management).
-/// The ``LLMChatView`` may also be passed a ``ChatView.ChatExportFormat`` to determine the export format of the to-be-exported ``Chat``. This parameter may be omitted, in which case the ``exportFormat`` will be ``.pdf``. If ``.none`` is passed, no share button will be displayed in the toolbar.
+/// The ``LLMChatView`` may also be passed a ``ChatView/ChatExportFormat`` to determine the export format of the to-be-exported ``Chat``. This parameter may be omitted, in which case the format will be ``.pdf``. If ``.none`` is passed, no share button will be displayed in the toolbar.
 ///
 /// In order to simplify the usage of an ``LLMSession``, SpeziLLM provides the ``LLMSessionProvider`` property wrapper that conveniently instantiates an ``LLMSchema`` to an ``LLMSession``.
 /// The `@LLMSessionProvider` wrapper abstracts away the necessity to use the ``LLMRunner`` from the SwiftUI `Environment` within a `.task()` view modifier to instantiate the ``LLMSession``.

--- a/Sources/SpeziLLM/Views/LLMChatViewSchema.swift
+++ b/Sources/SpeziLLM/Views/LLMChatViewSchema.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import SpeziChat
 import SwiftUI
 
 
@@ -32,21 +33,29 @@ import SwiftUI
 ///     }
 /// }
 /// ```
+///
+/// The ``LLMChatViewSchema`` may also be passed a `ChatView/ChatExportFormat` to enable the chat export functionality and define the format of the to-be-exported `SpeziChat/Chat`; possible export formats are `.pdf`, `.text`, and `.json`.
 public struct LLMChatViewSchema<Schema: LLMSchema>: View {
     @LLMSessionProvider<Schema> var llm: Schema.Platform.Session
+    private let exportFormat: ChatView.ChatExportFormat?
     
     
     public var body: some View {
-        LLMChatView(session: $llm)
+        LLMChatView(session: $llm, exportFormat: exportFormat)
     }
     
     
     /// Creates a ``LLMChatViewSchema`` with an ``LLMSchema`` that provides developers with a basic chat view to interact with a Spezi LLM.
-    ///
+    /// 
     /// - Parameters:
     ///   - schema: The ``LLMSchema`` that defines the to-be-used LLM to generate outputs based on user input.
-    public init(with schema: Schema) {
+    ///   - exportFormat: An optional `ChatView/ChatExportFormat` to enable the chat export functionality and define the format of the to-be-exported `SpeziChat/Chat`.
+    public init(
+        with schema: Schema,
+        exportFormat: ChatView.ChatExportFormat? = nil
+    ) {
         self._llm = LLMSessionProvider(schema: schema)
+        self.exportFormat = exportFormat
     }
 }
 


### PR DESCRIPTION
# LLMChatView exportFormat parameter

## :recycle: Current situation & Problem
Currently, the LLMChatView creates an instance of the ChatView by passing .pdf as the exportFormat. The result is that there is no way to change the export format or disable exporting entirely.

## :gear: Release Notes 
Instead of passing .pdf to the ChatView, LLMChatView now has an optional parameter exportFormat that is passed to the ChatView. By default, it is .pdf (so the .init signature need not change), but can now take any of .pdf, .json, .text, or .none. If exportFormat is .none, no export button will appear in the toolbar.


## :books: Documentation
The LLMChatView/init now has an optional new signature where the user passes in a value for exportFormat.
```swift
struct LLMChatTestView: View {
      // Use the convenience property wrapper to instantiate the `LLMMockSession`
     @LLMSessionProvider(schema: LLMMockSchema()) var llm: LLMMockSession
     @State var muted = true

     var body: some View {
         LLMChatView(session: $llm, exportFormat: .none)
             .speak(llm.context, muted: muted)
             .speechToolbarButton(muted: $muted)
     }
 }
``` 
Alternatively, the exportFormat parameter may be omitted, in which case the LLMChatView will default to .pdf.


## :white_check_mark: Testing
Export functionality is rigorously tested as part of the UI testing for the Spezi ChatView.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
