### PR TITLE
Add support for GPT-4o

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .library(name: "SpeziLLMFog", targets: ["SpeziLLMFog"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordBDHG/OpenAI", .upToNextMinor(from: "0.2.8")),
+        .package(url: "https://github.com/StanfordBDHG/OpenAI", .upToNextMinor(from: "0.2.9")),
         .package(url: "https://github.com/StanfordBDHG/llama.cpp", .upToNextMinor(from: "0.3.3")),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "1.0.4"),

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Spezi LLM provides a number of targets to help developers integrate LLMs in thei
 The section below highlights the setup and basic use of the [SpeziLLMLocal](https://swiftpackageindex.com/stanfordspezi/spezillm/documentation/spezillmlocal), [SpeziLLMOpenAI](https://swiftpackageindex.com/stanfordspezi/spezillm/documentation/spezillmopenai), and [SpeziLLMFog](https://swiftpackageindex.com/stanfordspezi/spezillm/documentation/spezillmfog) targets in order to integrate Language Models in a Spezi-based application. 
 
 > [!NOTE]  
-> To learn more about the usage of the individual targets, please refer to the [DocC documentation of the package] (https://swiftpackageindex.com/stanfordspezi/spezillm/documentation).
+> To learn more about the usage of the individual targets, please refer to the [DocC documentation of the package](https://swiftpackageindex.com/stanfordspezi/spezillm/documentation).
 
 ### Spezi LLM Local
 
@@ -136,7 +136,7 @@ struct LLMLocalDemoView: View {
 ```
 
 > [!NOTE]  
-> To learn more about the usage of SpeziLLMLocal, please refer to the [DocC documentation]: (https://swiftpackageindex.com/stanfordspezi/spezillm/documentation/spezillmlocal).
+> To learn more about the usage of SpeziLLMLocal, please refer to the [DocC documentation](https://swiftpackageindex.com/stanfordspezi/spezillm/documentation/spezillmlocal).
 
 ### Spezi LLM Open AI
 
@@ -198,7 +198,7 @@ struct LLMOpenAIDemoView: View {
 ```
 
 > [!NOTE]  
-> To learn more about the usage of SpeziLLMOpenAI, please refer to the [DocC documentation] (https://swiftpackageindex.com/stanfordspezi/spezillm/documentation/spezillmopenai).
+> To learn more about the usage of SpeziLLMOpenAI, please refer to the [DocC documentation](https://swiftpackageindex.com/stanfordspezi/spezillm/documentation/spezillmopenai).
 
 ### Spezi LLM Fog
 
@@ -272,7 +272,7 @@ struct LLMFogDemoView: View {
 ```
 
 > [!NOTE]  
-> To learn more about the usage of SpeziLLMFog, please refer to the [DocC documentation] (https://swiftpackageindex.com/stanfordspezi/spezillm/documentation/spezillmfog).
+> To learn more about the usage of SpeziLLMFog, please refer to the [DocC documentation](https://swiftpackageindex.com/stanfordspezi/spezillm/documentation/spezillmfog).
 
 ## Contributing
 

--- a/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunction.swift
+++ b/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunction.swift
@@ -51,7 +51,7 @@
 /// struct LLMOpenAIChatTestView: View {
 ///     private let schema = LLMOpenAISchema(
 ///         parameters: .init(
-///             modelType: .gpt4_1106_preview,
+///             modelType: .gpt4_turbo,
 ///             systemPrompt: "You're a helpful assistant that answers questions from users."
 ///         )
 ///     ) {

--- a/Sources/SpeziLLMOpenAI/Onboarding/LLMOpenAIModelOnboardingStep.swift
+++ b/Sources/SpeziLLMOpenAI/Onboarding/LLMOpenAIModelOnboardingStep.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// View to display an onboarding step for the user to enter change the OpenAI model.
 public struct LLMOpenAIModelOnboardingStep: View {
     public enum Default {
-        public static let models: [LLMOpenAIModelType] = [.gpt3_5Turbo, .gpt4_turbo_preview]
+        public static let models: [LLMOpenAIModelType] = [.gpt3_5Turbo, .gpt4_turbo, .gpt4_o]
     }
     
     

--- a/Sources/SpeziLLMOpenAI/SpeziLLMOpenAI.docc/FunctionCalling.md
+++ b/Sources/SpeziLLMOpenAI/SpeziLLMOpenAI.docc/FunctionCalling.md
@@ -57,7 +57,7 @@ struct WeatherFunction: LLMFunction {
 struct LLMOpenAIChatTestView: View {
     private let schema = LLMOpenAISchema(
         parameters: .init(
-            modelType: .gpt4_1106_preview,
+            modelType: .gpt4_turbo,
             systemPrompt: "You're a helpful assistant that answers questions from users."
         )
     ) {

--- a/Tests/SpeziLLMTests/LLMOpenAIParameterTests+Array.swift
+++ b/Tests/SpeziLLMTests/LLMOpenAIParameterTests+Array.swift
@@ -56,7 +56,7 @@ final class LLMOpenAIParameterArrayTests: XCTestCase {
     }
     
     let llm = LLMOpenAISchema(
-        parameters: .init(modelType: .gpt4_turbo_preview)
+        parameters: .init(modelType: .gpt4_turbo)
     ) {
         LLMFunctionTest(someInitArg: "testArg")
     }

--- a/Tests/SpeziLLMTests/LLMOpenAIParameterTests+CustomTypes.swift
+++ b/Tests/SpeziLLMTests/LLMOpenAIParameterTests+CustomTypes.swift
@@ -65,7 +65,7 @@ final class LLMOpenAIParameterCustomTypesTests: XCTestCase {
     }
     
     let llm = LLMOpenAISchema(
-        parameters: .init(modelType: .gpt4_turbo_preview)
+        parameters: .init(modelType: .gpt4_turbo)
     ) {
         LLMFunctionTest(someInitArg: "testArg")
     }

--- a/Tests/SpeziLLMTests/LLMOpenAIParameterTests+Enum.swift
+++ b/Tests/SpeziLLMTests/LLMOpenAIParameterTests+Enum.swift
@@ -61,7 +61,7 @@ final class LLMOpenAIParameterEnumTests: XCTestCase {
     }
     
     let llm = LLMOpenAISchema(
-        parameters: .init(modelType: .gpt4_turbo_preview)
+        parameters: .init(modelType: .gpt4_turbo)
     ) {
         LLMFunctionTest(someInitArg: "testArg")
     }

--- a/Tests/SpeziLLMTests/LLMOpenAIParameterTests+InvalidParameters.swift
+++ b/Tests/SpeziLLMTests/LLMOpenAIParameterTests+InvalidParameters.swift
@@ -44,7 +44,7 @@ final class LLMOpenAIInvalidParametersTests: XCTestCase {
     }
     
     let llm = LLMOpenAISchema(
-        parameters: .init(modelType: .gpt4_turbo_preview)
+        parameters: .init(modelType: .gpt4_turbo)
     ) {
         LLMFunctionTest(someInitArg: "testArg")
     }

--- a/Tests/SpeziLLMTests/LLMOpenAIParameterTests+OptionalTypes.swift
+++ b/Tests/SpeziLLMTests/LLMOpenAIParameterTests+OptionalTypes.swift
@@ -75,7 +75,7 @@ final class LLMOpenAIParameterOptionalTypesTests: XCTestCase {
     }
     
     let llm = LLMOpenAISchema(
-        parameters: .init(modelType: .gpt4_turbo_preview)
+        parameters: .init(modelType: .gpt4_turbo)
     ) {
         LLMFunctionTest(someInitArg: "testArg")
     }

--- a/Tests/SpeziLLMTests/LLMOpenAIParameterTests+PrimitiveTypes.swift
+++ b/Tests/SpeziLLMTests/LLMOpenAIParameterTests+PrimitiveTypes.swift
@@ -56,7 +56,7 @@ final class LLMOpenAIParameterPrimitiveTypesTests: XCTestCase {
     }
     
     let llm = LLMOpenAISchema(
-        parameters: .init(modelType: .gpt4_turbo_preview)
+        parameters: .init(modelType: .gpt4_turbo)
     ) {
         LLMFunctionTest(someInitArg: "testArg")
     }

--- a/Tests/UITests/TestApp/LLMOpenAI/LLMOpenAIChatTestView.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/LLMOpenAIChatTestView.swift
@@ -15,7 +15,7 @@ import SwiftUI
 struct LLMOpenAIChatTestView: View {
     static let schema = LLMOpenAISchema(
         parameters: .init(
-            modelType: .gpt4_turbo_preview,
+            modelType: .gpt4_turbo,
             systemPrompt: "You're a helpful assistant that answers questions from users."
         )
     ) {

--- a/Tests/UITests/TestAppUITests/TestAppLLMOpenAIUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppLLMOpenAIUITests.swift
@@ -44,15 +44,15 @@ class TestAppLLMOpenAIUITests: XCTestCase {
         #if os(macOS)
         XCTAssert(app.popUpButtons["modelPicker"].waitForExistence(timeout: 2))
         app.popUpButtons["modelPicker"].tap()
-        XCTAssert(app.menuItems["GPT 4 Turbo Preview"].waitForExistence(timeout: 2))
-        app.menuItems["GPT 4 Turbo Preview"].tap()
-        XCTAssert(app.popUpButtons["GPT 4 Turbo Preview"].waitForExistence(timeout: 2))
+        XCTAssert(app.menuItems["GPT 4 Turbo"].waitForExistence(timeout: 2))
+        app.menuItems["GPT 4 Turbo"].tap()
+        XCTAssert(app.popUpButtons["GPT 4 Turbo"].waitForExistence(timeout: 2))
         #elseif os(visionOS)
         app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).swipeUp()
-        XCTAssert(app.pickerWheels["GPT 4 Turbo Preview"].waitForExistence(timeout: 2))
+        XCTAssert(app.pickerWheels["GPT 4 Turbo"].waitForExistence(timeout: 2))
         #else
-        app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "GPT 4 Turbo Preview")
-        XCTAssert(app.pickerWheels["GPT 4 Turbo Preview"].waitForExistence(timeout: 2))
+        app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "GPT 4 Turbo")
+        XCTAssert(app.pickerWheels["GPT 4 Turbo"].waitForExistence(timeout: 2))
         #endif
         
         sleep(1)
@@ -64,14 +64,14 @@ class TestAppLLMOpenAIUITests: XCTestCase {
         let alert = app.alerts["Model Selected"]
         
         XCTAssertTrue(alert.waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(alert.staticTexts["gpt-4-turbo-preview"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert.staticTexts["gpt-4-turbo"].exists, "The correct model was not registered.")
         
         let okButton = alert.buttons["OK"]
         XCTAssertTrue(okButton.exists, "The OK button on the alert was not found.")
         okButton.tap()
         #else
         XCTAssertTrue(app.staticTexts["Model Selected"].waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(app.staticTexts["gpt-4-turbo-preview"].exists, "The correct model was not registered.")
+        XCTAssertTrue(app.staticTexts["gpt-4-turbo"].exists, "The correct model was not registered.")
         XCTAssert(app.buttons["OK"].firstMatch.waitForExistence(timeout: 2))
         app.buttons["OK"].firstMatch.tap()
         #endif

--- a/Tests/UITests/TestAppUITests/TestAppLLMOpenAIUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppLLMOpenAIUITests.swift
@@ -51,8 +51,8 @@ class TestAppLLMOpenAIUITests: XCTestCase {
         app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).swipeUp()
         XCTAssert(app.pickerWheels["GPT 4O"].waitForExistence(timeout: 2))
         #else
-        app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "GPT 4 Turbo")
-        XCTAssert(app.pickerWheels["GPT 4 Turbo"].waitForExistence(timeout: 2))
+        app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "GPT 4O")
+        XCTAssert(app.pickerWheels["GPT 4O"].waitForExistence(timeout: 2))
         #endif
         
         sleep(1)
@@ -64,7 +64,7 @@ class TestAppLLMOpenAIUITests: XCTestCase {
         let alert = app.alerts["Model Selected"]
         
         XCTAssertTrue(alert.waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(alert.staticTexts["gpt-4-turbo"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert.staticTexts["gpt-4o"].exists, "The correct model was not registered.")
         
         let okButton = alert.buttons["OK"]
         XCTAssertTrue(okButton.exists, "The OK button on the alert was not found.")

--- a/Tests/UITests/TestAppUITests/TestAppLLMOpenAIUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppLLMOpenAIUITests.swift
@@ -49,7 +49,7 @@ class TestAppLLMOpenAIUITests: XCTestCase {
         XCTAssert(app.popUpButtons["GPT 4 Turbo"].waitForExistence(timeout: 2))
         #elseif os(visionOS)
         app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).swipeUp()
-        XCTAssert(app.pickerWheels["GPT 4 Turbo"].waitForExistence(timeout: 2))
+        XCTAssert(app.pickerWheels["GPT 4O"].waitForExistence(timeout: 2))
         #else
         app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "GPT 4 Turbo")
         XCTAssert(app.pickerWheels["GPT 4 Turbo"].waitForExistence(timeout: 2))


### PR DESCRIPTION
# Add support for GPT-4o

## :gear: Release Notes 
- Lifts [OpenAI package](https://github.com/StanfordBDHG/OpenAI) version to 0.2.9.
- Adds GPT-4O to model options in onboarding via `LLMOpenAIModelOnboardingStep`.
- Replaces deprecated `gpt4-turbo-preview` model with `gpt4-turbo`

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
