### PR TITLE
SpeziLLMOpenAI: Repalce MacPaw/OpenAI With Generated API Calls

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,14 +2,13 @@
 
 //
 // This source file is part of the Stanford Spezi open source project
-// 
+//
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
-// 
+//
 // SPDX-License-Identifier: MIT
 //
 
 import PackageDescription
-
 
 let package = Package(
     name: "SpeziLLM",
@@ -34,7 +33,10 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.0.2"),
         .package(url: "https://github.com/StanfordSpezi/SpeziOnboarding", from: "1.1.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziChat", .upToNextMinor(from: "0.2.0")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.3.1")
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.3.1"),
+        .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.0")
     ],
     targets: [
         .target(
@@ -73,7 +75,12 @@ let package = Package(
                 .product(name: "Spezi", package: "Spezi"),
                 .product(name: "SpeziChat", package: "SpeziChat"),
                 .product(name: "SpeziSecureStorage", package: "SpeziStorage"),
-                .product(name: "SpeziOnboarding", package: "SpeziOnboarding")
+                .product(name: "SpeziOnboarding", package: "SpeziOnboarding"),
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession")
+            ],
+            plugins: [
+                .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")
             ]
         ),
         .target(

--- a/Sources/SpeziLLM/Models/LLMContextEntity.swift
+++ b/Sources/SpeziLLM/Models/LLMContextEntity.swift
@@ -19,6 +19,8 @@ public struct LLMContextEntity: Codable, Equatable, Hashable, Identifiable {
     public struct ToolCall: Codable, Equatable, Hashable {
         /// The ID of the function call, uniquely identifying the specific function call and matching the response to it.
         public let id: String
+        /// The type of the function call. Currently only "function" is supported by OpenAI.
+        public let type: String = "function"
         /// The name of the function call.
         public let name: String
         /// The arguments as JSON of the function call.

--- a/Sources/SpeziLLMOpenAI/Configuration/LLMOpenAIModelParameters.swift
+++ b/Sources/SpeziLLMOpenAI/Configuration/LLMOpenAIModelParameters.swift
@@ -7,13 +7,12 @@
 //
 
 import Foundation
-import OpenAI
-
+import OpenAPIRuntime
 
 /// Represents the model-specific parameters of OpenAIs LLMs.
 public struct LLMOpenAIModelParameters: Sendable {
     /// The format for model responses.
-    let responseFormat: ChatQuery.ResponseFormat?
+    let responseFormat: Components.Schemas.CreateChatCompletionRequest.response_formatPayload?
     /// The sampling temperature (0 to 2). Higher values increase randomness, lower values enhance focus.
     let temperature: Double?
     /// Nucleus sampling threshold. Considers tokens with top_p probability mass. Alternative to temperature sampling.
@@ -31,7 +30,7 @@ public struct LLMOpenAIModelParameters: Sendable {
     /// Controls repetition (-2.0 to 2.0). Higher values reduce the likelihood of repeating content.
     let frequencyPenalty: Double?
     /// Alters specific token's likelihood in completion.
-    let logitBias: [String: Int]
+    let logitBias: Components.Schemas.CreateChatCompletionRequest.logit_biasPayload
     /// Unique identifier for the end-user, aiding in abuse monitoring.
     let user: String?
     
@@ -51,7 +50,7 @@ public struct LLMOpenAIModelParameters: Sendable {
     ///   - logitBias: Alters specific token's likelihood in completion.
     ///   - user: Unique identifier for the end-user, aiding in abuse monitoring.
     public init(
-        responseFormat: ChatQuery.ResponseFormat? = nil,
+        responseFormat: Components.Schemas.CreateChatCompletionRequest.response_formatPayload? = nil,
         temperature: Double? = nil,
         topP: Double? = nil,
         completionsPerOutput: Int? = nil,
@@ -72,10 +71,9 @@ public struct LLMOpenAIModelParameters: Sendable {
         self.seed = seed
         self.presencePenalty = presencePenalty
         self.frequencyPenalty = frequencyPenalty
-        self.logitBias = logitBias
+        self.logitBias = Components.Schemas.CreateChatCompletionRequest
+            .logit_biasPayload(additionalProperties: logitBias)
         self.user = user
     }
 }
 
-
-extension ChatQuery.ResponseFormat: @unchecked Sendable {}

--- a/Sources/SpeziLLMOpenAI/Configuration/LLMOpenAIParameters.swift
+++ b/Sources/SpeziLLMOpenAI/Configuration/LLMOpenAIParameters.swift
@@ -7,8 +7,7 @@
 //
 
 import Foundation
-import OpenAI
-
+import OpenAPIRuntime
 
 /// Represents the parameters of OpenAIs LLMs.
 public struct LLMOpenAIParameters: Sendable {
@@ -21,7 +20,7 @@ public struct LLMOpenAIParameters: Sendable {
     
     
     /// The to-be-used OpenAI model.
-    let modelType: Model
+    let modelType: LLMOpenAIModelType
     /// The to-be-used system prompt(s) of the LLM.
     let systemPrompts: [String]
     /// Indicates if a model access test should be made during LLM setup.
@@ -38,7 +37,7 @@ public struct LLMOpenAIParameters: Sendable {
     ///   - modelAccessTest: Indicates if access to the configured OpenAI model via the specified token should be made upon LLM setup.
     ///   - overwritingToken: Separate OpenAI token that overrides the one defined within the ``LLMOpenAIPlatform``.
     public init(
-        modelType: Model,
+        modelType: LLMOpenAIModelType,
         systemPrompt: String? = Defaults.defaultOpenAISystemPrompt,
         modelAccessTest: Bool = false,
         overwritingToken: String? = nil
@@ -60,7 +59,7 @@ public struct LLMOpenAIParameters: Sendable {
     ///   - overwritingToken: Separate OpenAI token that overrides the one defined within the ``LLMOpenAIPlatform``.
     @_disfavoredOverload
     public init(
-        modelType: Model,
+        modelType: LLMOpenAIModelType,
         systemPrompts: [String] = [Defaults.defaultOpenAISystemPrompt],
         modelAccessTest: Bool = false,
         overwritingToken: String? = nil

--- a/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunctionParameterWrapper+ArrayTypes.swift
+++ b/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunctionParameterWrapper+ArrayTypes.swift
@@ -22,8 +22,8 @@ extension _LLMFunctionParameterWrapper where T: AnyArray, T.Element: BinaryInteg
     ///    - minItems: Defines the minimum amount of values in the `array`.
     ///    - maxItems: Defines the maximum amount of values in the `array`.
     ///    - uniqueItems: Specifies if all `array` elements need to be unique.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         multipleOf: Int? = nil,
         minimum: T.Element? = nil,
@@ -32,20 +32,44 @@ extension _LLMFunctionParameterWrapper where T: AnyArray, T.Element: BinaryInteg
         maxItems: Int? = nil,
         uniqueItems: Bool? = nil
     ) {
-        self.init(schema: .init(
-            type: .array,
-            description: String(description),
-            items: .init(
-                type: .integer,
-                const: const.map { String($0) },
-                multipleOf: multipleOf,
-                minimum: minimum.map { Double($0) },
-                maximum: maximum.map { Double($0) }
-            ),
-            minItems: minItems,
-            maxItems: maxItems,
-            uniqueItems: uniqueItems
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "array",
+                "description": String(description)
+            ]
+            var itemsNoOpt: [String: any Sendable] = [
+                "type": "integer"
+            ]
+            if let const = const.map({ String($0) }) {
+                itemsNoOpt["const"] = const
+            }
+            if let multipleOf {
+                itemsNoOpt["multipleOf"] = multipleOf
+            }
+            if let minimum {
+                itemsNoOpt["minimum"] = Double(minimum)
+            }
+            if let maximum {
+                itemsNoOpt["maximum"] = Double(maximum)
+            }
+            if itemsNoOpt.count > 1 {
+                addProp["items"] = itemsNoOpt
+            }
+            if let minItems {
+                addProp["minItems"] = minItems
+            }
+            if let maxItems {
+                addProp["maxItems"] = maxItems
+            }
+            if let uniqueItems {
+                addProp["uniqueItems"] = uniqueItems
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+ArrayTypes")
+        }
     }
 }
 
@@ -60,8 +84,8 @@ extension _LLMFunctionParameterWrapper where T: AnyArray, T.Element: BinaryFloat
     ///    - minItems: Defines the minimum amount of values in the `array`.
     ///    - maxItems: Defines the maximum amount of values in the `array`.
     ///    - uniqueItems: Specifies if all `array` elements need to be unique.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         minimum: T.Element? = nil,
         maximum: T.Element? = nil,
@@ -69,19 +93,41 @@ extension _LLMFunctionParameterWrapper where T: AnyArray, T.Element: BinaryFloat
         maxItems: Int? = nil,
         uniqueItems: Bool? = nil
     ) {
-        self.init(schema: .init(
-            type: .array,
-            description: String(description),
-            items: .init(
-                type: .number,
-                const: const.map { String($0) },
-                minimum: minimum.map { Double($0) },
-                maximum: maximum.map { Double($0) }
-            ),
-            minItems: minItems,
-            maxItems: maxItems,
-            uniqueItems: uniqueItems
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "array",
+                "description": String(description)
+            ]
+            var itemsNoOpt: [String: any Sendable] = [
+                "type": "number"
+            ]
+            if let const = const.map({ String($0) }) {
+                itemsNoOpt["const"] = const
+            }
+            if let minimum {
+                itemsNoOpt["minimum"] = Double(minimum)
+            }
+            if let maximum {
+                itemsNoOpt["maximum"] = Double(maximum)
+            }
+            if itemsNoOpt.count > 1 {
+                addProp["items"] = itemsNoOpt
+            }
+            if let minItems {
+                addProp["minItems"] = minItems
+            }
+            if let maxItems {
+                addProp["maxItems"] = maxItems
+            }
+            if let uniqueItems {
+                addProp["uniqueItems"] = uniqueItems
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LMMFunctionParameter+ArrayTypes")
+        }
     }
 }
 
@@ -94,24 +140,42 @@ extension _LLMFunctionParameterWrapper where T: AnyArray, T.Element == Bool {
     ///    - minItems: Defines the minimum amount of values in the `array`.
     ///    - maxItems: Defines the maximum amount of values in the `array`.
     ///    - uniqueItems: Specifies if all `array` elements need to be unique.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         minItems: Int? = nil,
         maxItems: Int? = nil,
         uniqueItems: Bool? = nil
     ) {
-        self.init(schema: .init(
-            type: .array,
-            description: String(description),
-            items: .init(
-                type: .boolean,
-                const: const.map { String($0) }
-            ),
-            minItems: minItems,
-            maxItems: maxItems,
-            uniqueItems: uniqueItems
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "array",
+                "description": String(description)
+            ]
+            var itemsNoOpt: [String: any Sendable] = [
+                "type": "boolean"
+            ]
+            if let const = const.map({ String($0) }) {
+                itemsNoOpt["const"] = const
+            }
+            if itemsNoOpt.count > 1 {
+                addProp["items"] = itemsNoOpt
+            }
+            if let minItems {
+                addProp["minItems"] = minItems
+            }
+            if let maxItems {
+                addProp["maxItems"] = maxItems
+            }
+            if let uniqueItems {
+                addProp["uniqueItems"] = uniqueItems
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+ArrayTypes")
+        }
     }
 }
 
@@ -126,8 +190,8 @@ extension _LLMFunctionParameterWrapper where T: AnyArray, T.Element: StringProto
     ///    - minItems: Defines the minimum amount of values in the `array`.
     ///    - maxItems: Defines the maximum amount of values in the `array`.
     ///    - uniqueItems: Specifies if all `array` elements need to be unique.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         pattern: (any StringProtocol)? = nil,
         const: (any StringProtocol)? = nil,
         enum: [any StringProtocol]? = nil,
@@ -135,19 +199,41 @@ extension _LLMFunctionParameterWrapper where T: AnyArray, T.Element: StringProto
         maxItems: Int? = nil,
         uniqueItems: Bool? = nil
     ) {
-        self.init(schema: .init(
-            type: .array,
-            description: String(description),
-            items: .init(
-                type: .string,
-                pattern: pattern.map { String($0) },
-                const: const.map { String($0) },
-                enum: `enum`.map { $0.map { String($0) } }
-            ),
-            minItems: minItems,
-            maxItems: maxItems,
-            uniqueItems: uniqueItems
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "array",
+                "description": String(description)
+            ]
+            var itemsNoOpt: [String: any Sendable] = [
+                "type": "string"
+            ]
+            if let pattern = pattern.map({ String($0) }) {
+                itemsNoOpt["pattern"] = pattern
+            }
+            if let const = const.map({ String($0) }) {
+                itemsNoOpt["const"] = const
+            }
+            if let `enum` = `enum`.map({ $0.map { String($0) } }) {
+                itemsNoOpt["const"] = `enum`
+            }
+            if itemsNoOpt.count > 1 {
+                addProp["items"] = itemsNoOpt
+            }
+            if let minItems {
+                addProp["minItems"] = minItems
+            }
+            if let maxItems {
+                addProp["maxItems"] = maxItems
+            }
+            if let uniqueItems {
+                addProp["uniqueItems"] = uniqueItems
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+ArrayTypes")
+        }
     }
 }
 

--- a/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunctionParameterWrapper+Enum.swift
+++ b/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunctionParameterWrapper+Enum.swift
@@ -16,39 +16,59 @@ extension _LLMFunctionParameterWrapper where T: LLMFunctionParameterEnum, T.RawV
     /// - Parameters:
     ///    - description: Describes the purpose of the parameter, used by the LLM to grasp the purpose of the parameter.
     ///    - const: Specifies the constant `String`-based value of a certain parameter.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil
     ) {
-        self.init(schema: .init(
-            type: .string,
-            description: String(description),
-            const: const.map { String($0) },
-            enum: T.allCases.map { String($0.rawValue) }
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "string",
+                "description": String(description)
+            ]
+            if let const {
+                addProp["const"] = String(const)
+            }
+            addProp["enum"] = T.allCases.map { String($0.rawValue) }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+Enum")
+        }
     }
 }
 
-extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: LLMFunctionParameterEnum, T.Wrapped.RawValue: StringProtocol {
+extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: LLMFunctionParameterEnum,
+    T.Wrapped.RawValue: StringProtocol {
     /// Declares an optional `enum`-based ``LLMFunction/Parameter`` defining all options of a text-based parameter of the ``LLMFunction``.
     ///
     /// - Parameters:
     ///    - description: Describes the purpose of the parameter, used by the LLM to grasp the purpose of the parameter.
     ///    - const: Specifies the constant `String`-based value of a certain parameter.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil
     ) {
-        self.init(schema: .init(
-            type: .string,
-            description: String(description),
-            const: const.map { String($0) },
-            enum: T.Wrapped.allCases.map { String($0.rawValue) }
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "string",
+                "description": String(description)
+            ]
+            if let const {
+                addProp["const"] = String(const)
+            }
+            addProp["enum"] = T.Wrapped.allCases.map { String($0.rawValue) }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+Enum")
+        }
     }
 }
 
-extension _LLMFunctionParameterWrapper where T: AnyArray, T.Element: LLMFunctionParameterEnum, T.Element.RawValue: StringProtocol {
+extension _LLMFunctionParameterWrapper where T: AnyArray, T.Element: LLMFunctionParameterEnum,
+    T.Element.RawValue: StringProtocol {
     /// Declares an `enum`-based ``LLMFunction/Parameter`` `array`. An individual `array` element defines all options of a text-based parameter of the ``LLMFunction``.
     ///
     /// - Parameters:
@@ -57,25 +77,41 @@ extension _LLMFunctionParameterWrapper where T: AnyArray, T.Element: LLMFunction
     ///    - minItems: Defines the minimum amount of values in the `array`.
     ///    - maxItems: Defines the maximum amount of values in the `array`.
     ///    - uniqueItems: Specifies if all `array` elements need to be unique.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         minItems: Int? = nil,
         maxItems: Int? = nil,
         uniqueItems: Bool? = nil
     ) {
-        self.init(schema: .init(
-            type: .array,
-            description: String(description),
-            items: .init(
-                type: .string,
-                const: const.map { String($0) },
-                enum: T.Element.allCases.map { String($0.rawValue) }
-            ),
-            minItems: minItems,
-            maxItems: maxItems,
-            uniqueItems: uniqueItems
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "array",
+                "description": String(description)
+            ]
+            var itemNonOpt: [String: any Sendable] = [
+                "type": "string"
+            ]
+            if let const {
+                itemNonOpt["const"] = String(const)
+            }
+            itemNonOpt["enum"] = T.Element.allCases.map { String($0.rawValue) }
+            addProp["items"] = itemNonOpt
+            if let minItems {
+                addProp["minItems"] = minItems
+            }
+            if let maxItems {
+                addProp["maxItems"] = maxItems
+            }
+            if let uniqueItems {
+                addProp["uniqueItems"] = uniqueItems
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+Enum")
+        }
     }
 }
 
@@ -91,25 +127,41 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional,
     ///    - minItems: Defines the minimum amount of values in the `array`.
     ///    - maxItems: Defines the maximum amount of values in the `array`.
     ///    - uniqueItems: Specifies if all `array` elements need to be unique.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         minItems: Int? = nil,
         maxItems: Int? = nil,
         uniqueItems: Bool? = nil
     ) {
-        self.init(schema: .init(
-            type: .array,
-            description: String(description),
-            items: .init(
-                type: .string,
-                const: const.map { String($0) },
-                enum: T.Wrapped.Element.allCases.map { String($0.rawValue) }
-            ),
-            minItems: minItems,
-            maxItems: maxItems,
-            uniqueItems: uniqueItems
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "array",
+                "description": String(description)
+            ]
+            var itemNonOpt: [String: any Sendable] = [
+                "type": "string"
+            ]
+            if let const {
+                itemNonOpt["const"] = String(const)
+            }
+            itemNonOpt["enum"] = T.Wrapped.Element.allCases.map { String($0.rawValue) }
+            addProp["items"] = itemNonOpt
+            if let minItems {
+                addProp["minItems"] = minItems
+            }
+            if let maxItems {
+                addProp["maxItems"] = maxItems
+            }
+            if let uniqueItems {
+                addProp["uniqueItems"] = uniqueItems
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+Enum")
+        }
     }
 }
 

--- a/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunctionParameterWrapper+OptionalTypes.swift
+++ b/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunctionParameterWrapper+OptionalTypes.swift
@@ -19,21 +19,36 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: BinaryIn
     ///    - multipleOf: Defines that the LLM parameter needs to be a multiple of the init argument.
     ///    - minimum: The minimum value of the parameter.
     ///    - maximum: The maximum value of the parameter.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         multipleOf: Int? = nil,
         minimum: T.Wrapped? = nil,
         maximum: T.Wrapped? = nil
     ) {
-        self.init(schema: .init(
-            type: .integer,
-            description: String(description),
-            const: const.map { String($0) },
-            multipleOf: multipleOf,
-            minimum: minimum.map { Double($0) },
-            maximum: maximum.map { Double($0) }
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "integer",
+                "description": String(description)
+            ]
+            if let const {
+                addProp["const"] = String(const)
+            }
+            if let multipleOf {
+                addProp["multipleOf "] = multipleOf
+            }
+            if let minimum {
+                addProp["minimum"] = Double(minimum)
+            }
+            if let maximum {
+                addProp["maximum"] = Double(maximum)
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionparaemter+OptionalType")
+        }
     }
 }
 
@@ -45,19 +60,32 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: BinaryFl
     ///    - const: Specifies the constant `String`-based value of a certain parameter.
     ///    - minimum: The minimum value of the parameter.
     ///    - maximum: The maximum value of the parameter.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         minimum: T.Wrapped? = nil,
         maximum: T.Wrapped? = nil
     ) {
-        self.init(schema: .init(
-            type: .number,
-            description: String(description),
-            const: const.map { String($0) },
-            minimum: minimum.map { Double($0) },
-            maximum: maximum.map { Double($0) }
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "number",
+                "description": String(description)
+            ]
+            if let const {
+                addProp["const"] = String(const)
+            }
+            if let minimum {
+                addProp["minimum"] = Double(minimum)
+            }
+            if let maximum {
+                addProp["maximum"] = Double(maximum)
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+OptionalType")
+        }
     }
 }
 
@@ -67,15 +95,24 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped == Bool {
     /// - Parameters:
     ///    - description: Describes the purpose of the parameter, used by the LLM to grasp the purpose of the parameter.
     ///    - const: Specifies the constant `String`-based value of a certain parameter.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil
     ) {
-        self.init(schema: .init(
-            type: .boolean,
-            description: String(description),
-            const: const.map { String($0) }
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "boolean",
+                "description": String(description)
+            ]
+            if let const {
+                addProp["const"] = String(const)
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionalParameterWrapper+OptionalTypes")
+        }
     }
 }
 
@@ -88,25 +125,42 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: StringPr
     ///    - pattern: A Regular Expression that the parameter needs to conform to.
     ///    - const: Specifies the constant `String`-based value of a certain parameter.
     ///    - enum: Defines all cases of the `String` parameter.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         format: _LLMFunctionParameterWrapper.Format? = nil,
         pattern: (any StringProtocol)? = nil,
         const: (any StringProtocol)? = nil,
         enum: [any StringProtocol]? = nil
     ) {
-        self.init(schema: .init(
-            type: .string,
-            description: String(description),
-            format: format?.rawValue,
-            pattern: pattern.map { String($0) },
-            const: const.map { String($0) },
-            enum: `enum`.map { $0.map { String($0) } }
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "string",
+                "description": String(description)
+            ]
+            if let format {
+                addProp["format"] = format.rawValue
+            }
+            if let pattern {
+                addProp["pattern"] = String(pattern)
+            }
+            if let const {
+                addProp["const"] = String(const)
+            }
+            if let `enum` {
+                addProp["enum"] = `enum`.map { $0.map { String($0) } }
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+OptionalTypes")
+        }
     }
 }
 
-extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray, T.Wrapped.Element: BinaryInteger {
+extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray,
+    T.Wrapped.Element: BinaryInteger {
     /// Declares an optional `Int`-based ``LLMFunction/Parameter`` `array`.
     ///
     /// - Parameters:
@@ -118,34 +172,56 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray
     ///    - minItems: Defines the minimum amount of values in the `array`.
     ///    - maxItems: Defines the maximum amount of values in the `array`.
     ///    - uniqueItems: Specifies if all `array` elements need to be unique.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         multipleOf: Int? = nil,
         minimum: T.Wrapped.Element? = nil,
         maximum: T.Wrapped.Element? = nil,
         minItems: Int? = nil,
         maxItems: Int? = nil,
-        uniqueItems: Bool? = nil
+        uniqueItems _: Bool? = nil
     ) {
-        self.init(schema: .init(
-            type: .array,
-            description: String(description),
-            items: .init(
-                type: .integer,
-                const: const.map { String($0) },
-                multipleOf: multipleOf.map { Int($0) },
-                minimum: minimum.map { Double($0) },
-                maximum: maximum.map { Double($0) }
-            ),
-            minItems: minItems,
-            maxItems: maxItems,
-            uniqueItems: uniqueItems
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "array",
+                "description": String(description)
+            ]
+            var itemNonOpt: [String: any Sendable] = [
+                "type": "integer"
+            ]
+            if let const {
+                itemNonOpt["const"] = String(const)
+            }
+            if let multipleOf {
+                itemNonOpt["multipleOf"] = String(multipleOf)
+            }
+            if let minimum {
+                itemNonOpt["minimum"] = Double(minimum)
+            }
+            if let maximum {
+                itemNonOpt["maximum"] = Double(maximum)
+            }
+            if itemNonOpt.count > 1 {
+                addProp["items"] = itemNonOpt
+            }
+            if let minItems {
+                addProp["minItems"] = minItems
+            }
+            if let maxItems {
+                addProp["maxItems"] = maxItems
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionPropertyWrapper+OptionalType")
+        }
     }
 }
 
-extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray, T.Wrapped.Element: BinaryFloatingPoint {
+extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray,
+    T.Wrapped.Element: BinaryFloatingPoint {
     /// Declares an optional `Float` or `Double` (`BinaryFloatingPoint`) -based ``LLMFunction/Parameter`` `array`.
     ///
     /// - Parameters:
@@ -156,8 +232,8 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray
     ///    - minItems: Defines the minimum amount of values in the `array`.
     ///    - maxItems: Defines the maximum amount of values in the `array`.
     ///    - uniqueItems: Specifies if all `array` elements need to be unique.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         minimum: T.Wrapped.Element? = nil,
         maximum: T.Wrapped.Element? = nil,
@@ -165,19 +241,41 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray
         maxItems: Int? = nil,
         uniqueItems: Bool? = nil
     ) {
-        self.init(schema: .init(
-            type: .array,
-            description: String(description),
-            items: .init(
-                type: .number,
-                const: const.map { String($0) },
-                minimum: minimum.map { Double($0) },
-                maximum: maximum.map { Double($0) }
-            ),
-            minItems: minItems,
-            maxItems: maxItems,
-            uniqueItems: uniqueItems
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "array",
+                "description": String(description)
+            ]
+            var itemNonOpt: [String: any Sendable] = [
+                "type": "number"
+            ]
+            if let const {
+                itemNonOpt["const"] = String(const)
+            }
+            if let minimum {
+                itemNonOpt["minimum"] = Double(minimum)
+            }
+            if let maximum {
+                itemNonOpt["maximum"] = Double(maximum)
+            }
+            if itemNonOpt.count > 1 {
+                addProp["items"] = itemNonOpt
+            }
+            if let minItems {
+                addProp["minItems"] = minItems
+            }
+            if let maxItems {
+                addProp["maxItems"] = maxItems
+            }
+            if let uniqueItems {
+                addProp["uniqueItems"] = uniqueItems
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+OptionalTypes")
+        }
     }
 }
 
@@ -190,28 +288,47 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray
     ///    - minItems: Defines the minimum amount of values in the `array`.
     ///    - maxItems: Defines the maximum amount of values in the `array`.
     ///    - uniqueItems: Specifies if all `array` elements need to be unique.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         minItems: Int? = nil,
         maxItems: Int? = nil,
         uniqueItems: Bool? = nil
     ) {
-        self.init(schema: .init(
-            type: .array,
-            description: String(description),
-            items: .init(
-                type: .boolean,
-                const: const.map { String($0) }
-            ),
-            minItems: minItems,
-            maxItems: maxItems,
-            uniqueItems: uniqueItems
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "array",
+                "description": String(description)
+            ]
+            var itemNonOpt: [String: any Sendable] = [
+                "type": "boolean"
+            ]
+            if let const {
+                itemNonOpt["const"] = String(const)
+            }
+            if itemNonOpt.count > 1 {
+                addProp["items"] = itemNonOpt
+            }
+            if let minItems {
+                addProp["minItems"] = minItems
+            }
+            if let maxItems {
+                addProp["maxItems"] = maxItems
+            }
+            if let uniqueItems {
+                addProp["uniqueItems"] = uniqueItems
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+OptionalTypes.swift")
+        }
     }
 }
 
-extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray, T.Wrapped.Element: StringProtocol {
+extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray,
+    T.Wrapped.Element: StringProtocol {
     /// Declares an optional `String`-based ``LLMFunction/Parameter`` `array`.
     ///
     /// - Parameters:
@@ -222,8 +339,8 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray
     ///    - minItems: Defines the minimum amount of values in the `array`.
     ///    - maxItems: Defines the maximum amount of values in the `array`.
     ///    - uniqueItems: Specifies if all `array` elements need to be unique.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         pattern: (any StringProtocol)? = nil,
         const: (any StringProtocol)? = nil,
         enum: [any StringProtocol]? = nil,
@@ -231,19 +348,41 @@ extension _LLMFunctionParameterWrapper where T: AnyOptional, T.Wrapped: AnyArray
         maxItems: Int? = nil,
         uniqueItems: Bool? = nil
     ) {
-        self.init(schema: .init(
-            type: .array,
-            description: String(description),
-            items: .init(
-                type: .string,
-                pattern: pattern.map { String($0) },
-                const: const.map { String($0) },
-                enum: `enum`.map { $0.map { String($0) } }
-            ),
-            minItems: minItems,
-            maxItems: maxItems,
-            uniqueItems: uniqueItems
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "array",
+                "description": String(description)
+            ]
+            var itemNonOpt: [String: any Sendable] = [
+                "type": "string"
+            ]
+            if let pattern {
+                itemNonOpt["pattern"] = String(pattern)
+            }
+            if let const {
+                itemNonOpt["const"] = String(const)
+            }
+            if let `enum` {
+                itemNonOpt["enum"] = `enum`.map { $0.map { String($0) } }
+            }
+            if itemNonOpt.count > 1 {
+                addProp["items"] = itemNonOpt
+            }
+            if let minItems {
+                addProp["minItems"] = minItems
+            }
+            if let maxItems {
+                addProp["maxItems"] = maxItems
+            }
+            if let uniqueItems {
+                addProp["uniqueItems"] = uniqueItems
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+OptionalType")
+        }
     }
 }
 

--- a/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunctionParameterWrapper+PrimitiveTypes.swift
+++ b/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunctionParameterWrapper+PrimitiveTypes.swift
@@ -17,21 +17,36 @@ extension _LLMFunctionParameterWrapper where T: BinaryInteger {
     ///    - multipleOf: Defines that the LLM parameter needs to be a multiple of the init argument.
     ///    - minimum: The minimum value of the parameter.
     ///    - maximum: The maximum value of the parameter.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         multipleOf: Int? = nil,
         minimum: T? = nil,
         maximum: T? = nil
     ) {
-        self.init(schema: .init(
-            type: .integer,
-            description: String(description),
-            const: const.map { String($0) },
-            multipleOf: multipleOf,
-            minimum: minimum.map { Double($0) },
-            maximum: maximum.map { Double($0) }
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "integer",
+                "description": String(description)
+            ]
+            if let const {
+                addProp["const"] = const.map { String($0) }
+            }
+            if let multipleOf {
+                addProp["multipleOf"] = multipleOf
+            }
+            if let minimum {
+                addProp["minimum"] = Double(minimum)
+            }
+            if let maximum {
+                addProp["maximum"] = Double(maximum)
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameter+PrimitveTypes")
+        }
     }
 }
 
@@ -44,19 +59,32 @@ extension _LLMFunctionParameterWrapper where T: BinaryFloatingPoint {
     ///    - const: Specifies the constant `String`-based value of a certain parameter.
     ///    - minimum: The minimum value of the parameter.
     ///    - maximum: The maximum value of the parameter.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil,
         minimum: T? = nil,
         maximum: T? = nil
     ) {
-        self.init(schema: .init(
-            type: .number,
-            description: String(description),
-            const: const.map { String($0) },
-            minimum: minimum.map { Double($0) },
-            maximum: maximum.map { Double($0) }
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "number",
+                "description": String(description)
+            ]
+            if let const {
+                addProp["const"] = String(const)
+            }
+            if let minimum {
+                addProp["minimum"] = Double(minimum)
+            }
+            if let maximum {
+                addProp["maximum"] = Double(maximum)
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+PrimitveTypes")
+        }
     }
 }
 
@@ -66,15 +94,24 @@ extension _LLMFunctionParameterWrapper where T == Bool {
     /// - Parameters:
     ///    - description: Describes the purpose of the parameter, used by the LLM to grasp the purpose of the parameter.
     ///    - const: Specifies the constant `String`-based value of a certain parameter.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         const: (any StringProtocol)? = nil
     ) {
-        self.init(schema: .init(
-            type: .boolean,
-            description: String(description),
-            const: const.map { String($0) }
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "boolean",
+                "description": String(description)
+            ]
+            if let const {
+                addProp["const"] = String(const)
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+PrimiteveTypes")
+        }
     }
 }
 
@@ -87,21 +124,36 @@ extension _LLMFunctionParameterWrapper where T: StringProtocol {
     ///    - pattern: A Regular Expression that the parameter needs to conform to.
     ///    - const: Specifies the constant `String`-based value of a certain parameter.
     ///    - enum: Defines all cases of the `String` parameter.
-    public convenience init<D: StringProtocol>(
-        description: D,
+    public convenience init(
+        description: some StringProtocol,
         format: _LLMFunctionParameterWrapper.Format? = nil,
         pattern: (any StringProtocol)? = nil,
         const: (any StringProtocol)? = nil,
         enum: [any StringProtocol]? = nil
     ) {
-        self.init(schema: .init(
-            type: .string,
-            description: String(description),
-            format: format?.rawValue,
-            pattern: pattern.map { String($0) },
-            const: const.map { String($0) },
-            enum: `enum`.map { $0.map { String($0) } }
-        ))
+        do {
+            // FIXME: How can this be simplified?
+            var addProp: [String: any Sendable] = [
+                "type": "string",
+                "description": String(description)
+            ]
+            if let const {
+                addProp["const"] = String(const)
+            }
+            if let format {
+                addProp["format"] = format.rawValue
+            }
+            if let pattern {
+                addProp["pattern"] = String(pattern)
+            }
+            if let `enum` {
+                addProp["enum"] = `enum`.map { $0.map { String($0) } }
+            }
+            try self.init(schema: .init(additionalProperties: .init(unvalidatedValue: addProp)))
+        } catch {
+            // FIXME: handle error correctly
+            fatalError("LLMFunctionParameterWrapper+PrimitiveTypes")
+        }
     }
 }
 

--- a/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunctionParameterWrapper.swift
+++ b/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunctionParameterWrapper.swift
@@ -7,17 +7,21 @@
 //
 
 import OpenAI
-
+import OpenAPIRuntime
 
 /// Alias of the OpenAI `JSONSchema/Property` type, describing properties within an object schema.
-public typealias LLMFunctionParameterPropertySchema = ChatQuery.ChatCompletionToolParam.FunctionDefinition.FunctionParameters.Property
+public typealias LLMFunctionParameterPropertySchema = Components.Schemas.FunctionParameters
 /// Alias of the OpenAI `JSONSchema/Item` type, describing array items within an array schema.
-public typealias LLMFunctionParameterItemSchema = ChatQuery.ChatCompletionToolParam.FunctionDefinition.FunctionParameters.Property.Items
 
+// FIXME: LLMFunctionParameterItemSchema does not use a generated type yet
+public typealias LLMFunctionParameterItemSchema = ChatQuery.ChatCompletionToolParam.FunctionDefinition
+    .FunctionParameters.Property.Items
 
 /// Refer to the documentation of ``LLMFunction/Parameter`` for information on how to use the `@Parameter` property wrapper.
+// swiftlint:disable type_name
 @propertyWrapper
-public class _LLMFunctionParameterWrapper<T: Decodable>: LLMFunctionParameterSchemaCollector { // swiftlint:disable:this type_name
+public class _LLMFunctionParameterWrapper<T: Decodable>: LLMFunctionParameterSchemaCollector {
+    // swiftlint:enable type_name
     private var injectedValue: T?
     var schema: LLMFunctionParameterPropertySchema
     
@@ -50,23 +54,12 @@ public class _LLMFunctionParameterWrapper<T: Decodable>: LLMFunctionParameterSch
     /// - Parameters:
     ///    - description: Describes the purpose of the parameter, used by the LLM to grasp the purpose of the parameter.
     @_disfavoredOverload
-    public convenience init<D: StringProtocol>(description: D) where T: LLMFunctionParameter {
-        self.init(schema: .init(
-            type: T.schema.type,
-            description: String(description),   // Take description from the property wrapper, all other things from self defined schema
-            format: T.schema.format,
-            items: T.schema.items,
-            required: T.schema.required,
-            pattern: T.schema.pattern,
-            const: T.schema.const,
-            enum: T.schema.enum,
-            multipleOf: T.schema.multipleOf,
-            minimum: T.schema.minimum,
-            maximum: T.schema.maximum,
-            minItems: T.schema.minItems,
-            maxItems: T.schema.maxItems,
-            uniqueItems: T.schema.uniqueItems
-        ))
+    public convenience init(description _: some StringProtocol) where T: LLMFunctionParameter {
+        do {
+            try self.init(schema: T.schema)
+        } catch {
+            fatalError("LLMFunctionPropertyWrapper")
+        }
     }
     
     init(schema: LLMFunctionParameterPropertySchema) {
@@ -111,5 +104,4 @@ extension LLMFunction {
 
 
 /// Ensuring `Sendable` conformances of ``LLMFunctionParameterPropertySchema`` and ``LLMFunctionParameterItemSchema``
-extension LLMFunctionParameterPropertySchema: @unchecked Sendable {}
 extension LLMFunctionParameterItemSchema: @unchecked Sendable {}

--- a/Sources/SpeziLLMOpenAI/Helpers/Chat+OpenAI.swift
+++ b/Sources/SpeziLLMOpenAI/Helpers/Chat+OpenAI.swift
@@ -6,14 +6,14 @@
 // SPDX-License-Identifier: MIT
 //
 
-import struct OpenAI.ChatQuery
+import OpenAPIRuntime
 import SpeziLLM
 
 
 extension LLMContextEntity.Role {
-    typealias Role = ChatQuery.ChatCompletionMessageParam.Role
-    
-    
+    typealias Role = Components.Schemas.ChatCompletionRole
+
+
     /// Maps the `LLMContextEntity/Role`s to the `OpenAI/Chat/Role`s.
     var openAIRepresentation: Role {
         switch self {

--- a/Sources/SpeziLLMOpenAI/Helpers/LLMOpenAIStreamResult.swift
+++ b/Sources/SpeziLLMOpenAI/Helpers/LLMOpenAIStreamResult.swift
@@ -6,15 +6,15 @@
 // SPDX-License-Identifier: MIT
 //
 
-import OpenAI
-
+import OpenAPIRuntime
 
 /// Helper to process the returned stream by the LLM output generation call, especially in regards to the function call and a possible stop reason
 struct LLMOpenAIStreamResult {
-    typealias Role = ChatQuery.ChatCompletionMessageParam.Role
-    typealias FinishReason = ChatStreamResult.Choice.FinishReason
-    
-    
+    typealias Role = Components.Schemas.ChatCompletionStreamResponseDelta.rolePayload
+    typealias FinishReason = Components.Schemas.CreateChatCompletionStreamResponse.choicesPayloadPayload
+        .finish_reasonPayload
+
+
     struct FunctionCall {
         var id: String?
         var name: String?
@@ -42,46 +42,45 @@ struct LLMOpenAIStreamResult {
         self.finishReason = finishReason
         self.functionCall = functionCall
     }
-    
-    
-    mutating func append(choice: ChatStreamResult.Choice) -> Self {
-        self.deltaContent = choice.delta.content
+
+    mutating func append(choice: Components.Schemas.CreateChatCompletionStreamResponse.choicesPayloadPayload) -> Self {
+        deltaContent = choice.delta.content
 
         if let role = choice.delta.role {
             self.role = role
         }
-        
-        if let finishReason = choice.finishReason {
+
+        if let finishReason = choice.finish_reason {
             self.finishReason = finishReason
         }
-        
-        guard let functionCallId = choice.delta.toolCalls?.last?.index else {
+
+        guard let functionCallID = choice.delta.tool_calls?.last?.index else {
             return self
         }
-        
-        if functionCallId != currentFunctionCallIndex {
+
+        if functionCallID != currentFunctionCallIndex {
             functionCall.append(FunctionCall())
             currentFunctionCallIndex += 1
         }
         
         var newFunctionCall = functionCall[currentFunctionCallIndex]
-        
-        if let functionCallId = choice.delta.toolCalls?.first?.id {
-            newFunctionCall.id = (newFunctionCall.id ?? "") + functionCallId
+
+        if let functionCallID = choice.delta.tool_calls?.first?.id {
+            newFunctionCall.id = (newFunctionCall.id ?? "") + functionCallID
         }
 
-        if let deltaName = choice.delta.toolCalls?.first?.function?.name {
+        if let deltaName = choice.delta.tool_calls?.first?.function?.name {
             newFunctionCall.name = (newFunctionCall.name ?? "") + deltaName
         }
 
-        if let deltaArguments = choice.delta.toolCalls?.first?.function?.arguments {
+        if let deltaArguments = choice.delta.tool_calls?.first?.function?.arguments {
             newFunctionCall.arguments = (newFunctionCall.arguments ?? "") + deltaArguments
         }
         
         // Only assign back if there were changes
-        if choice.delta.toolCalls?.first?.id != nil ||
-            choice.delta.toolCalls?.first?.function?.name != nil ||
-            choice.delta.toolCalls?.first?.function?.arguments != nil {
+        if choice.delta.tool_calls?.first?.id != nil ||
+            choice.delta.tool_calls?.first?.function?.name != nil ||
+            choice.delta.tool_calls?.first?.function?.arguments != nil {
             functionCall[currentFunctionCallIndex] = newFunctionCall
         }
         

--- a/Sources/SpeziLLMOpenAI/Helpers/OpenAI+Export.swift
+++ b/Sources/SpeziLLMOpenAI/Helpers/OpenAI+Export.swift
@@ -6,11 +6,10 @@
 // SPDX-License-Identifier: MIT
 //
 
-import struct OpenAI.Model
-
+import OpenAPIRuntime
 
 /// Convenience export of the `OpenAI/Model` type.
 ///
 /// The ``LLMOpenAIModelType`` exports the `OpenAI/Model` describing the type of the to-be-used OpenAI Model.
 /// This enables convenience access to the `OpenAI/Model` without naming conflicts resulting from the `OpenAI/Model` name.
-public typealias LLMOpenAIModelType = Model
+public typealias LLMOpenAIModelType = Components.Schemas.CreateChatCompletionRequest.modelPayload

--- a/Sources/SpeziLLMOpenAI/LLMOpenAIAuthMiddleware.swift
+++ b/Sources/SpeziLLMOpenAI/LLMOpenAIAuthMiddleware.swift
@@ -1,0 +1,23 @@
+// Based on: https://github.com/apple/swift-openapi-generator/blob/main/Examples/auth-client-middleware-example/Sources/AuthenticationClientMiddleware/AuthenticationClientMiddleware.swift
+
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+
+struct AuthMiddleware: ClientMiddleware {
+    private let APIKey: String
+
+    init(APIKey: String) { self.APIKey = APIKey }
+
+    func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID _: String,
+        next: (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        var request = request
+        request.headerFields[.authorization] = "Bearer \(APIKey)"
+        return try await next(request, body, baseURL)
+    }
+}

--- a/Sources/SpeziLLMOpenAI/LLMOpenAISession+Generation.swift
+++ b/Sources/SpeziLLMOpenAI/LLMOpenAISession+Generation.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import OpenAI
+import OpenAPIRuntime
 import SpeziChat
 import SpeziLLM
 
@@ -26,14 +26,24 @@ extension LLMOpenAISession {
         }
         
         while true {
-            let chatStream: AsyncThrowingStream<ChatStreamResult, Error> = await self.model.chatsStream(query: self.openAIChatQuery)
-            
             var llmStreamResults: [Int: LLMOpenAIStreamResult] = [:]
             
             do {
-                for try await chatStreamResult in chatStream {
+                let response = try await chatGPTClient.createChatCompletion(openAIChatQuery)
+
+                // FIXME: does not handle the "[DONE]" message
+                let chatStream = try response.ok.body.text_event_hyphen_stream
+                    .asDecodedServerSentEventsWithJSONData(of: Components.Schemas.CreateChatCompletionStreamResponse
+                        .self)
+
+                chatStreamIteration: for try await chatStreamResult in chatStream {
+                    guard let choices = chatStreamResult.data?.choices else {
+                        Self.logger.error("SpeziLLMOpenAI: Couldn't obtain choices from stream response.")
+                        return
+                    }
+
                     // Important to iterate over all choices as LLM could choose to call multiple functions / generate multiple choices
-                    for choice in chatStreamResult.choices {
+                    for choice in choices {
                         llmStreamResults[choice.index] = llmStreamResults[
                             choice.index,
                             default: .init()
@@ -70,31 +80,38 @@ extension LLMOpenAISession {
                         context.completeAssistantStreaming()
                     }
                 }
-            } catch let error as APIErrorResponse {
-                switch error.error.code {
-                case LLMOpenAIError.invalidAPIToken.openAIErrorMessage:
-                    Self.logger.error("SpeziLLMOpenAI: Invalid OpenAI API token - \(error)")
-                    await finishGenerationWithError(LLMOpenAIError.invalidAPIToken, on: continuation)
-                case LLMOpenAIError.insufficientQuota.openAIErrorMessage:
-                    Self.logger.error("SpeziLLMOpenAI: Insufficient OpenAI API quota - \(error)")
-                    await finishGenerationWithError(LLMOpenAIError.insufficientQuota, on: continuation)
-                default:
-                    Self.logger.error("SpeziLLMOpenAI: Generation error occurred - \(error)")
-                    await finishGenerationWithError(LLMOpenAIError.generationError, on: continuation)
-                }
-                return
+
+                // FIXME: what is the counterpart for the generated API calls?
+                // } catch let error as APIErrorResponse {
+                // switch error.error.code {
+                // case LLMOpenAIError.invalidAPIToken.openAIErrorMessage:
+                //     Self.logger.error("SpeziLLMOpenAI: Invalid OpenAI API token - \(error)")
+                //     await finishGenerationWithError(LLMOpenAIError.invalidAPIToken, on: continuation)
+                // case LLMOpenAIError.insufficientQuota.openAIErrorMessage:
+                //     Self.logger.error("SpeziLLMOpenAI: Insufficient OpenAI API quota - \(error)")
+                //     await finishGenerationWithError(LLMOpenAIError.insufficientQuota, on: continuation)
+                // default:
+                //     Self.logger.error("SpeziLLMOpenAI: Generation error occurred - \(error)")
+                //     await finishGenerationWithError(LLMOpenAIError.generationError, on: continuation)
+                // }
+                // return
             } catch let error as URLError {
                 Self.logger.error("SpeziLLMOpenAI: Connectivity Issues with the OpenAI API: \(error)")
                 await finishGenerationWithError(LLMOpenAIError.connectivityIssues(error), on: continuation)
                 return
+            } catch let Swift.DecodingError.dataCorrupted(context) {
+                // FIXME: The API sends a "[DONE]" message to conclude the stream. As it does not conform to the Components.Schemas.CreateChatCompletionStreamResponse schema, it will cause a crash. This is a hacky workaround to avoid the crash.
             } catch {
                 Self.logger.error("SpeziLLMOpenAI: Generation error occurred - \(error)")
                 await finishGenerationWithError(LLMOpenAIError.generationError, on: continuation)
                 return
             }
 
-            let functionCalls = llmStreamResults.values.compactMap { $0.functionCall }.flatMap { $0 }
-            
+            // FIXME: Swiftformat bug?
+            // swiftformat:disable all
+            let functionCalls = llmStreamResults.values.compactMap{ return $0.functionCall }.flatMap { $0 }
+            // swiftformat:enable all
+
             // Exit the while loop if we don't have any function calls
             guard !functionCalls.isEmpty else {
                 break
@@ -102,12 +119,12 @@ extension LLMOpenAISession {
             
             // Inject the requested function calls into the LLM context
             let functionCallContext: [LLMContextEntity.ToolCall] = functionCalls.compactMap { functionCall in
-                guard let functionCallId = functionCall.id,
+                guard let functionCallID = functionCall.id,
                       let functionCallName = functionCall.name else {
                     return nil
                 }
-                
-                return .init(id: functionCallId, name: functionCallName, arguments: functionCall.arguments ?? "")
+
+                return .init(id: functionCallID, name: functionCallName, arguments: functionCall.arguments ?? "")
             }
             await MainActor.run {
                 context.append(functionCalls: functionCallContext)

--- a/Sources/SpeziLLMOpenAI/LLMOpenAISession.swift
+++ b/Sources/SpeziLLMOpenAI/LLMOpenAISession.swift
@@ -7,7 +7,8 @@
 //
 
 import Foundation
-import class OpenAI.OpenAI
+import OpenAPIRuntime
+import OpenAPIURLSession
 import os
 import SpeziChat
 import SpeziLLM
@@ -75,17 +76,16 @@ public final class LLMOpenAISession: LLMSession, @unchecked Sendable {
     
     @MainActor public var state: LLMState = .uninitialized
     @MainActor public var context: LLMContext = []
-    @ObservationIgnored var wrappedModel: OpenAI?
-    
-    
-    var model: OpenAI {
-        guard let model = wrappedModel else {
+    @ObservationIgnored var wrappedClient: Client?
+
+    var chatGPTClient: Client {
+        guard let chatGPTClient = wrappedClient else {
             preconditionFailure("""
-            SpeziLLMOpenAI: Illegal Access - Tried to access the wrapped OpenAI model of `LLMOpenAISession` before being initialized.
+            SpeziLLMOpenAI: Illegal Access - Tried to access the wrapped OpenAI client of `LLMOpenAISession` before being initialized.
             Ensure that the `LLMOpenAIPlatform` is passed to the `LLMRunner` within the Spezi `Configuration`.
             """)
         }
-        return model
+        return chatGPTClient
     }
     
     
@@ -126,7 +126,7 @@ public final class LLMOpenAISession: LLMSession, @unchecked Sendable {
             }
             
             // Setup the model, if not already done
-            if wrappedModel == nil {
+            if wrappedClient == nil {
                 guard await setup(continuation: continuation) else {
                     return
                 }

--- a/Sources/SpeziLLMOpenAI/Onboarding/LLMOpenAIAPITokenOnboardingStep.swift
+++ b/Sources/SpeziLLMOpenAI/Onboarding/LLMOpenAIAPITokenOnboardingStep.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-import OpenAI
 import Spezi
 import SpeziOnboarding
 import SwiftUI

--- a/Sources/SpeziLLMOpenAI/Onboarding/LLMOpenAIModelOnboardingStep.swift
+++ b/Sources/SpeziLLMOpenAI/Onboarding/LLMOpenAIModelOnboardingStep.swift
@@ -14,7 +14,16 @@ import SwiftUI
 /// View to display an onboarding step for the user to enter change the OpenAI model.
 public struct LLMOpenAIModelOnboardingStep: View {
     public enum Default {
-        public static let models: [LLMOpenAIModelType] = [.gpt3_5Turbo, .gpt4_turbo, .gpt4_o]
+        public static let models: [LLMOpenAIModelType] = [
+            .init(value1: "GPT 3.5 Turbo",
+                  value2: .gpt_hyphen_3_period_5_hyphen_turbo),
+            .init(
+                value1: "GPT 4 Turbo",
+                value2: .gpt_hyphen_4_hyphen_turbo
+            ),
+            .init(value1: "GPT 4O",
+                  value2: .gpt_hyphen_4o)
+        ]
     }
     
     
@@ -33,10 +42,15 @@ public struct LLMOpenAIModelOnboardingStep: View {
                 )
             },
             contentView: {
-                Picker(String(localized: "OPENAI_MODEL_SELECTION_DESCRIPTION", bundle: .module), selection: $modelSelection) {
-                    ForEach(models, id: \.self) { model in
-                        Text(model.formattedModelDescription)
-                            .tag(model)
+                Picker(
+                    String(localized: "OPENAI_MODEL_SELECTION_DESCRIPTION", bundle: .module),
+                    selection: $modelSelection
+                ) {
+                    ForEach(models, id: \.value1) { model in
+                        if let modelStr = model.value1 {
+                            Text(modelStr)
+                                .tag(model)
+                        }
                     }
                 }
                     #if !os(macOS)
@@ -86,13 +100,7 @@ public struct LLMOpenAIModelOnboardingStep: View {
         self.actionText = String(actionText)
         self.models = models
         self.action = action
-        self._modelSelection = State(initialValue: models.first ?? .gpt3_5Turbo)
+        _modelSelection = State(initialValue: models.first ?? .init(value2: .gpt_hyphen_3_period_5_hyphen_turbo))
     }
 }
 
-
-extension LLMOpenAIModelType {
-    fileprivate var formattedModelDescription: String {
-        self.replacing("-", with: " ").capitalized.replacing("Gpt", with: "GPT")
-    }
-}

--- a/Sources/SpeziLLMOpenAI/openapi-generator-config.yaml
+++ b/Sources/SpeziLLMOpenAI/openapi-generator-config.yaml
@@ -1,0 +1,3 @@
+generate:
+  - types
+  - client

--- a/Sources/SpeziLLMOpenAI/openapi-generator-config.yaml
+++ b/Sources/SpeziLLMOpenAI/openapi-generator-config.yaml
@@ -1,3 +1,4 @@
 generate:
   - types
   - client
+accessModifier: public

--- a/Sources/SpeziLLMOpenAI/openapi.yaml
+++ b/Sources/SpeziLLMOpenAI/openapi.yaml
@@ -1,0 +1,14280 @@
+openapi: 3.0.0
+info:
+    title: OpenAI API
+    description: The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details.
+    version: "2.1.0"
+    termsOfService: https://openai.com/policies/terms-of-use
+    contact:
+        name: OpenAI Support
+        url: https://help.openai.com/
+    license:
+        name: MIT
+        url: https://github.com/openai/openai-openapi/blob/master/LICENSE
+servers:
+    - url: https://api.openai.com/v1
+tags:
+    - name: Assistants
+      description: Build Assistants that can call models and use tools.
+    - name: Audio
+      description: Turn audio into text or text into audio.
+    - name: Chat
+      description: Given a list of messages comprising a conversation, the model will return a response.
+    - name: Completions
+      description: Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position.
+    - name: Embeddings
+      description: Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
+    - name: Fine-tuning
+      description: Manage fine-tuning jobs to tailor a model to your specific training data.
+    - name: Batch
+      description: Create large batches of API requests to run asynchronously.
+    - name: Files
+      description: Files are used to upload documents that can be used with features like Assistants and Fine-tuning.
+    - name: Uploads
+      description: Use Uploads to upload large files in multiple parts.
+    - name: Images
+      description: Given a prompt and/or an input image, the model will generate a new image.
+    - name: Models
+      description: List and describe the various models available in the API.
+    - name: Moderations
+      description: Given a input text, outputs if the model classifies it as potentially harmful.
+paths:
+    # Note: When adding an endpoint, make sure you also add it in the `groups` section, in the end of this file,
+    # under the appropriate group
+    /chat/completions:
+        post:
+            operationId: createChatCompletion
+            tags:
+                - Chat
+            summary: Creates a model response for the given chat conversation.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateChatCompletionRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CreateChatCompletionResponse"
+
+            x-oaiMeta:
+                name: Create chat completion
+                group: chat
+                returns: |
+                    Returns a [chat completion](/docs/api-reference/chat/object) object, or a streamed sequence of [chat completion chunk](/docs/api-reference/chat/streaming) objects if the request is streamed.
+                path: create
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/chat/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "VAR_model_id",
+                                  "messages": [
+                                    {
+                                      "role": "system",
+                                      "content": "You are a helpful assistant."
+                                    },
+                                    {
+                                      "role": "user",
+                                      "content": "Hello!"
+                                    }
+                                  ]
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              completion = client.chat.completions.create(
+                                model="VAR_model_id",
+                                messages=[
+                                  {"role": "system", "content": "You are a helpful assistant."},
+                                  {"role": "user", "content": "Hello!"}
+                                ]
+                              )
+
+                              print(completion.choices[0].message)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const completion = await openai.chat.completions.create({
+                                  messages: [{ role: "system", content: "You are a helpful assistant." }],
+                                  model: "VAR_model_id",
+                                });
+
+                                console.log(completion.choices[0]);
+                              }
+
+                              main();
+                      response: &chat_completion_example |
+                          {
+                            "id": "chatcmpl-123",
+                            "object": "chat.completion",
+                            "created": 1677652288,
+                            "model": "gpt-4o-mini",
+                            "system_fingerprint": "fp_44709d6fcb",
+                            "choices": [{
+                              "index": 0,
+                              "message": {
+                                "role": "assistant",
+                                "content": "\n\nHello there, how may I assist you today?",
+                              },
+                              "logprobs": null,
+                              "finish_reason": "stop"
+                            }],
+                            "usage": {
+                              "prompt_tokens": 9,
+                              "completion_tokens": 12,
+                              "total_tokens": 21
+                            }
+                          }
+                    - title: Image input
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/chat/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "gpt-4-turbo",
+                                  "messages": [
+                                    {
+                                      "role": "user",
+                                      "content": [
+                                        {
+                                          "type": "text",
+                                          "text": "What'\''s in this image?"
+                                        },
+                                        {
+                                          "type": "image_url",
+                                          "image_url": {
+                                            "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "max_tokens": 300
+                                }'
+                          python: |
+                              from openai import OpenAI
+
+                              client = OpenAI()
+
+                              response = client.chat.completions.create(
+                                  model="gpt-4-turbo",
+                                  messages=[
+                                      {
+                                          "role": "user",
+                                          "content": [
+                                              {"type": "text", "text": "What's in this image?"},
+                                              {
+                                                  "type": "image_url",
+                                                  "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                                              },
+                                          ],
+                                      }
+                                  ],
+                                  max_tokens=300,
+                              )
+
+                              print(response.choices[0])
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const response = await openai.chat.completions.create({
+                                  model: "gpt-4-turbo",
+                                  messages: [
+                                    {
+                                      role: "user",
+                                      content: [
+                                        { type: "text", text: "What's in this image?" },
+                                        {
+                                          type: "image_url",
+                                          image_url:
+                                            "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                });
+                                console.log(response.choices[0]);
+                              }
+                              main();
+                      response: &chat_completion_image_example |
+                          {
+                            "id": "chatcmpl-123",
+                            "object": "chat.completion",
+                            "created": 1677652288,
+                            "model": "gpt-4o-mini",
+                            "system_fingerprint": "fp_44709d6fcb",
+                            "choices": [{
+                              "index": 0,
+                              "message": {
+                                "role": "assistant",
+                                "content": "\n\nThis image shows a wooden boardwalk extending through a lush green marshland.",
+                              },
+                              "logprobs": null,
+                              "finish_reason": "stop"
+                            }],
+                            "usage": {
+                              "prompt_tokens": 9,
+                              "completion_tokens": 12,
+                              "total_tokens": 21
+                            }
+                          }
+                    - title: Streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/chat/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "VAR_model_id",
+                                  "messages": [
+                                    {
+                                      "role": "system",
+                                      "content": "You are a helpful assistant."
+                                    },
+                                    {
+                                      "role": "user",
+                                      "content": "Hello!"
+                                    }
+                                  ],
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              completion = client.chat.completions.create(
+                                model="VAR_model_id",
+                                messages=[
+                                  {"role": "system", "content": "You are a helpful assistant."},
+                                  {"role": "user", "content": "Hello!"}
+                                ],
+                                stream=True
+                              )
+
+                              for chunk in completion:
+                                print(chunk.choices[0].delta)
+
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const completion = await openai.chat.completions.create({
+                                  model: "VAR_model_id",
+                                  messages: [
+                                    {"role": "system", "content": "You are a helpful assistant."},
+                                    {"role": "user", "content": "Hello!"}
+                                  ],
+                                  stream: true,
+                                });
+
+                                for await (const chunk of completion) {
+                                  console.log(chunk.choices[0].delta.content);
+                                }
+                              }
+
+                              main();
+                      response: &chat_completion_chunk_example |
+                          {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+                          {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}
+
+                          ....
+
+                          {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+                    - title: Functions
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/chat/completions \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -d '{
+                                "model": "gpt-4-turbo",
+                                "messages": [
+                                  {
+                                    "role": "user",
+                                    "content": "What'\''s the weather like in Boston today?"
+                                  }
+                                ],
+                                "tools": [
+                                  {
+                                    "type": "function",
+                                    "function": {
+                                      "name": "get_current_weather",
+                                      "description": "Get the current weather in a given location",
+                                      "parameters": {
+                                        "type": "object",
+                                        "properties": {
+                                          "location": {
+                                            "type": "string",
+                                            "description": "The city and state, e.g. San Francisco, CA"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": ["celsius", "fahrenheit"]
+                                          }
+                                        },
+                                        "required": ["location"]
+                                      }
+                                    }
+                                  }
+                                ],
+                                "tool_choice": "auto"
+                              }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              tools = [
+                                {
+                                  "type": "function",
+                                  "function": {
+                                    "name": "get_current_weather",
+                                    "description": "Get the current weather in a given location",
+                                    "parameters": {
+                                      "type": "object",
+                                      "properties": {
+                                        "location": {
+                                          "type": "string",
+                                          "description": "The city and state, e.g. San Francisco, CA",
+                                        },
+                                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                      },
+                                      "required": ["location"],
+                                    },
+                                  }
+                                }
+                              ]
+                              messages = [{"role": "user", "content": "What's the weather like in Boston today?"}]
+                              completion = client.chat.completions.create(
+                                model="VAR_model_id",
+                                messages=messages,
+                                tools=tools,
+                                tool_choice="auto"
+                              )
+
+                              print(completion)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const messages = [{"role": "user", "content": "What's the weather like in Boston today?"}];
+                                const tools = [
+                                    {
+                                      "type": "function",
+                                      "function": {
+                                        "name": "get_current_weather",
+                                        "description": "Get the current weather in a given location",
+                                        "parameters": {
+                                          "type": "object",
+                                          "properties": {
+                                            "location": {
+                                              "type": "string",
+                                              "description": "The city and state, e.g. San Francisco, CA",
+                                            },
+                                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                          },
+                                          "required": ["location"],
+                                        },
+                                      }
+                                    }
+                                ];
+
+                                const response = await openai.chat.completions.create({
+                                  model: "gpt-4-turbo",
+                                  messages: messages,
+                                  tools: tools,
+                                  tool_choice: "auto",
+                                });
+
+                                console.log(response);
+                              }
+
+                              main();
+                      response: &chat_completion_function_example |
+                          {
+                            "id": "chatcmpl-abc123",
+                            "object": "chat.completion",
+                            "created": 1699896916,
+                            "model": "gpt-4o-mini",
+                            "choices": [
+                              {
+                                "index": 0,
+                                "message": {
+                                  "role": "assistant",
+                                  "content": null,
+                                  "tool_calls": [
+                                    {
+                                      "id": "call_abc123",
+                                      "type": "function",
+                                      "function": {
+                                        "name": "get_current_weather",
+                                        "arguments": "{\n\"location\": \"Boston, MA\"\n}"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "logprobs": null,
+                                "finish_reason": "tool_calls"
+                              }
+                            ],
+                            "usage": {
+                              "prompt_tokens": 82,
+                              "completion_tokens": 17,
+                              "total_tokens": 99
+                            }
+                          }
+                    - title: Logprobs
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/chat/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "VAR_model_id",
+                                  "messages": [
+                                    {
+                                      "role": "user",
+                                      "content": "Hello!"
+                                    }
+                                  ],
+                                  "logprobs": true,
+                                  "top_logprobs": 2
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              completion = client.chat.completions.create(
+                                model="VAR_model_id",
+                                messages=[
+                                  {"role": "user", "content": "Hello!"}
+                                ],
+                                logprobs=True,
+                                top_logprobs=2
+                              )
+
+                              print(completion.choices[0].message)
+                              print(completion.choices[0].logprobs)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const completion = await openai.chat.completions.create({
+                                  messages: [{ role: "user", content: "Hello!" }],
+                                  model: "VAR_model_id",
+                                  logprobs: true,
+                                  top_logprobs: 2,
+                                });
+
+                                console.log(completion.choices[0]);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "chatcmpl-123",
+                            "object": "chat.completion",
+                            "created": 1702685778,
+                            "model": "gpt-4o-mini",
+                            "choices": [
+                              {
+                                "index": 0,
+                                "message": {
+                                  "role": "assistant",
+                                  "content": "Hello! How can I assist you today?"
+                                },
+                                "logprobs": {
+                                  "content": [
+                                    {
+                                      "token": "Hello",
+                                      "logprob": -0.31725305,
+                                      "bytes": [72, 101, 108, 108, 111],
+                                      "top_logprobs": [
+                                        {
+                                          "token": "Hello",
+                                          "logprob": -0.31725305,
+                                          "bytes": [72, 101, 108, 108, 111]
+                                        },
+                                        {
+                                          "token": "Hi",
+                                          "logprob": -1.3190403,
+                                          "bytes": [72, 105]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": "!",
+                                      "logprob": -0.02380986,
+                                      "bytes": [
+                                        33
+                                      ],
+                                      "top_logprobs": [
+                                        {
+                                          "token": "!",
+                                          "logprob": -0.02380986,
+                                          "bytes": [33]
+                                        },
+                                        {
+                                          "token": " there",
+                                          "logprob": -3.787621,
+                                          "bytes": [32, 116, 104, 101, 114, 101]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " How",
+                                      "logprob": -0.000054669687,
+                                      "bytes": [32, 72, 111, 119],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " How",
+                                          "logprob": -0.000054669687,
+                                          "bytes": [32, 72, 111, 119]
+                                        },
+                                        {
+                                          "token": "<|end|>",
+                                          "logprob": -10.953937,
+                                          "bytes": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " can",
+                                      "logprob": -0.015801601,
+                                      "bytes": [32, 99, 97, 110],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " can",
+                                          "logprob": -0.015801601,
+                                          "bytes": [32, 99, 97, 110]
+                                        },
+                                        {
+                                          "token": " may",
+                                          "logprob": -4.161023,
+                                          "bytes": [32, 109, 97, 121]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " I",
+                                      "logprob": -3.7697225e-6,
+                                      "bytes": [
+                                        32,
+                                        73
+                                      ],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " I",
+                                          "logprob": -3.7697225e-6,
+                                          "bytes": [32, 73]
+                                        },
+                                        {
+                                          "token": " assist",
+                                          "logprob": -13.596657,
+                                          "bytes": [32, 97, 115, 115, 105, 115, 116]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " assist",
+                                      "logprob": -0.04571125,
+                                      "bytes": [32, 97, 115, 115, 105, 115, 116],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " assist",
+                                          "logprob": -0.04571125,
+                                          "bytes": [32, 97, 115, 115, 105, 115, 116]
+                                        },
+                                        {
+                                          "token": " help",
+                                          "logprob": -3.1089056,
+                                          "bytes": [32, 104, 101, 108, 112]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " you",
+                                      "logprob": -5.4385737e-6,
+                                      "bytes": [32, 121, 111, 117],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " you",
+                                          "logprob": -5.4385737e-6,
+                                          "bytes": [32, 121, 111, 117]
+                                        },
+                                        {
+                                          "token": " today",
+                                          "logprob": -12.807695,
+                                          "bytes": [32, 116, 111, 100, 97, 121]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " today",
+                                      "logprob": -0.0040071653,
+                                      "bytes": [32, 116, 111, 100, 97, 121],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " today",
+                                          "logprob": -0.0040071653,
+                                          "bytes": [32, 116, 111, 100, 97, 121]
+                                        },
+                                        {
+                                          "token": "?",
+                                          "logprob": -5.5247097,
+                                          "bytes": [63]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": "?",
+                                      "logprob": -0.0008108172,
+                                      "bytes": [63],
+                                      "top_logprobs": [
+                                        {
+                                          "token": "?",
+                                          "logprob": -0.0008108172,
+                                          "bytes": [63]
+                                        },
+                                        {
+                                          "token": "?\n",
+                                          "logprob": -7.184561,
+                                          "bytes": [63, 10]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "finish_reason": "stop"
+                              }
+                            ],
+                            "usage": {
+                              "prompt_tokens": 9,
+                              "completion_tokens": 9,
+                              "total_tokens": 18
+                            },
+                            "system_fingerprint": null
+                          }
+
+    /completions:
+        post:
+            operationId: createCompletion
+            tags:
+                - Completions
+            summary: Creates a completion for the provided prompt and parameters.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateCompletionRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CreateCompletionResponse"
+            x-oaiMeta:
+                name: Create completion
+                group: completions
+                returns: |
+                    Returns a [completion](/docs/api-reference/completions/object) object, or a sequence of completion objects if the request is streamed.
+                legacy: true
+                examples:
+                    - title: No streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "VAR_model_id",
+                                  "prompt": "Say this is a test",
+                                  "max_tokens": 7,
+                                  "temperature": 0
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              client.completions.create(
+                                model="VAR_model_id",
+                                prompt="Say this is a test",
+                                max_tokens=7,
+                                temperature=0
+                              )
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const completion = await openai.completions.create({
+                                  model: "VAR_model_id",
+                                  prompt: "Say this is a test.",
+                                  max_tokens: 7,
+                                  temperature: 0,
+                                });
+
+                                console.log(completion);
+                              }
+                              main();
+                      response: |
+                          {
+                            "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+                            "object": "text_completion",
+                            "created": 1589478378,
+                            "model": "VAR_model_id",
+                            "system_fingerprint": "fp_44709d6fcb",
+                            "choices": [
+                              {
+                                "text": "\n\nThis is indeed a test",
+                                "index": 0,
+                                "logprobs": null,
+                                "finish_reason": "length"
+                              }
+                            ],
+                            "usage": {
+                              "prompt_tokens": 5,
+                              "completion_tokens": 7,
+                              "total_tokens": 12
+                            }
+                          }
+                    - title: Streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "VAR_model_id",
+                                  "prompt": "Say this is a test",
+                                  "max_tokens": 7,
+                                  "temperature": 0,
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              for chunk in client.completions.create(
+                                model="VAR_model_id",
+                                prompt="Say this is a test",
+                                max_tokens=7,
+                                temperature=0,
+                                stream=True
+                              ):
+                                print(chunk.choices[0].text)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const stream = await openai.completions.create({
+                                  model: "VAR_model_id",
+                                  prompt: "Say this is a test.",
+                                  stream: true,
+                                });
+
+                                for await (const chunk of stream) {
+                                  console.log(chunk.choices[0].text)
+                                }
+                              }
+                              main();
+                      response: |
+                          {
+                            "id": "cmpl-7iA7iJjj8V2zOkCGvWF2hAkDWBQZe",
+                            "object": "text_completion",
+                            "created": 1690759702,
+                            "choices": [
+                              {
+                                "text": "This",
+                                "index": 0,
+                                "logprobs": null,
+                                "finish_reason": null
+                              }
+                            ],
+                            "model": "gpt-3.5-turbo-instruct"
+                            "system_fingerprint": "fp_44709d6fcb",
+                          }
+
+    /images/generations:
+        post:
+            operationId: createImage
+            tags:
+                - Images
+            summary: Creates an image given a prompt.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateImageRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ImagesResponse"
+            x-oaiMeta:
+                name: Create image
+                group: images
+                returns: Returns a list of [image](/docs/api-reference/images/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/images/generations \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -d '{
+                                "model": "dall-e-3",
+                                "prompt": "A cute baby sea otter",
+                                "n": 1,
+                                "size": "1024x1024"
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.images.generate(
+                              model="dall-e-3",
+                              prompt="A cute baby sea otter",
+                              n=1,
+                              size="1024x1024"
+                            )
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const image = await openai.images.generate({ model: "dall-e-3", prompt: "A cute baby sea otter" });
+
+                              console.log(image.data);
+                            }
+                            main();
+                    response: |
+                        {
+                          "created": 1589478378,
+                          "data": [
+                            {
+                              "url": "https://..."
+                            },
+                            {
+                              "url": "https://..."
+                            }
+                          ]
+                        }
+    /images/edits:
+        post:
+            operationId: createImageEdit
+            tags:
+                - Images
+            summary: Creates an edited or extended image given an original image and a prompt.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/CreateImageEditRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ImagesResponse"
+            x-oaiMeta:
+                name: Create image edit
+                group: images
+                returns: Returns a list of [image](/docs/api-reference/images/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/images/edits \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -F image="@otter.png" \
+                              -F mask="@mask.png" \
+                              -F prompt="A cute baby sea otter wearing a beret" \
+                              -F n=2 \
+                              -F size="1024x1024"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.images.edit(
+                              image=open("otter.png", "rb"),
+                              mask=open("mask.png", "rb"),
+                              prompt="A cute baby sea otter wearing a beret",
+                              n=2,
+                              size="1024x1024"
+                            )
+                        node.js: |-
+                            import fs from "fs";
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const image = await openai.images.edit({
+                                image: fs.createReadStream("otter.png"),
+                                mask: fs.createReadStream("mask.png"),
+                                prompt: "A cute baby sea otter wearing a beret",
+                              });
+
+                              console.log(image.data);
+                            }
+                            main();
+                    response: |
+                        {
+                          "created": 1589478378,
+                          "data": [
+                            {
+                              "url": "https://..."
+                            },
+                            {
+                              "url": "https://..."
+                            }
+                          ]
+                        }
+    /images/variations:
+        post:
+            operationId: createImageVariation
+            tags:
+                - Images
+            summary: Creates a variation of a given image.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/CreateImageVariationRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ImagesResponse"
+            x-oaiMeta:
+                name: Create image variation
+                group: images
+                returns: Returns a list of [image](/docs/api-reference/images/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/images/variations \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -F image="@otter.png" \
+                              -F n=2 \
+                              -F size="1024x1024"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            response = client.images.create_variation(
+                              image=open("image_edit_original.png", "rb"),
+                              n=2,
+                              size="1024x1024"
+                            )
+                        node.js: |-
+                            import fs from "fs";
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const image = await openai.images.createVariation({
+                                image: fs.createReadStream("otter.png"),
+                              });
+
+                              console.log(image.data);
+                            }
+                            main();
+                    response: |
+                        {
+                          "created": 1589478378,
+                          "data": [
+                            {
+                              "url": "https://..."
+                            },
+                            {
+                              "url": "https://..."
+                            }
+                          ]
+                        }
+
+    /embeddings:
+        post:
+            operationId: createEmbedding
+            tags:
+                - Embeddings
+            summary: Creates an embedding vector representing the input text.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateEmbeddingRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CreateEmbeddingResponse"
+            x-oaiMeta:
+                name: Create embeddings
+                group: embeddings
+                returns: A list of [embedding](/docs/api-reference/embeddings/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/embeddings \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -d '{
+                                "input": "The food was delicious and the waiter...",
+                                "model": "text-embedding-ada-002",
+                                "encoding_format": "float"
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.embeddings.create(
+                              model="text-embedding-ada-002",
+                              input="The food was delicious and the waiter...",
+                              encoding_format="float"
+                            )
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const embedding = await openai.embeddings.create({
+                                model: "text-embedding-ada-002",
+                                input: "The quick brown fox jumped over the lazy dog",
+                                encoding_format: "float",
+                              });
+
+                              console.log(embedding);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "object": "embedding",
+                              "embedding": [
+                                0.0023064255,
+                                -0.009327292,
+                                .... (1536 floats total for ada-002)
+                                -0.0028842222,
+                              ],
+                              "index": 0
+                            }
+                          ],
+                          "model": "text-embedding-ada-002",
+                          "usage": {
+                            "prompt_tokens": 8,
+                            "total_tokens": 8
+                          }
+                        }
+
+    /audio/speech:
+        post:
+            operationId: createSpeech
+            tags:
+                - Audio
+            summary: Generates audio from the input text.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateSpeechRequest"
+            responses:
+                "200":
+                    description: OK
+                    headers:
+                        Transfer-Encoding:
+                            schema:
+                                type: string
+                            description: chunked
+                    content:
+                        application/octet-stream:
+                            schema:
+                                type: string
+                                format: binary
+            x-oaiMeta:
+                name: Create speech
+                group: audio
+                returns: The audio file content.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/audio/speech \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -d '{
+                                "model": "tts-1",
+                                "input": "The quick brown fox jumped over the lazy dog.",
+                                "voice": "alloy"
+                              }' \
+                              --output speech.mp3
+                        python: |
+                            from pathlib import Path
+                            import openai
+
+                            speech_file_path = Path(__file__).parent / "speech.mp3"
+                            response = openai.audio.speech.create(
+                              model="tts-1",
+                              voice="alloy",
+                              input="The quick brown fox jumped over the lazy dog."
+                            )
+                            response.stream_to_file(speech_file_path)
+                        node: |
+                            import fs from "fs";
+                            import path from "path";
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            const speechFile = path.resolve("./speech.mp3");
+
+                            async function main() {
+                              const mp3 = await openai.audio.speech.create({
+                                model: "tts-1",
+                                voice: "alloy",
+                                input: "Today is a wonderful day to build something people love!",
+                              });
+                              console.log(speechFile);
+                              const buffer = Buffer.from(await mp3.arrayBuffer());
+                              await fs.promises.writeFile(speechFile, buffer);
+                            }
+                            main();
+    /audio/transcriptions:
+        post:
+            operationId: createTranscription
+            tags:
+                - Audio
+            summary: Transcribes audio into the input language.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/CreateTranscriptionRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                oneOf:
+                                    - $ref: "#/components/schemas/CreateTranscriptionResponseJson"
+                                    - $ref: "#/components/schemas/CreateTranscriptionResponseVerboseJson"
+            x-oaiMeta:
+                name: Create transcription
+                group: audio
+                returns: The [transcription object](/docs/api-reference/audio/json-object) or a [verbose transcription object](/docs/api-reference/audio/verbose-json-object).
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/audio/transcriptions \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: multipart/form-data" \
+                                -F file="@/path/to/file/audio.mp3" \
+                                -F model="whisper-1"
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              audio_file = open("speech.mp3", "rb")
+                              transcript = client.audio.transcriptions.create(
+                                model="whisper-1",
+                                file=audio_file
+                              )
+                          node: |
+                              import fs from "fs";
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const transcription = await openai.audio.transcriptions.create({
+                                  file: fs.createReadStream("audio.mp3"),
+                                  model: "whisper-1",
+                                });
+
+                                console.log(transcription.text);
+                              }
+                              main();
+                      response: &basic_transcription_response_example |
+                          {
+                            "text": "Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that."
+                          }
+                    - title: Word timestamps
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/audio/transcriptions \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: multipart/form-data" \
+                                -F file="@/path/to/file/audio.mp3" \
+                                -F "timestamp_granularities[]=word" \
+                                -F model="whisper-1" \
+                                -F response_format="verbose_json"
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              audio_file = open("speech.mp3", "rb")
+                              transcript = client.audio.transcriptions.create(
+                                file=audio_file,
+                                model="whisper-1",
+                                response_format="verbose_json",
+                                timestamp_granularities=["word"]
+                              )
+
+                              print(transcript.words)
+                          node: |
+                              import fs from "fs";
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const transcription = await openai.audio.transcriptions.create({
+                                  file: fs.createReadStream("audio.mp3"),
+                                  model: "whisper-1",
+                                  response_format: "verbose_json",
+                                  timestamp_granularities: ["word"]
+                                });
+
+                                console.log(transcription.text);
+                              }
+                              main();
+                      response: |
+                          {
+                            "task": "transcribe",
+                            "language": "english",
+                            "duration": 8.470000267028809,
+                            "text": "The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.",
+                            "words": [
+                              {
+                                "word": "The",
+                                "start": 0.0,
+                                "end": 0.23999999463558197
+                              },
+                              ...
+                              {
+                                "word": "volleyball",
+                                "start": 7.400000095367432,
+                                "end": 7.900000095367432
+                              }
+                            ]
+                          }
+                    - title: Segment timestamps
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/audio/transcriptions \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: multipart/form-data" \
+                                -F file="@/path/to/file/audio.mp3" \
+                                -F "timestamp_granularities[]=segment" \
+                                -F model="whisper-1" \
+                                -F response_format="verbose_json"
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              audio_file = open("speech.mp3", "rb")
+                              transcript = client.audio.transcriptions.create(
+                                file=audio_file,
+                                model="whisper-1",
+                                response_format="verbose_json",
+                                timestamp_granularities=["segment"]
+                              )
+
+                              print(transcript.words)
+                          node: |
+                              import fs from "fs";
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const transcription = await openai.audio.transcriptions.create({
+                                  file: fs.createReadStream("audio.mp3"),
+                                  model: "whisper-1",
+                                  response_format: "verbose_json",
+                                  timestamp_granularities: ["segment"]
+                                });
+
+                                console.log(transcription.text);
+                              }
+                              main();
+                      response: &verbose_transcription_response_example |
+                          {
+                            "task": "transcribe",
+                            "language": "english",
+                            "duration": 8.470000267028809,
+                            "text": "The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.",
+                            "segments": [
+                              {
+                                "id": 0,
+                                "seek": 0,
+                                "start": 0.0,
+                                "end": 3.319999933242798,
+                                "text": " The beach was a popular spot on a hot summer day.",
+                                "tokens": [
+                                  50364, 440, 7534, 390, 257, 3743, 4008, 322, 257, 2368, 4266, 786, 13, 50530
+                                ],
+                                "temperature": 0.0,
+                                "avg_logprob": -0.2860786020755768,
+                                "compression_ratio": 1.2363636493682861,
+                                "no_speech_prob": 0.00985979475080967
+                              },
+                              ...
+                            ]
+                          }
+    /audio/translations:
+        post:
+            operationId: createTranslation
+            tags:
+                - Audio
+            summary: Translates audio into English.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/CreateTranslationRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                oneOf:
+                                    - $ref: "#/components/schemas/CreateTranslationResponseJson"
+                                    - $ref: "#/components/schemas/CreateTranslationResponseVerboseJson"
+            x-oaiMeta:
+                name: Create translation
+                group: audio
+                returns: The translated text.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/audio/translations \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: multipart/form-data" \
+                              -F file="@/path/to/file/german.m4a" \
+                              -F model="whisper-1"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            audio_file = open("speech.mp3", "rb")
+                            transcript = client.audio.translations.create(
+                              model="whisper-1",
+                              file=audio_file
+                            )
+                        node: |
+                            import fs from "fs";
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                                const translation = await openai.audio.translations.create({
+                                    file: fs.createReadStream("speech.mp3"),
+                                    model: "whisper-1",
+                                });
+
+                                console.log(translation.text);
+                            }
+                            main();
+                    response: |
+                        {
+                          "text": "Hello, my name is Wolfgang and I come from Germany. Where are you heading today?"
+                        }
+
+    /files:
+        get:
+            operationId: listFiles
+            tags:
+                - Files
+            summary: Returns a list of files that belong to the user's organization.
+            parameters:
+                - in: query
+                  name: purpose
+                  required: false
+                  schema:
+                      type: string
+                  description: Only return files with the given purpose.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListFilesResponse"
+            x-oaiMeta:
+                name: List files
+                group: files
+                returns: A list of [File](/docs/api-reference/files/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/files \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.files.list()
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const list = await openai.files.list();
+
+                              for await (const file of list) {
+                                console.log(file);
+                              }
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "data": [
+                            {
+                              "id": "file-abc123",
+                              "object": "file",
+                              "bytes": 175,
+                              "created_at": 1613677385,
+                              "filename": "salesOverview.pdf",
+                              "purpose": "assistants",
+                            },
+                            {
+                              "id": "file-abc123",
+                              "object": "file",
+                              "bytes": 140,
+                              "created_at": 1613779121,
+                              "filename": "puppy.jsonl",
+                              "purpose": "fine-tune",
+                            }
+                          ],
+                          "object": "list"
+                        }
+        post:
+            operationId: createFile
+            tags:
+                - Files
+            summary: |
+                Upload a file that can be used across various endpoints. Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB.
+
+                The Assistants API supports files up to 2 million tokens and of specific file types. See the [Assistants Tools guide](/docs/assistants/tools) for details.
+
+                The Fine-tuning API only supports `.jsonl` files. The input also has certain required formats for fine-tuning [chat](/docs/api-reference/fine-tuning/chat-input) or [completions](/docs/api-reference/fine-tuning/completions-input) models.
+
+                The Batch API only supports `.jsonl` files up to 100 MB in size. The input also has a specific required [format](/docs/api-reference/batch/request-input).
+
+                Please [contact us](https://help.openai.com/) if you need to increase these storage limits.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/CreateFileRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/OpenAIFile"
+            x-oaiMeta:
+                name: Upload file
+                group: files
+                returns: The uploaded [File](/docs/api-reference/files/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/files \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -F purpose="fine-tune" \
+                              -F file="@mydata.jsonl"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.files.create(
+                              file=open("mydata.jsonl", "rb"),
+                              purpose="fine-tune"
+                            )
+                        node.js: |-
+                            import fs from "fs";
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const file = await openai.files.create({
+                                file: fs.createReadStream("mydata.jsonl"),
+                                purpose: "fine-tune",
+                              });
+
+                              console.log(file);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "file-abc123",
+                          "object": "file",
+                          "bytes": 120000,
+                          "created_at": 1677610602,
+                          "filename": "mydata.jsonl",
+                          "purpose": "fine-tune",
+                        }
+    /files/{file_id}:
+        delete:
+            operationId: deleteFile
+            tags:
+                - Files
+            summary: Delete a file.
+            parameters:
+                - in: path
+                  name: file_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the file to use for this request.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteFileResponse"
+            x-oaiMeta:
+                name: Delete file
+                group: files
+                returns: Deletion status.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/files/file-abc123 \
+                              -X DELETE \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.files.delete("file-abc123")
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const file = await openai.files.del("file-abc123");
+
+                              console.log(file);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "file-abc123",
+                          "object": "file",
+                          "deleted": true
+                        }
+        get:
+            operationId: retrieveFile
+            tags:
+                - Files
+            summary: Returns information about a specific file.
+            parameters:
+                - in: path
+                  name: file_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the file to use for this request.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/OpenAIFile"
+            x-oaiMeta:
+                name: Retrieve file
+                group: files
+                returns: The [File](/docs/api-reference/files/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/files/file-abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.files.retrieve("file-abc123")
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const file = await openai.files.retrieve("file-abc123");
+
+                              console.log(file);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "file-abc123",
+                          "object": "file",
+                          "bytes": 120000,
+                          "created_at": 1677610602,
+                          "filename": "mydata.jsonl",
+                          "purpose": "fine-tune",
+                        }
+    /files/{file_id}/content:
+        get:
+            operationId: downloadFile
+            tags:
+                - Files
+            summary: Returns the contents of the specified file.
+            parameters:
+                - in: path
+                  name: file_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the file to use for this request.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+            x-oaiMeta:
+                name: Retrieve file content
+                group: files
+                returns: The file content.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/files/file-abc123/content \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" > file.jsonl
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            content = client.files.content("file-abc123")
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const file = await openai.files.content("file-abc123");
+
+                              console.log(file);
+                            }
+
+                            main();
+    /uploads:
+        post:
+            operationId: createUpload
+            tags:
+                - Uploads
+            summary: |
+                Creates an intermediate [Upload](/docs/api-reference/uploads/object) object that you can add [Parts](/docs/api-reference/uploads/part-object) to. Currently, an Upload can accept at most 8 GB in total and expires after an hour after you create it.
+                
+                Once you complete the Upload, we will create a [File](/docs/api-reference/files/object) object that contains all the parts you uploaded. This File is usable in the rest of our platform as a regular File object.
+                
+                For certain `purpose`s, the correct `mime_type` must be specified. Please refer to documentation for the supported MIME types for your use case:
+                - [Assistants](/docs/assistants/tools/file-search/supported-files)
+                
+                For guidance on the proper filename extensions for each purpose, please follow the documentation on [creating a File](/docs/api-reference/files/create).
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateUploadRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Upload"
+            x-oaiMeta:
+                name: Create upload
+                group: uploads
+                returns: The [Upload](/docs/api-reference/uploads/object) object with status `pending`.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/uploads \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -d '{
+                                "purpose": "fine-tune",
+                                "filename": "training_examples.jsonl",
+                                "bytes": 2147483648,
+                                "mime_type": "text/jsonl"
+                              }'
+                    response: |
+                        {
+                          "id": "upload_abc123",
+                          "object": "upload",
+                          "bytes": 2147483648,
+                          "created_at": 1719184911,
+                          "filename": "training_examples.jsonl",
+                          "purpose": "fine-tune",
+                          "status": "pending",
+                          "expires_at": 1719127296
+                        }
+
+    /uploads/{upload_id}/parts:
+        post:
+            operationId: addUploadPart
+            tags:
+                - Uploads
+            summary: |
+                Adds a [Part](/docs/api-reference/uploads/part-object) to an [Upload](/docs/api-reference/uploads/object) object. A Part represents a chunk of bytes from the file you are trying to upload. 
+
+                Each Part can be at most 64 MB, and you can add Parts until you hit the Upload maximum of 8 GB.
+
+                It is possible to add multiple Parts in parallel. You can decide the intended order of the Parts when you [complete the Upload](/docs/api-reference/uploads/complete).
+            parameters:
+                - in: path
+                  name: upload_id
+                  required: true
+                  schema:
+                      type: string
+                      example: upload_abc123
+                  description: |
+                      The ID of the Upload.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/AddUploadPartRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/UploadPart"
+            x-oaiMeta:
+                name: Add upload part
+                group: uploads
+                returns: The upload [Part](/docs/api-reference/uploads/part-object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/uploads/upload_abc123/parts
+                              -F data="aHR0cHM6Ly9hcGkub3BlbmFpLmNvbS92MS91cGxvYWRz..."
+                    response: |
+                        {
+                          "id": "part_def456",
+                          "object": "upload.part",
+                          "created_at": 1719185911,
+                          "upload_id": "upload_abc123"
+                        }
+
+    /uploads/{upload_id}/complete:
+        post:
+            operationId: completeUpload
+            tags:
+                - Uploads
+            summary: |
+                Completes the [Upload](/docs/api-reference/uploads/object). 
+                
+                Within the returned Upload object, there is a nested [File](/docs/api-reference/files/object) object that is ready to use in the rest of the platform.
+
+                You can specify the order of the Parts by passing in an ordered list of the Part IDs.
+
+                The number of bytes uploaded upon completion must match the number of bytes initially specified when creating the Upload object. No Parts may be added after an Upload is completed.
+            parameters:
+                - in: path
+                  name: upload_id
+                  required: true
+                  schema:
+                      type: string
+                      example: upload_abc123
+                  description: |
+                      The ID of the Upload.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CompleteUploadRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Upload"
+            x-oaiMeta:
+                name: Complete upload
+                group: uploads
+                returns: The [Upload](/docs/api-reference/uploads/object) object with status `completed` with an additional `file` property containing the created usable File object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/uploads/upload_abc123/complete
+                              -d '{
+                                "part_ids": ["part_def456", "part_ghi789"]
+                              }'
+                    response: |
+                        {
+                          "id": "upload_abc123",
+                          "object": "upload",
+                          "bytes": 2147483648,
+                          "created_at": 1719184911,
+                          "filename": "training_examples.jsonl",
+                          "purpose": "fine-tune",
+                          "status": "completed",
+                          "expires_at": 1719127296,
+                          "file": {
+                            "id": "file-xyz321",
+                            "object": "file",
+                            "bytes": 2147483648,
+                            "created_at": 1719186911,
+                            "filename": "training_examples.jsonl",
+                            "purpose": "fine-tune",
+                          }
+                        }
+
+    /uploads/{upload_id}/cancel:
+        post:
+            operationId: cancelUpload
+            tags:
+                - Uploads
+            summary: |
+                Cancels the Upload. No Parts may be added after an Upload is cancelled.
+            parameters:
+                - in: path
+                  name: upload_id
+                  required: true
+                  schema:
+                      type: string
+                      example: upload_abc123
+                  description: |
+                      The ID of the Upload.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Upload"
+            x-oaiMeta:
+                name: Cancel upload
+                group: uploads
+                returns: The [Upload](/docs/api-reference/uploads/object) object with status `cancelled`.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/uploads/upload_abc123/cancel
+                    response: |
+                        {
+                          "id": "upload_abc123",
+                          "object": "upload",
+                          "bytes": 2147483648,
+                          "created_at": 1719184911,
+                          "filename": "training_examples.jsonl",
+                          "purpose": "fine-tune",
+                          "status": "cancelled",
+                          "expires_at": 1719127296
+                        }
+  
+    /fine_tuning/jobs:
+        post:
+            operationId: createFineTuningJob
+            tags:
+                - Fine-tuning
+            summary: |
+                Creates a fine-tuning job which begins the process of creating a new model from a given dataset.
+
+                Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
+
+                [Learn more about fine-tuning](/docs/guides/fine-tuning)
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateFineTuningJobRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FineTuningJob"
+            x-oaiMeta:
+                name: Create fine-tuning job
+                group: fine-tuning
+                returns: A [fine-tuning.job](/docs/api-reference/fine-tuning/object) object.
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/fine_tuning/jobs \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "training_file": "file-BK7bzQj3FfZFXr7DbL6xJwfo",
+                                  "model": "gpt-3.5-turbo"
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              client.fine_tuning.jobs.create(
+                                training_file="file-abc123",
+                                model="gpt-3.5-turbo"
+                              )
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const fineTune = await openai.fineTuning.jobs.create({
+                                  training_file: "file-abc123"
+                                });
+
+                                console.log(fineTune);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "object": "fine_tuning.job",
+                            "id": "ftjob-abc123",
+                            "model": "gpt-3.5-turbo-0125",
+                            "created_at": 1614807352,
+                            "fine_tuned_model": null,
+                            "organization_id": "org-123",
+                            "result_files": [],
+                            "status": "queued",
+                            "validation_file": null,
+                            "training_file": "file-abc123",
+                          }
+                    - title: Epochs
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/fine_tuning/jobs \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "training_file": "file-abc123",
+                                  "model": "gpt-3.5-turbo",
+                                  "hyperparameters": {
+                                    "n_epochs": 2
+                                  }
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              client.fine_tuning.jobs.create(
+                                training_file="file-abc123",
+                                model="gpt-3.5-turbo",
+                                hyperparameters={
+                                  "n_epochs":2
+                                }
+                              )
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const fineTune = await openai.fineTuning.jobs.create({
+                                  training_file: "file-abc123",
+                                  model: "gpt-3.5-turbo",
+                                  hyperparameters: { n_epochs: 2 }
+                                });
+
+                                console.log(fineTune);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "object": "fine_tuning.job",
+                            "id": "ftjob-abc123",
+                            "model": "gpt-3.5-turbo-0125",
+                            "created_at": 1614807352,
+                            "fine_tuned_model": null,
+                            "organization_id": "org-123",
+                            "result_files": [],
+                            "status": "queued",
+                            "validation_file": null,
+                            "training_file": "file-abc123",
+                            "hyperparameters": {"n_epochs": 2},
+                          }
+                    - title: Validation file
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/fine_tuning/jobs \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "training_file": "file-abc123",
+                                  "validation_file": "file-abc123",
+                                  "model": "gpt-3.5-turbo"
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              client.fine_tuning.jobs.create(
+                                training_file="file-abc123",
+                                validation_file="file-def456",
+                                model="gpt-3.5-turbo"
+                              )
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const fineTune = await openai.fineTuning.jobs.create({
+                                  training_file: "file-abc123",
+                                  validation_file: "file-abc123"
+                                });
+
+                                console.log(fineTune);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "object": "fine_tuning.job",
+                            "id": "ftjob-abc123",
+                            "model": "gpt-3.5-turbo-0125",
+                            "created_at": 1614807352,
+                            "fine_tuned_model": null,
+                            "organization_id": "org-123",
+                            "result_files": [],
+                            "status": "queued",
+                            "validation_file": "file-abc123",
+                            "training_file": "file-abc123",
+                          }
+                    - title: W&B Integration
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/fine_tuning/jobs \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "training_file": "file-abc123",
+                                  "validation_file": "file-abc123",
+                                  "model": "gpt-3.5-turbo",
+                                  "integrations": [
+                                    {
+                                      "type": "wandb",
+                                      "wandb": {
+                                        "project": "my-wandb-project",
+                                        "name": "ft-run-display-name"
+                                        "tags": [
+                                          "first-experiment", "v2"
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }'
+                      response: |
+                          {
+                            "object": "fine_tuning.job",
+                            "id": "ftjob-abc123",
+                            "model": "gpt-3.5-turbo-0125",
+                            "created_at": 1614807352,
+                            "fine_tuned_model": null,
+                            "organization_id": "org-123",
+                            "result_files": [],
+                            "status": "queued",
+                            "validation_file": "file-abc123",
+                            "training_file": "file-abc123",
+                            "integrations": [
+                              {
+                                "type": "wandb",
+                                "wandb": {
+                                  "project": "my-wandb-project",
+                                  "entity": None,
+                                  "run_id": "ftjob-abc123"
+                                }
+                              }
+                            ]
+                          }
+        get:
+            operationId: listPaginatedFineTuningJobs
+            tags:
+                - Fine-tuning
+            summary: |
+                List your organization's fine-tuning jobs
+            parameters:
+                - name: after
+                  in: query
+                  description: Identifier for the last job from the previous pagination request.
+                  required: false
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: Number of fine-tuning jobs to retrieve.
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListPaginatedFineTuningJobsResponse"
+            x-oaiMeta:
+                name: List fine-tuning jobs
+                group: fine-tuning
+                returns: A list of paginated [fine-tuning job](/docs/api-reference/fine-tuning/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/fine_tuning/jobs?limit=2 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.fine_tuning.jobs.list()
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const list = await openai.fineTuning.jobs.list();
+
+                              for await (const fineTune of list) {
+                                console.log(fineTune);
+                              }
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "object": "fine_tuning.job.event",
+                              "id": "ft-event-TjX0lMfOniCZX64t9PUQT5hn",
+                              "created_at": 1689813489,
+                              "level": "warn",
+                              "message": "Fine tuning process stopping due to job cancellation",
+                              "data": null,
+                              "type": "message"
+                            },
+                            { ... },
+                            { ... }
+                          ], "has_more": true
+                        }
+    /fine_tuning/jobs/{fine_tuning_job_id}:
+        get:
+            operationId: retrieveFineTuningJob
+            tags:
+                - Fine-tuning
+            summary: |
+                Get info about a fine-tuning job.
+
+                [Learn more about fine-tuning](/docs/guides/fine-tuning)
+            parameters:
+                - in: path
+                  name: fine_tuning_job_id
+                  required: true
+                  schema:
+                      type: string
+                      example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+                  description: |
+                      The ID of the fine-tuning job.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FineTuningJob"
+            x-oaiMeta:
+                name: Retrieve fine-tuning job
+                group: fine-tuning
+                returns: The [fine-tuning](/docs/api-reference/fine-tuning/object) object with the given ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.fine_tuning.jobs.retrieve("ftjob-abc123")
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const fineTune = await openai.fineTuning.jobs.retrieve("ftjob-abc123");
+
+                              console.log(fineTune);
+                            }
+
+                            main();
+                    response: &fine_tuning_example |
+                        {
+                          "object": "fine_tuning.job",
+                          "id": "ftjob-abc123",
+                          "model": "davinci-002",
+                          "created_at": 1692661014,
+                          "finished_at": 1692661190,
+                          "fine_tuned_model": "ft:davinci-002:my-org:custom_suffix:7q8mpxmy",
+                          "organization_id": "org-123",
+                          "result_files": [
+                              "file-abc123"
+                          ],
+                          "status": "succeeded",
+                          "validation_file": null,
+                          "training_file": "file-abc123",
+                          "hyperparameters": {
+                              "n_epochs": 4,
+                              "batch_size": 1,
+                              "learning_rate_multiplier": 1.0
+                          },
+                          "trained_tokens": 5768,
+                          "integrations": [],
+                          "seed": 0,
+                          "estimated_finish": 0
+                        }
+    /fine_tuning/jobs/{fine_tuning_job_id}/events:
+        get:
+            operationId: listFineTuningEvents
+            tags:
+                - Fine-tuning
+            summary: |
+                Get status updates for a fine-tuning job.
+            parameters:
+                - in: path
+                  name: fine_tuning_job_id
+                  required: true
+                  schema:
+                      type: string
+                      example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+                  description: |
+                      The ID of the fine-tuning job to get events for.
+                - name: after
+                  in: query
+                  description: Identifier for the last event from the previous pagination request.
+                  required: false
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: Number of events to retrieve.
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListFineTuningJobEventsResponse"
+            x-oaiMeta:
+                name: List fine-tuning events
+                group: fine-tuning
+                returns: A list of fine-tuning event objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/events \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.fine_tuning.jobs.list_events(
+                              fine_tuning_job_id="ftjob-abc123",
+                              limit=2
+                            )
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const list = await openai.fineTuning.list_events(id="ftjob-abc123", limit=2);
+
+                              for await (const fineTune of list) {
+                                console.log(fineTune);
+                              }
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "object": "fine_tuning.job.event",
+                              "id": "ft-event-ddTJfwuMVpfLXseO0Am0Gqjm",
+                              "created_at": 1692407401,
+                              "level": "info",
+                              "message": "Fine tuning job successfully completed",
+                              "data": null,
+                              "type": "message"
+                            },
+                            {
+                              "object": "fine_tuning.job.event",
+                              "id": "ft-event-tyiGuB72evQncpH87xe505Sv",
+                              "created_at": 1692407400,
+                              "level": "info",
+                              "message": "New fine-tuned model created: ft:gpt-3.5-turbo:openai::7p4lURel",
+                              "data": null,
+                              "type": "message"
+                            }
+                          ],
+                          "has_more": true
+                        }
+    /fine_tuning/jobs/{fine_tuning_job_id}/cancel:
+        post:
+            operationId: cancelFineTuningJob
+            tags:
+                - Fine-tuning
+            summary: |
+                Immediately cancel a fine-tune job.
+            parameters:
+                - in: path
+                  name: fine_tuning_job_id
+                  required: true
+                  schema:
+                      type: string
+                      example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+                  description: |
+                      The ID of the fine-tuning job to cancel.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FineTuningJob"
+            x-oaiMeta:
+                name: Cancel fine-tuning
+                group: fine-tuning
+                returns: The cancelled [fine-tuning](/docs/api-reference/fine-tuning/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl -X POST https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/cancel \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.fine_tuning.jobs.cancel("ftjob-abc123")
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const fineTune = await openai.fineTuning.jobs.cancel("ftjob-abc123");
+
+                              console.log(fineTune);
+                            }
+                            main();
+                    response: |
+                        {
+                          "object": "fine_tuning.job",
+                          "id": "ftjob-abc123",
+                          "model": "gpt-3.5-turbo-0125",
+                          "created_at": 1689376978,
+                          "fine_tuned_model": null,
+                          "organization_id": "org-123",
+                          "result_files": [],
+                          "hyperparameters": {
+                            "n_epochs":  "auto"
+                          },
+                          "status": "cancelled",
+                          "validation_file": "file-abc123",
+                          "training_file": "file-abc123"
+                        }
+    /fine_tuning/jobs/{fine_tuning_job_id}/checkpoints:
+        get:
+            operationId: listFineTuningJobCheckpoints
+            tags:
+                - Fine-tuning
+            summary: |
+                List checkpoints for a fine-tuning job.
+            parameters:
+                - in: path
+                  name: fine_tuning_job_id
+                  required: true
+                  schema:
+                      type: string
+                      example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+                  description: |
+                      The ID of the fine-tuning job to get checkpoints for.
+                - name: after
+                  in: query
+                  description: Identifier for the last checkpoint ID from the previous pagination request.
+                  required: false
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: Number of checkpoints to retrieve.
+                  required: false
+                  schema:
+                      type: integer
+                      default: 10
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListFineTuningJobCheckpointsResponse"
+            x-oaiMeta:
+                name: List fine-tuning checkpoints
+                group: fine-tuning
+                returns: A list of fine-tuning [checkpoint objects](/docs/api-reference/fine-tuning/checkpoint-object) for a fine-tuning job.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/checkpoints \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                    response: |
+                        {
+                          "object": "list"
+                          "data": [
+                            {
+                              "object": "fine_tuning.job.checkpoint",
+                              "id": "ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB",
+                              "created_at": 1519129973,
+                              "fine_tuned_model_checkpoint": "ft:gpt-3.5-turbo-0125:my-org:custom-suffix:96olL566:ckpt-step-2000",
+                              "metrics": {
+                                "full_valid_loss": 0.134,
+                                "full_valid_mean_token_accuracy": 0.874
+                              },
+                              "fine_tuning_job_id": "ftjob-abc123",
+                              "step_number": 2000,
+                            },
+                            {
+                              "object": "fine_tuning.job.checkpoint",
+                              "id": "ftckpt_enQCFmOTGj3syEpYVhBRLTSy",
+                              "created_at": 1519129833,
+                              "fine_tuned_model_checkpoint": "ft:gpt-3.5-turbo-0125:my-org:custom-suffix:7q8mpxmy:ckpt-step-1000",
+                              "metrics": {
+                                "full_valid_loss": 0.167,
+                                "full_valid_mean_token_accuracy": 0.781
+                              },
+                              "fine_tuning_job_id": "ftjob-abc123",
+                              "step_number": 1000,
+                            },
+                          ],
+                          "first_id": "ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB",
+                          "last_id": "ftckpt_enQCFmOTGj3syEpYVhBRLTSy",
+                          "has_more": true
+                        }
+
+    /models:
+        get:
+            operationId: listModels
+            tags:
+                - Models
+            summary: Lists the currently available models, and provides basic information about each one such as the owner and availability.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListModelsResponse"
+            x-oaiMeta:
+                name: List models
+                group: models
+                returns: A list of [model](/docs/api-reference/models/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/models \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.models.list()
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const list = await openai.models.list();
+
+                              for await (const model of list) {
+                                console.log(model);
+                              }
+                            }
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "model-id-0",
+                              "object": "model",
+                              "created": 1686935002,
+                              "owned_by": "organization-owner"
+                            },
+                            {
+                              "id": "model-id-1",
+                              "object": "model",
+                              "created": 1686935002,
+                              "owned_by": "organization-owner",
+                            },
+                            {
+                              "id": "model-id-2",
+                              "object": "model",
+                              "created": 1686935002,
+                              "owned_by": "openai"
+                            },
+                          ],
+                          "object": "list"
+                        }
+    /models/{model}:
+        get:
+            operationId: retrieveModel
+            tags:
+                - Models
+            summary: Retrieves a model instance, providing basic information about the model such as the owner and permissioning.
+            parameters:
+                - in: path
+                  name: model
+                  required: true
+                  schema:
+                      type: string
+                      # ideally this will be an actual ID, so this will always work from browser
+                      example: gpt-3.5-turbo
+                  description: The ID of the model to use for this request
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Model"
+            x-oaiMeta:
+                name: Retrieve model
+                group: models
+                returns: The [model](/docs/api-reference/models/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/models/VAR_model_id \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.models.retrieve("VAR_model_id")
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const model = await openai.models.retrieve("VAR_model_id");
+
+                              console.log(model);
+                            }
+
+                            main();
+                    response: &retrieve_model_response |
+                        {
+                          "id": "VAR_model_id",
+                          "object": "model",
+                          "created": 1686935002,
+                          "owned_by": "openai"
+                        }
+        delete:
+            operationId: deleteModel
+            tags:
+                - Models
+            summary: Delete a fine-tuned model. You must have the Owner role in your organization to delete a model.
+            parameters:
+                - in: path
+                  name: model
+                  required: true
+                  schema:
+                      type: string
+                      example: ft:gpt-3.5-turbo:acemeco:suffix:abc123
+                  description: The model to delete
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteModelResponse"
+            x-oaiMeta:
+                name: Delete a fine-tuned model
+                group: models
+                returns: Deletion status.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/models/ft:gpt-3.5-turbo:acemeco:suffix:abc123 \
+                              -X DELETE \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.models.delete("ft:gpt-3.5-turbo:acemeco:suffix:abc123")
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const model = await openai.models.del("ft:gpt-3.5-turbo:acemeco:suffix:abc123");
+
+                              console.log(model);
+                            }
+                            main();
+                    response: |
+                        {
+                          "id": "ft:gpt-3.5-turbo:acemeco:suffix:abc123",
+                          "object": "model",
+                          "deleted": true
+                        }
+
+    /moderations:
+        post:
+            operationId: createModeration
+            tags:
+                - Moderations
+            summary: Classifies if text is potentially harmful.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateModerationRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CreateModerationResponse"
+            x-oaiMeta:
+                name: Create moderation
+                group: moderations
+                returns: A [moderation](/docs/api-reference/moderations/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/moderations \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -d '{
+                                "input": "I want to kill them."
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            moderation = client.moderations.create(input="I want to kill them.")
+                            print(moderation)
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const moderation = await openai.moderations.create({ input: "I want to kill them." });
+
+                              console.log(moderation);
+                            }
+                            main();
+                    response: &moderation_example |
+                        {
+                          "id": "modr-XXXXX",
+                          "model": "text-moderation-005",
+                          "results": [
+                            {
+                              "flagged": true,
+                              "categories": {
+                                "sexual": false,
+                                "hate": false,
+                                "harassment": false,
+                                "self-harm": false,
+                                "sexual/minors": false,
+                                "hate/threatening": false,
+                                "violence/graphic": false,
+                                "self-harm/intent": false,
+                                "self-harm/instructions": false,
+                                "harassment/threatening": true,
+                                "violence": true,
+                              },
+                              "category_scores": {
+                                "sexual": 1.2282071e-06,
+                                "hate": 0.010696256,
+                                "harassment": 0.29842457,
+                                "self-harm": 1.5236925e-08,
+                                "sexual/minors": 5.7246268e-08,
+                                "hate/threatening": 0.0060676364,
+                                "violence/graphic": 4.435014e-06,
+                                "self-harm/intent": 8.098441e-10,
+                                "self-harm/instructions": 2.8498655e-11,
+                                "harassment/threatening": 0.63055265,
+                                "violence": 0.99011886,
+                              }
+                            }
+                          ]
+                        }
+
+    /assistants:
+        get:
+            operationId: listAssistants
+            tags:
+                - Assistants
+            summary: Returns a list of assistants.
+            parameters:
+                - name: limit
+                  in: query
+                  description: &pagination_limit_param_description |
+                      A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: &pagination_order_param_description |
+                      Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: &pagination_after_param_description |
+                      A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: &pagination_before_param_description |
+                      A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListAssistantsResponse"
+            x-oaiMeta:
+                name: List assistants
+                group: assistants
+                beta: true
+                returns: A list of [assistant](/docs/api-reference/assistants/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl "https://api.openai.com/v1/assistants?order=desc&limit=20" \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            my_assistants = client.beta.assistants.list(
+                                order="desc",
+                                limit="20",
+                            )
+                            print(my_assistants.data)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myAssistants = await openai.beta.assistants.list({
+                                order: "desc",
+                                limit: "20",
+                              });
+
+                              console.log(myAssistants.data);
+                            }
+
+                            main();
+                    response: &list_assistants_example |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "asst_abc123",
+                              "object": "assistant",
+                              "created_at": 1698982736,
+                              "name": "Coding Tutor",
+                              "description": null,
+                              "model": "gpt-4-turbo",
+                              "instructions": "You are a helpful assistant designed to make me better at coding!",
+                              "tools": [],
+                              "tool_resources": {},
+                              "metadata": {},
+                              "top_p": 1.0,
+                              "temperature": 1.0,
+                              "response_format": "auto"
+                            },
+                            {
+                              "id": "asst_abc456",
+                              "object": "assistant",
+                              "created_at": 1698982718,
+                              "name": "My Assistant",
+                              "description": null,
+                              "model": "gpt-4-turbo",
+                              "instructions": "You are a helpful assistant designed to make me better at coding!",
+                              "tools": [],
+                              "tool_resources": {},
+                              "metadata": {},
+                              "top_p": 1.0,
+                              "temperature": 1.0,
+                              "response_format": "auto"
+                            },
+                            {
+                              "id": "asst_abc789",
+                              "object": "assistant",
+                              "created_at": 1698982643,
+                              "name": null,
+                              "description": null,
+                              "model": "gpt-4-turbo",
+                              "instructions": null,
+                              "tools": [],
+                              "tool_resources": {},
+                              "metadata": {},
+                              "top_p": 1.0,
+                              "temperature": 1.0,
+                              "response_format": "auto"
+                            }
+                          ],
+                          "first_id": "asst_abc123",
+                          "last_id": "asst_abc789",
+                          "has_more": false
+                        }
+        post:
+            operationId: createAssistant
+            tags:
+                - Assistants
+            summary: Create an assistant with a model and instructions.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateAssistantRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AssistantObject"
+            x-oaiMeta:
+                name: Create assistant
+                group: assistants
+                beta: true
+                returns: An [assistant](/docs/api-reference/assistants/object) object.
+                examples:
+                    - title: Code Interpreter
+                      request:
+                          curl: |
+                              curl "https://api.openai.com/v1/assistants" \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "instructions": "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                                  "name": "Math Tutor",
+                                  "tools": [{"type": "code_interpreter"}],
+                                  "model": "gpt-4-turbo"
+                                }'
+
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              my_assistant = client.beta.assistants.create(
+                                  instructions="You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                                  name="Math Tutor",
+                                  tools=[{"type": "code_interpreter"}],
+                                  model="gpt-4-turbo",
+                              )
+                              print(my_assistant)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const myAssistant = await openai.beta.assistants.create({
+                                  instructions:
+                                    "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                                  name: "Math Tutor",
+                                  tools: [{ type: "code_interpreter" }],
+                                  model: "gpt-4-turbo",
+                                });
+
+                                console.log(myAssistant);
+                              }
+
+                              main();
+                      response: &create_assistants_example |
+                          {
+                            "id": "asst_abc123",
+                            "object": "assistant",
+                            "created_at": 1698984975,
+                            "name": "Math Tutor",
+                            "description": null,
+                            "model": "gpt-4-turbo",
+                            "instructions": "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                            "tools": [
+                              {
+                                "type": "code_interpreter"
+                              }
+                            ],
+                            "metadata": {},
+                            "top_p": 1.0,
+                            "temperature": 1.0,
+                            "response_format": "auto"
+                          }
+                    - title: Files
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/assistants \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                                  "tools": [{"type": "file_search"}],
+                                  "tool_resources": {"file_search": {"vector_store_ids": ["vs_123"]}},
+                                  "model": "gpt-4-turbo"
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              my_assistant = client.beta.assistants.create(
+                                  instructions="You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                                  name="HR Helper",
+                                  tools=[{"type": "file_search"}],
+                                  tool_resources={"file_search": {"vector_store_ids": ["vs_123"]}},
+                                  model="gpt-4-turbo"
+                              )
+                              print(my_assistant)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const myAssistant = await openai.beta.assistants.create({
+                                  instructions:
+                                    "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                                  name: "HR Helper",
+                                  tools: [{ type: "file_search" }],
+                                  tool_resources: {
+                                    file_search: {
+                                      vector_store_ids: ["vs_123"]
+                                    }
+                                  },
+                                  model: "gpt-4-turbo"
+                                });
+
+                                console.log(myAssistant);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "asst_abc123",
+                            "object": "assistant",
+                            "created_at": 1699009403,
+                            "name": "HR Helper",
+                            "description": null,
+                            "model": "gpt-4-turbo",
+                            "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                            "tools": [
+                              {
+                                "type": "file_search"
+                              }
+                            ],
+                            "tool_resources": {
+                              "file_search": {
+                                "vector_store_ids": ["vs_123"]
+                              }
+                            },
+                            "metadata": {},
+                            "top_p": 1.0,
+                            "temperature": 1.0,
+                            "response_format": "auto"
+                          }
+
+    /assistants/{assistant_id}:
+        get:
+            operationId: getAssistant
+            tags:
+                - Assistants
+            summary: Retrieves an assistant.
+            parameters:
+                - in: path
+                  name: assistant_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the assistant to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AssistantObject"
+            x-oaiMeta:
+                name: Retrieve assistant
+                group: assistants
+                beta: true
+                returns: The [assistant](/docs/api-reference/assistants/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/assistants/asst_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            my_assistant = client.beta.assistants.retrieve("asst_abc123")
+                            print(my_assistant)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myAssistant = await openai.beta.assistants.retrieve(
+                                "asst_abc123"
+                              );
+
+                              console.log(myAssistant);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "asst_abc123",
+                          "object": "assistant",
+                          "created_at": 1699009709,
+                          "name": "HR Helper",
+                          "description": null,
+                          "model": "gpt-4-turbo",
+                          "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                          "tools": [
+                            {
+                              "type": "file_search"
+                            }
+                          ],
+                          "metadata": {},
+                          "top_p": 1.0,
+                          "temperature": 1.0,
+                          "response_format": "auto"
+                        }
+        post:
+            operationId: modifyAssistant
+            tags:
+                - Assistants
+            summary: Modifies an assistant.
+            parameters:
+                - in: path
+                  name: assistant_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the assistant to modify.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ModifyAssistantRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AssistantObject"
+            x-oaiMeta:
+                name: Modify assistant
+                group: assistants
+                beta: true
+                returns: The modified [assistant](/docs/api-reference/assistants/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/assistants/asst_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                  "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                                  "tools": [{"type": "file_search"}],
+                                  "model": "gpt-4-turbo"
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            my_updated_assistant = client.beta.assistants.update(
+                              "asst_abc123",
+                              instructions="You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                              name="HR Helper",
+                              tools=[{"type": "file_search"}],
+                              model="gpt-4-turbo"
+                            )
+
+                            print(my_updated_assistant)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myUpdatedAssistant = await openai.beta.assistants.update(
+                                "asst_abc123",
+                                {
+                                  instructions:
+                                    "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                                  name: "HR Helper",
+                                  tools: [{ type: "file_search" }],
+                                  model: "gpt-4-turbo"
+                                }
+                              );
+
+                              console.log(myUpdatedAssistant);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "asst_123",
+                          "object": "assistant",
+                          "created_at": 1699009709,
+                          "name": "HR Helper",
+                          "description": null,
+                          "model": "gpt-4-turbo",
+                          "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                          "tools": [
+                            {
+                              "type": "file_search"
+                            }
+                          ],
+                          "tool_resources": {
+                            "file_search": {
+                              "vector_store_ids": []
+                            }
+                          },
+                          "metadata": {},
+                          "top_p": 1.0,
+                          "temperature": 1.0,
+                          "response_format": "auto"
+                        }
+        delete:
+            operationId: deleteAssistant
+            tags:
+                - Assistants
+            summary: Delete an assistant.
+            parameters:
+                - in: path
+                  name: assistant_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the assistant to delete.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteAssistantResponse"
+            x-oaiMeta:
+                name: Delete assistant
+                group: assistants
+                beta: true
+                returns: Deletion status
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/assistants/asst_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X DELETE
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            response = client.beta.assistants.delete("asst_abc123")
+                            print(response)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const response = await openai.beta.assistants.del("asst_abc123");
+
+                              console.log(response);
+                            }
+                            main();
+                    response: |
+                        {
+                          "id": "asst_abc123",
+                          "object": "assistant.deleted",
+                          "deleted": true
+                        }
+
+    /threads:
+        post:
+            operationId: createThread
+            tags:
+                - Assistants
+            summary: Create a thread.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateThreadRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ThreadObject"
+            x-oaiMeta:
+                name: Create thread
+                group: threads
+                beta: true
+                returns: A [thread](/docs/api-reference/threads) object.
+                examples:
+                    - title: Empty
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d ''
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              empty_thread = client.beta.threads.create()
+                              print(empty_thread)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const emptyThread = await openai.beta.threads.create();
+
+                                console.log(emptyThread);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "thread_abc123",
+                            "object": "thread",
+                            "created_at": 1699012949,
+                            "metadata": {},
+                            "tool_resources": {}
+                          }
+                    - title: Messages
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                  "messages": [{
+                                    "role": "user",
+                                    "content": "Hello, what is AI?"
+                                  }, {
+                                    "role": "user",
+                                    "content": "How does AI work? Explain it in simple terms."
+                                  }]
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              message_thread = client.beta.threads.create(
+                                messages=[
+                                  {
+                                    "role": "user",
+                                    "content": "Hello, what is AI?"
+                                  },
+                                  {
+                                    "role": "user",
+                                    "content": "How does AI work? Explain it in simple terms."
+                                  },
+                                ]
+                              )
+
+                              print(message_thread)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const messageThread = await openai.beta.threads.create({
+                                  messages: [
+                                    {
+                                      role: "user",
+                                      content: "Hello, what is AI?"
+                                    },
+                                    {
+                                      role: "user",
+                                      content: "How does AI work? Explain it in simple terms.",
+                                    },
+                                  ],
+                                });
+
+                                console.log(messageThread);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "thread_abc123",
+                            "object": "thread",
+                            "created_at": 1699014083,
+                            "metadata": {},
+                            "tool_resources": {}
+                          }
+
+    /threads/{thread_id}:
+        get:
+            operationId: getThread
+            tags:
+                - Assistants
+            summary: Retrieves a thread.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ThreadObject"
+            x-oaiMeta:
+                name: Retrieve thread
+                group: threads
+                beta: true
+                returns: The [thread](/docs/api-reference/threads/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            my_thread = client.beta.threads.retrieve("thread_abc123")
+                            print(my_thread)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myThread = await openai.beta.threads.retrieve(
+                                "thread_abc123"
+                              );
+
+                              console.log(myThread);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "thread_abc123",
+                          "object": "thread",
+                          "created_at": 1699014083,
+                          "metadata": {},
+                          "tool_resources": {
+                            "code_interpreter": {
+                              "file_ids": []
+                            }
+                          }
+                        }
+        post:
+            operationId: modifyThread
+            tags:
+                - Assistants
+            summary: Modifies a thread.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to modify. Only the `metadata` can be modified.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ModifyThreadRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ThreadObject"
+            x-oaiMeta:
+                name: Modify thread
+                group: threads
+                beta: true
+                returns: The modified [thread](/docs/api-reference/threads/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                  "metadata": {
+                                    "modified": "true",
+                                    "user": "abc123"
+                                  }
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            my_updated_thread = client.beta.threads.update(
+                              "thread_abc123",
+                              metadata={
+                                "modified": "true",
+                                "user": "abc123"
+                              }
+                            )
+                            print(my_updated_thread)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const updatedThread = await openai.beta.threads.update(
+                                "thread_abc123",
+                                {
+                                  metadata: { modified: "true", user: "abc123" },
+                                }
+                              );
+
+                              console.log(updatedThread);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "thread_abc123",
+                          "object": "thread",
+                          "created_at": 1699014083,
+                          "metadata": {
+                            "modified": "true",
+                            "user": "abc123"
+                          },
+                          "tool_resources": {}
+                        }
+        delete:
+            operationId: deleteThread
+            tags:
+                - Assistants
+            summary: Delete a thread.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to delete.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteThreadResponse"
+            x-oaiMeta:
+                name: Delete thread
+                group: threads
+                beta: true
+                returns: Deletion status
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X DELETE
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            response = client.beta.threads.delete("thread_abc123")
+                            print(response)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const response = await openai.beta.threads.del("thread_abc123");
+
+                              console.log(response);
+                            }
+                            main();
+                    response: |
+                        {
+                          "id": "thread_abc123",
+                          "object": "thread.deleted",
+                          "deleted": true
+                        }
+
+    /threads/{thread_id}/messages:
+        get:
+            operationId: listMessages
+            tags:
+                - Assistants
+            summary: Returns a list of messages for a given thread.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) the messages belong to.
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+                - name: run_id
+                  in: query
+                  description: |
+                      Filter messages by the run ID that generated them.
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListMessagesResponse"
+            x-oaiMeta:
+                name: List messages
+                group: threads
+                beta: true
+                returns: A list of [message](/docs/api-reference/messages) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/messages \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            thread_messages = client.beta.threads.messages.list("thread_abc123")
+                            print(thread_messages.data)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const threadMessages = await openai.beta.threads.messages.list(
+                                "thread_abc123"
+                              );
+
+                              console.log(threadMessages.data);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "msg_abc123",
+                              "object": "thread.message",
+                              "created_at": 1699016383,
+                              "assistant_id": null,
+                              "thread_id": "thread_abc123",
+                              "run_id": null,
+                              "role": "user",
+                              "content": [
+                                {
+                                  "type": "text",
+                                  "text": {
+                                    "value": "How does AI work? Explain it in simple terms.",
+                                    "annotations": []
+                                  }
+                                }
+                              ],
+                              "attachments": [],
+                              "metadata": {}
+                            },
+                            {
+                              "id": "msg_abc456",
+                              "object": "thread.message",
+                              "created_at": 1699016383,
+                              "assistant_id": null,
+                              "thread_id": "thread_abc123",
+                              "run_id": null,
+                              "role": "user",
+                              "content": [
+                                {
+                                  "type": "text",
+                                  "text": {
+                                    "value": "Hello, what is AI?",
+                                    "annotations": []
+                                  }
+                                }
+                              ],
+                              "attachments": [],
+                              "metadata": {}
+                            }
+                          ],
+                          "first_id": "msg_abc123",
+                          "last_id": "msg_abc456",
+                          "has_more": false
+                        }
+        post:
+            operationId: createMessage
+            tags:
+                - Assistants
+            summary: Create a message.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) to create a message for.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateMessageRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/MessageObject"
+            x-oaiMeta:
+                name: Create message
+                group: threads
+                beta: true
+                returns: A [message](/docs/api-reference/messages/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/messages \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                  "role": "user",
+                                  "content": "How does AI work? Explain it in simple terms."
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            thread_message = client.beta.threads.messages.create(
+                              "thread_abc123",
+                              role="user",
+                              content="How does AI work? Explain it in simple terms.",
+                            )
+                            print(thread_message)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const threadMessages = await openai.beta.threads.messages.create(
+                                "thread_abc123",
+                                { role: "user", content: "How does AI work? Explain it in simple terms." }
+                              );
+
+                              console.log(threadMessages);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "msg_abc123",
+                          "object": "thread.message",
+                          "created_at": 1713226573,
+                          "assistant_id": null,
+                          "thread_id": "thread_abc123",
+                          "run_id": null,
+                          "role": "user",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": {
+                                "value": "How does AI work? Explain it in simple terms.",
+                                "annotations": []
+                              }
+                            }
+                          ],
+                          "attachments": [],
+                          "metadata": {}
+                        }
+
+    /threads/{thread_id}/messages/{message_id}:
+        get:
+            operationId: getMessage
+            tags:
+                - Assistants
+            summary: Retrieve a message.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) to which this message belongs.
+                - in: path
+                  name: message_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the message to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/MessageObject"
+            x-oaiMeta:
+                name: Retrieve message
+                group: threads
+                beta: true
+                returns: The [message](/docs/api-reference/messages/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            message = client.beta.threads.messages.retrieve(
+                              message_id="msg_abc123",
+                              thread_id="thread_abc123",
+                            )
+                            print(message)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const message = await openai.beta.threads.messages.retrieve(
+                                "thread_abc123",
+                                "msg_abc123"
+                              );
+
+                              console.log(message);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "msg_abc123",
+                          "object": "thread.message",
+                          "created_at": 1699017614,
+                          "assistant_id": null,
+                          "thread_id": "thread_abc123",
+                          "run_id": null,
+                          "role": "user",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": {
+                                "value": "How does AI work? Explain it in simple terms.",
+                                "annotations": []
+                              }
+                            }
+                          ],
+                          "attachments": [],
+                          "metadata": {}
+                        }
+        post:
+            operationId: modifyMessage
+            tags:
+                - Assistants
+            summary: Modifies a message.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to which this message belongs.
+                - in: path
+                  name: message_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the message to modify.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ModifyMessageRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/MessageObject"
+            x-oaiMeta:
+                name: Modify message
+                group: threads
+                beta: true
+                returns: The modified [message](/docs/api-reference/messages/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                  "metadata": {
+                                    "modified": "true",
+                                    "user": "abc123"
+                                  }
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            message = client.beta.threads.messages.update(
+                              message_id="msg_abc12",
+                              thread_id="thread_abc123",
+                              metadata={
+                                "modified": "true",
+                                "user": "abc123",
+                              },
+                            )
+                            print(message)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const message = await openai.beta.threads.messages.update(
+                                "thread_abc123",
+                                "msg_abc123",
+                                {
+                                  metadata: {
+                                    modified: "true",
+                                    user: "abc123",
+                                  },
+                                }
+                              }'
+                    response: |
+                        {
+                          "id": "msg_abc123",
+                          "object": "thread.message",
+                          "created_at": 1699017614,
+                          "assistant_id": null,
+                          "thread_id": "thread_abc123",
+                          "run_id": null,
+                          "role": "user",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": {
+                                "value": "How does AI work? Explain it in simple terms.",
+                                "annotations": []
+                              }
+                            }
+                          ],
+                          "file_ids": [],
+                          "metadata": {
+                            "modified": "true",
+                            "user": "abc123"
+                          }
+                        }
+        delete:
+            operationId: deleteMessage
+            tags:
+                - Assistants
+            summary: Deletes a message.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to which this message belongs.
+                - in: path
+                  name: message_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the message to delete.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteMessageResponse"
+            x-oaiMeta:
+                name: Delete message
+                group: threads
+                beta: true
+                returns: Deletion status
+                examples:
+                    request:
+                        curl: |
+                            curl -X DELETE https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            deleted_message = client.beta.threads.messages.delete(
+                              message_id="msg_abc12",
+                              thread_id="thread_abc123",
+                            )
+                            print(deleted_message)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const deletedMessage = await openai.beta.threads.messages.del(
+                                "thread_abc123",
+                                "msg_abc123"
+                              );
+
+                              console.log(deletedMessage);
+                            }
+                    response: |
+                        {
+                          "id": "msg_abc123",
+                          "object": "thread.message.deleted",
+                          "deleted": true
+                        }
+
+    /threads/runs:
+        post:
+            operationId: createThreadAndRun
+            tags:
+                - Assistants
+            summary: Create a thread and run it in one request.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateThreadAndRunRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Create thread and run
+                group: threads
+                beta: true
+                returns: A [run](/docs/api-reference/runs/object) object.
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                    "assistant_id": "asst_abc123",
+                                    "thread": {
+                                      "messages": [
+                                        {"role": "user", "content": "Explain deep learning to a 5 year old."}
+                                      ]
+                                    }
+                                  }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              run = client.beta.threads.create_and_run(
+                                assistant_id="asst_abc123",
+                                thread={
+                                  "messages": [
+                                    {"role": "user", "content": "Explain deep learning to a 5 year old."}
+                                  ]
+                                }
+                              )
+
+                              print(run)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const run = await openai.beta.threads.createAndRun({
+                                  assistant_id: "asst_abc123",
+                                  thread: {
+                                    messages: [
+                                      { role: "user", content: "Explain deep learning to a 5 year old." },
+                                    ],
+                                  },
+                                });
+
+                                console.log(run);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "run_abc123",
+                            "object": "thread.run",
+                            "created_at": 1699076792,
+                            "assistant_id": "asst_abc123",
+                            "thread_id": "thread_abc123",
+                            "status": "queued",
+                            "started_at": null,
+                            "expires_at": 1699077392,
+                            "cancelled_at": null,
+                            "failed_at": null,
+                            "completed_at": null,
+                            "required_action": null,
+                            "last_error": null,
+                            "model": "gpt-4-turbo",
+                            "instructions": "You are a helpful assistant.",
+                            "tools": [],
+                            "tool_resources": {},
+                            "metadata": {},
+                            "temperature": 1.0,
+                            "top_p": 1.0,
+                            "max_completion_tokens": null,
+                            "max_prompt_tokens": null,
+                            "truncation_strategy": {
+                              "type": "auto",
+                              "last_messages": null
+                            },
+                            "incomplete_details": null,
+                            "usage": null,
+                            "response_format": "auto",
+                            "tool_choice": "auto",
+                            "parallel_tool_calls": true
+                          }
+
+                    - title: Streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "assistant_id": "asst_123",
+                                  "thread": {
+                                    "messages": [
+                                      {"role": "user", "content": "Hello"}
+                                    ]
+                                  },
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              stream = client.beta.threads.create_and_run(
+                                assistant_id="asst_123",
+                                thread={
+                                  "messages": [
+                                    {"role": "user", "content": "Hello"}
+                                  ]
+                                },
+                                stream=True
+                              )
+
+                              for event in stream:
+                                print(event)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const stream = await openai.beta.threads.createAndRun({
+                                    assistant_id: "asst_123",
+                                    thread: {
+                                      messages: [
+                                        { role: "user", content: "Hello" },
+                                      ],
+                                    },
+                                    stream: true
+                                });
+
+                                for await (const event of stream) {
+                                  console.log(event);
+                                }
+                              }
+
+                              main();
+                      response: |
+                          event: thread.created
+                          data: {"id":"thread_123","object":"thread","created_at":1710348075,"metadata":{}}
+
+                          event: thread.run.created
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+                          event: thread.run.queued
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+                          event: thread.run.in_progress
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+                          event: thread.run.step.created
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.run.step.in_progress
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.message.created
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[], "metadata":{}}
+
+                          event: thread.message.in_progress
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[], "metadata":{}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+                          ...
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" today"}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+                          event: thread.message.completed
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710348077,"role":"assistant","content":[{"type":"text","text":{"value":"Hello! How can I assist you today?","annotations":[]}}], "metadata":{}}
+
+                          event: thread.run.step.completed
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710348077,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+                          event: thread.run.completed
+                          {"id":"run_123","object":"thread.run","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1713226836,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1713226837,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":345,"completion_tokens":11,"total_tokens":356},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+                          event: done
+                          data: [DONE]
+
+                    - title: Streaming with Functions
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "assistant_id": "asst_abc123",
+                                  "thread": {
+                                    "messages": [
+                                      {"role": "user", "content": "What is the weather like in San Francisco?"}
+                                    ]
+                                  },
+                                  "tools": [
+                                    {
+                                      "type": "function",
+                                      "function": {
+                                        "name": "get_current_weather",
+                                        "description": "Get the current weather in a given location",
+                                        "parameters": {
+                                          "type": "object",
+                                          "properties": {
+                                            "location": {
+                                              "type": "string",
+                                              "description": "The city and state, e.g. San Francisco, CA"
+                                            },
+                                            "unit": {
+                                              "type": "string",
+                                              "enum": ["celsius", "fahrenheit"]
+                                            }
+                                          },
+                                          "required": ["location"]
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              tools = [
+                                {
+                                  "type": "function",
+                                  "function": {
+                                    "name": "get_current_weather",
+                                    "description": "Get the current weather in a given location",
+                                    "parameters": {
+                                      "type": "object",
+                                      "properties": {
+                                        "location": {
+                                          "type": "string",
+                                          "description": "The city and state, e.g. San Francisco, CA",
+                                        },
+                                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                      },
+                                      "required": ["location"],
+                                    },
+                                  }
+                                }
+                              ]
+
+                              stream = client.beta.threads.create_and_run(
+                                thread={
+                                    "messages": [
+                                      {"role": "user", "content": "What is the weather like in San Francisco?"}
+                                    ]
+                                },
+                                assistant_id="asst_abc123",
+                                tools=tools,
+                                stream=True
+                              )
+
+                              for event in stream:
+                                print(event)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              const tools = [
+                                  {
+                                    "type": "function",
+                                    "function": {
+                                      "name": "get_current_weather",
+                                      "description": "Get the current weather in a given location",
+                                      "parameters": {
+                                        "type": "object",
+                                        "properties": {
+                                          "location": {
+                                            "type": "string",
+                                            "description": "The city and state, e.g. San Francisco, CA",
+                                          },
+                                          "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                        },
+                                        "required": ["location"],
+                                      },
+                                    }
+                                  }
+                              ];
+
+                              async function main() {
+                                const stream = await openai.beta.threads.createAndRun({
+                                  assistant_id: "asst_123",
+                                  thread: {
+                                    messages: [
+                                      { role: "user", content: "What is the weather like in San Francisco?" },
+                                    ],
+                                  },
+                                  tools: tools,
+                                  stream: true
+                                });
+
+                                for await (const event of stream) {
+                                  console.log(event);
+                                }
+                              }
+
+                              main();
+                      response: |
+                          event: thread.created
+                          data: {"id":"thread_123","object":"thread","created_at":1710351818,"metadata":{}}
+
+                          event: thread.run.created
+                          data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.queued
+                          data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.in_progress
+                          data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710351818,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.step.created
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710351819,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710352418,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[]},"usage":null}
+
+                          event: thread.run.step.in_progress
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710351819,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710352418,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[]},"usage":null}
+
+                          event: thread.run.step.delta
+                          data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"id":"call_XXNp8YGaFrjrSjgqxtC8JJ1B","type":"function","function":{"name":"get_current_weather","arguments":"","output":null}}]}}}
+
+                          event: thread.run.step.delta
+                          data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"{\""}}]}}}
+
+                          event: thread.run.step.delta
+                          data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"location"}}]}}}
+
+                          ...
+
+                          event: thread.run.step.delta
+                          data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"ahrenheit"}}]}}}
+
+                          event: thread.run.step.delta
+                          data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"\"}"}}]}}}
+
+                          event: thread.run.requires_action
+                          data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"requires_action","started_at":1710351818,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":{"type":"submit_tool_outputs","submit_tool_outputs":{"tool_calls":[{"id":"call_XXNp8YGaFrjrSjgqxtC8JJ1B","type":"function","function":{"name":"get_current_weather","arguments":"{\"location\":\"San Francisco, CA\",\"unit\":\"fahrenheit\"}"}}]}},"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":345,"completion_tokens":11,"total_tokens":356},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: done
+                          data: [DONE]
+
+    /threads/{thread_id}/runs:
+        get:
+            operationId: listRuns
+            tags:
+                - Assistants
+            summary: Returns a list of runs belonging to a thread.
+            parameters:
+                - name: thread_id
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread the run belongs to.
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListRunsResponse"
+            x-oaiMeta:
+                name: List runs
+                group: threads
+                beta: true
+                returns: A list of [run](/docs/api-reference/runs/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            runs = client.beta.threads.runs.list(
+                              "thread_abc123"
+                            )
+
+                            print(runs)
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const runs = await openai.beta.threads.runs.list(
+                                "thread_abc123"
+                              );
+
+                              console.log(runs);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "run_abc123",
+                              "object": "thread.run",
+                              "created_at": 1699075072,
+                              "assistant_id": "asst_abc123",
+                              "thread_id": "thread_abc123",
+                              "status": "completed",
+                              "started_at": 1699075072,
+                              "expires_at": null,
+                              "cancelled_at": null,
+                              "failed_at": null,
+                              "completed_at": 1699075073,
+                              "last_error": null,
+                              "model": "gpt-4-turbo",
+                              "instructions": null,
+                              "incomplete_details": null,
+                              "tools": [
+                                {
+                                  "type": "code_interpreter"
+                                }
+                              ],
+                              "tool_resources": {
+                                "code_interpreter": {
+                                  "file_ids": [
+                                    "file-abc123",
+                                    "file-abc456"
+                                  ]
+                                }
+                              },
+                              "metadata": {},
+                              "usage": {
+                                "prompt_tokens": 123,
+                                "completion_tokens": 456,
+                                "total_tokens": 579
+                              },
+                              "temperature": 1.0,
+                              "top_p": 1.0,
+                              "max_prompt_tokens": 1000,
+                              "max_completion_tokens": 1000,
+                              "truncation_strategy": {
+                                "type": "auto",
+                                "last_messages": null
+                              },
+                              "response_format": "auto",
+                              "tool_choice": "auto",
+                              "parallel_tool_calls": true
+                            },
+                            {
+                              "id": "run_abc456",
+                              "object": "thread.run",
+                              "created_at": 1699063290,
+                              "assistant_id": "asst_abc123",
+                              "thread_id": "thread_abc123",
+                              "status": "completed",
+                              "started_at": 1699063290,
+                              "expires_at": null,
+                              "cancelled_at": null,
+                              "failed_at": null,
+                              "completed_at": 1699063291,
+                              "last_error": null,
+                              "model": "gpt-4-turbo",
+                              "instructions": null,
+                              "incomplete_details": null,
+                              "tools": [
+                                {
+                                  "type": "code_interpreter"
+                                }
+                              ],
+                              "tool_resources": {
+                                "code_interpreter": {
+                                  "file_ids": [
+                                    "file-abc123",
+                                    "file-abc456"
+                                  ]
+                                }
+                              },
+                              "metadata": {},
+                              "usage": {
+                                "prompt_tokens": 123,
+                                "completion_tokens": 456,
+                                "total_tokens": 579
+                              },
+                              "temperature": 1.0,
+                              "top_p": 1.0,
+                              "max_prompt_tokens": 1000,
+                              "max_completion_tokens": 1000,
+                              "truncation_strategy": {
+                                "type": "auto",
+                                "last_messages": null
+                              },
+                              "response_format": "auto",
+                              "tool_choice": "auto",
+                              "parallel_tool_calls": true
+                            }
+                          ],
+                          "first_id": "run_abc123",
+                          "last_id": "run_abc456",
+                          "has_more": false
+                        }
+        post:
+            operationId: createRun
+            tags:
+                - Assistants
+            summary: Create a run.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to run.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateRunRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Create run
+                group: threads
+                beta: true
+                returns: A [run](/docs/api-reference/runs/object) object.
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "assistant_id": "asst_abc123"
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              run = client.beta.threads.runs.create(
+                                thread_id="thread_abc123",
+                                assistant_id="asst_abc123"
+                              )
+
+                              print(run)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const run = await openai.beta.threads.runs.create(
+                                  "thread_abc123",
+                                  { assistant_id: "asst_abc123" }
+                                );
+
+                                console.log(run);
+                              }
+
+                              main();
+                      response: &run_object_example |
+                          {
+                            "id": "run_abc123",
+                            "object": "thread.run",
+                            "created_at": 1699063290,
+                            "assistant_id": "asst_abc123",
+                            "thread_id": "thread_abc123",
+                            "status": "queued",
+                            "started_at": 1699063290,
+                            "expires_at": null,
+                            "cancelled_at": null,
+                            "failed_at": null,
+                            "completed_at": 1699063291,
+                            "last_error": null,
+                            "model": "gpt-4-turbo",
+                            "instructions": null,
+                            "incomplete_details": null,
+                            "tools": [
+                              {
+                                "type": "code_interpreter"
+                              }
+                            ],
+                            "metadata": {},
+                            "usage": null,
+                            "temperature": 1.0,
+                            "top_p": 1.0,
+                            "max_prompt_tokens": 1000,
+                            "max_completion_tokens": 1000,
+                            "truncation_strategy": {
+                              "type": "auto",
+                              "last_messages": null
+                            },
+                            "response_format": "auto",
+                            "tool_choice": "auto",
+                            "parallel_tool_calls": true
+                          }
+                    - title: Streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/thread_123/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "assistant_id": "asst_123",
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              stream = client.beta.threads.runs.create(
+                                thread_id="thread_123",
+                                assistant_id="asst_123",
+                                stream=True
+                              )
+
+                              for event in stream:
+                                print(event)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const stream = await openai.beta.threads.runs.create(
+                                  "thread_123",
+                                  { assistant_id: "asst_123", stream: true }
+                                );
+
+                                for await (const event of stream) {
+                                  console.log(event);
+                                }
+                              }
+
+                              main();
+                      response: |
+                          event: thread.run.created
+                          data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.queued
+                          data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.in_progress
+                          data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710330641,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.step.created
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.run.step.in_progress
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.message.created
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.in_progress
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+                          ...
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" today"}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+                          event: thread.message.completed
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710330642,"role":"assistant","content":[{"type":"text","text":{"value":"Hello! How can I assist you today?","annotations":[]}}],"metadata":{}}
+
+                          event: thread.run.step.completed
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710330642,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+                          event: thread.run.completed
+                          data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710330641,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710330642,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: done
+                          data: [DONE]
+
+                    - title: Streaming with Functions
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "assistant_id": "asst_abc123",
+                                  "tools": [
+                                    {
+                                      "type": "function",
+                                      "function": {
+                                        "name": "get_current_weather",
+                                        "description": "Get the current weather in a given location",
+                                        "parameters": {
+                                          "type": "object",
+                                          "properties": {
+                                            "location": {
+                                              "type": "string",
+                                              "description": "The city and state, e.g. San Francisco, CA"
+                                            },
+                                            "unit": {
+                                              "type": "string",
+                                              "enum": ["celsius", "fahrenheit"]
+                                            }
+                                          },
+                                          "required": ["location"]
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              tools = [
+                                {
+                                  "type": "function",
+                                  "function": {
+                                    "name": "get_current_weather",
+                                    "description": "Get the current weather in a given location",
+                                    "parameters": {
+                                      "type": "object",
+                                      "properties": {
+                                        "location": {
+                                          "type": "string",
+                                          "description": "The city and state, e.g. San Francisco, CA",
+                                        },
+                                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                      },
+                                      "required": ["location"],
+                                    },
+                                  }
+                                }
+                              ]
+
+                              stream = client.beta.threads.runs.create(
+                                thread_id="thread_abc123",
+                                assistant_id="asst_abc123",
+                                tools=tools,
+                                stream=True
+                              )
+
+                              for event in stream:
+                                print(event)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              const tools = [
+                                  {
+                                    "type": "function",
+                                    "function": {
+                                      "name": "get_current_weather",
+                                      "description": "Get the current weather in a given location",
+                                      "parameters": {
+                                        "type": "object",
+                                        "properties": {
+                                          "location": {
+                                            "type": "string",
+                                            "description": "The city and state, e.g. San Francisco, CA",
+                                          },
+                                          "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                        },
+                                        "required": ["location"],
+                                      },
+                                    }
+                                  }
+                              ];
+
+                              async function main() {
+                                const stream = await openai.beta.threads.runs.create(
+                                  "thread_abc123",
+                                  {
+                                    assistant_id: "asst_abc123",
+                                    tools: tools,
+                                    stream: true
+                                  }
+                                );
+
+                                for await (const event of stream) {
+                                  console.log(event);
+                                }
+                              }
+
+                              main();
+                      response: |
+                          event: thread.run.created
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.queued
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.in_progress
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710348075,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.step.created
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.run.step.in_progress
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.message.created
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.in_progress
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+                          ...
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" today"}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+                          event: thread.message.completed
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710348077,"role":"assistant","content":[{"type":"text","text":{"value":"Hello! How can I assist you today?","annotations":[]}}],"metadata":{}}
+
+                          event: thread.run.step.completed
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710348077,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+                          event: thread.run.completed
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710348075,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710348077,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: done
+                          data: [DONE]
+
+    /threads/{thread_id}/runs/{run_id}:
+        get:
+            operationId: getRun
+            tags:
+                - Assistants
+            summary: Retrieves a run.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) that was run.
+                - in: path
+                  name: run_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Retrieve run
+                group: threads
+                beta: true
+                returns: The [run](/docs/api-reference/runs/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            run = client.beta.threads.runs.retrieve(
+                              thread_id="thread_abc123",
+                              run_id="run_abc123"
+                            )
+
+                            print(run)
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const run = await openai.beta.threads.runs.retrieve(
+                                "thread_abc123",
+                                "run_abc123"
+                              );
+
+                              console.log(run);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "run_abc123",
+                          "object": "thread.run",
+                          "created_at": 1699075072,
+                          "assistant_id": "asst_abc123",
+                          "thread_id": "thread_abc123",
+                          "status": "completed",
+                          "started_at": 1699075072,
+                          "expires_at": null,
+                          "cancelled_at": null,
+                          "failed_at": null,
+                          "completed_at": 1699075073,
+                          "last_error": null,
+                          "model": "gpt-4-turbo",
+                          "instructions": null,
+                          "incomplete_details": null,
+                          "tools": [
+                            {
+                              "type": "code_interpreter"
+                            }
+                          ],
+                          "metadata": {},
+                          "usage": {
+                            "prompt_tokens": 123,
+                            "completion_tokens": 456,
+                            "total_tokens": 579
+                          },
+                          "temperature": 1.0,
+                          "top_p": 1.0,
+                          "max_prompt_tokens": 1000,
+                          "max_completion_tokens": 1000,
+                          "truncation_strategy": {
+                            "type": "auto",
+                            "last_messages": null
+                          },
+                          "response_format": "auto",
+                          "tool_choice": "auto",
+                          "parallel_tool_calls": true
+                        }
+        post:
+            operationId: modifyRun
+            tags:
+                - Assistants
+            summary: Modifies a run.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) that was run.
+                - in: path
+                  name: run_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run to modify.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ModifyRunRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Modify run
+                group: threads
+                beta: true
+                returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                "metadata": {
+                                  "user_id": "user_abc123"
+                                }
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            run = client.beta.threads.runs.update(
+                              thread_id="thread_abc123",
+                              run_id="run_abc123",
+                              metadata={"user_id": "user_abc123"},
+                            )
+
+                            print(run)
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const run = await openai.beta.threads.runs.update(
+                                "thread_abc123",
+                                "run_abc123",
+                                {
+                                  metadata: {
+                                    user_id: "user_abc123",
+                                  },
+                                }
+                              );
+
+                              console.log(run);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "run_abc123",
+                          "object": "thread.run",
+                          "created_at": 1699075072,
+                          "assistant_id": "asst_abc123",
+                          "thread_id": "thread_abc123",
+                          "status": "completed",
+                          "started_at": 1699075072,
+                          "expires_at": null,
+                          "cancelled_at": null,
+                          "failed_at": null,
+                          "completed_at": 1699075073,
+                          "last_error": null,
+                          "model": "gpt-4-turbo",
+                          "instructions": null,
+                          "incomplete_details": null,
+                          "tools": [
+                            {
+                              "type": "code_interpreter"
+                            }
+                          ],
+                          "tool_resources": {
+                            "code_interpreter": {
+                              "file_ids": [
+                                "file-abc123",
+                                "file-abc456"
+                              ]
+                            }
+                          },
+                          "metadata": {
+                            "user_id": "user_abc123"
+                          },
+                          "usage": {
+                            "prompt_tokens": 123,
+                            "completion_tokens": 456,
+                            "total_tokens": 579
+                          },
+                          "temperature": 1.0,
+                          "top_p": 1.0,
+                          "max_prompt_tokens": 1000,
+                          "max_completion_tokens": 1000,
+                          "truncation_strategy": {
+                            "type": "auto",
+                            "last_messages": null
+                          },
+                          "response_format": "auto",
+                          "tool_choice": "auto",
+                          "parallel_tool_calls": true
+                        }
+
+    /threads/{thread_id}/runs/{run_id}/submit_tool_outputs:
+        post:
+            operationId: submitToolOuputsToRun
+            tags:
+                - Assistants
+            summary: |
+                When a run has the `status: "requires_action"` and `required_action.type` is `submit_tool_outputs`, this endpoint can be used to submit the outputs from the tool calls once they're all completed. All outputs must be submitted in a single request.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) to which this run belongs.
+                - in: path
+                  name: run_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run that requires the tool output submission.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/SubmitToolOutputsRunRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Submit tool outputs to run
+                group: threads
+                beta: true
+                returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/thread_123/runs/run_123/submit_tool_outputs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "tool_outputs": [
+                                    {
+                                      "tool_call_id": "call_001",
+                                      "output": "70 degrees and sunny."
+                                    }
+                                  ]
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              run = client.beta.threads.runs.submit_tool_outputs(
+                                thread_id="thread_123",
+                                run_id="run_123",
+                                tool_outputs=[
+                                  {
+                                    "tool_call_id": "call_001",
+                                    "output": "70 degrees and sunny."
+                                  }
+                                ]
+                              )
+
+                              print(run)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const run = await openai.beta.threads.runs.submitToolOutputs(
+                                  "thread_123",
+                                  "run_123",
+                                  {
+                                    tool_outputs: [
+                                      {
+                                        tool_call_id: "call_001",
+                                        output: "70 degrees and sunny.",
+                                      },
+                                    ],
+                                  }
+                                );
+
+                                console.log(run);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "run_123",
+                            "object": "thread.run",
+                            "created_at": 1699075592,
+                            "assistant_id": "asst_123",
+                            "thread_id": "thread_123",
+                            "status": "queued",
+                            "started_at": 1699075592,
+                            "expires_at": 1699076192,
+                            "cancelled_at": null,
+                            "failed_at": null,
+                            "completed_at": null,
+                            "last_error": null,
+                            "model": "gpt-4-turbo",
+                            "instructions": null,
+                            "tools": [
+                              {
+                                "type": "function",
+                                "function": {
+                                  "name": "get_current_weather",
+                                  "description": "Get the current weather in a given location",
+                                  "parameters": {
+                                    "type": "object",
+                                    "properties": {
+                                      "location": {
+                                        "type": "string",
+                                        "description": "The city and state, e.g. San Francisco, CA"
+                                      },
+                                      "unit": {
+                                        "type": "string",
+                                        "enum": ["celsius", "fahrenheit"]
+                                      }
+                                    },
+                                    "required": ["location"]
+                                  }
+                                }
+                              }
+                            ],
+                            "metadata": {},
+                            "usage": null,
+                            "temperature": 1.0,
+                            "top_p": 1.0,
+                            "max_prompt_tokens": 1000,
+                            "max_completion_tokens": 1000,
+                            "truncation_strategy": {
+                              "type": "auto",
+                              "last_messages": null
+                            },
+                            "response_format": "auto",
+                            "tool_choice": "auto",
+                            "parallel_tool_calls": true
+                          }
+
+                    - title: Streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/thread_123/runs/run_123/submit_tool_outputs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "tool_outputs": [
+                                    {
+                                      "tool_call_id": "call_001",
+                                      "output": "70 degrees and sunny."
+                                    }
+                                  ],
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              stream = client.beta.threads.runs.submit_tool_outputs(
+                                thread_id="thread_123",
+                                run_id="run_123",
+                                tool_outputs=[
+                                  {
+                                    "tool_call_id": "call_001",
+                                    "output": "70 degrees and sunny."
+                                  }
+                                ],
+                                stream=True
+                              )
+
+                              for event in stream:
+                                print(event)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const stream = await openai.beta.threads.runs.submitToolOutputs(
+                                  "thread_123",
+                                  "run_123",
+                                  {
+                                    tool_outputs: [
+                                      {
+                                        tool_call_id: "call_001",
+                                        output: "70 degrees and sunny.",
+                                      },
+                                    ],
+                                  }
+                                );
+
+                                for await (const event of stream) {
+                                  console.log(event);
+                                }
+                              }
+
+                              main();
+                      response: |
+                          event: thread.run.step.completed
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710352449,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"completed","cancelled_at":null,"completed_at":1710352475,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[{"id":"call_iWr0kQ2EaYMaxNdl0v3KYkx7","type":"function","function":{"name":"get_current_weather","arguments":"{\"location\":\"San Francisco, CA\",\"unit\":\"fahrenheit\"}","output":"70 degrees and sunny."}}]},"usage":{"prompt_tokens":291,"completion_tokens":24,"total_tokens":315}}
+
+                          event: thread.run.queued
+                          data: {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":1710352448,"expires_at":1710353047,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.in_progress
+                          data: {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710352475,"expires_at":1710353047,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.step.created
+                          data: {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":null}
+
+                          event: thread.run.step.in_progress
+                          data: {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":null}
+
+                          event: thread.message.created
+                          data: {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.in_progress
+                          data: {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"The","annotations":[]}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" current"}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" weather"}}]}}
+
+                          ...
+
+                          event: thread.message.delta
+                          data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" sunny"}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"."}}]}}
+
+                          event: thread.message.completed
+                          data: {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710352477,"role":"assistant","content":[{"type":"text","text":{"value":"The current weather in San Francisco, CA is 70 degrees Fahrenheit and sunny.","annotations":[]}}],"metadata":{}}
+
+                          event: thread.run.step.completed
+                          data: {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710352477,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":{"prompt_tokens":329,"completion_tokens":18,"total_tokens":347}}
+
+                          event: thread.run.completed
+                          data: {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710352475,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710352477,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: done
+                          data: [DONE]
+
+    /threads/{thread_id}/runs/{run_id}/cancel:
+        post:
+            operationId: cancelRun
+            tags:
+                - Assistants
+            summary: Cancels a run that is `in_progress`.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to which this run belongs.
+                - in: path
+                  name: run_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run to cancel.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Cancel a run
+                group: threads
+                beta: true
+                returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/cancel \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X POST
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            run = client.beta.threads.runs.cancel(
+                              thread_id="thread_abc123",
+                              run_id="run_abc123"
+                            )
+
+                            print(run)
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const run = await openai.beta.threads.runs.cancel(
+                                "thread_abc123",
+                                "run_abc123"
+                              );
+
+                              console.log(run);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "run_abc123",
+                          "object": "thread.run",
+                          "created_at": 1699076126,
+                          "assistant_id": "asst_abc123",
+                          "thread_id": "thread_abc123",
+                          "status": "cancelling",
+                          "started_at": 1699076126,
+                          "expires_at": 1699076726,
+                          "cancelled_at": null,
+                          "failed_at": null,
+                          "completed_at": null,
+                          "last_error": null,
+                          "model": "gpt-4-turbo",
+                          "instructions": "You summarize books.",
+                          "tools": [
+                            {
+                              "type": "file_search"
+                            }
+                          ],
+                          "tool_resources": {
+                            "file_search": {
+                              "vector_store_ids": ["vs_123"]
+                            }
+                          },
+                          "metadata": {},
+                          "usage": null,
+                          "temperature": 1.0,
+                          "top_p": 1.0,
+                          "response_format": "auto",
+                          "tool_choice": "auto",
+                          "parallel_tool_calls": true
+                        }
+
+    /threads/{thread_id}/runs/{run_id}/steps:
+        get:
+            operationId: listRunSteps
+            tags:
+                - Assistants
+            summary: Returns a list of run steps belonging to a run.
+            parameters:
+                - name: thread_id
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread the run and run steps belong to.
+                - name: run_id
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run the run steps belong to.
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListRunStepsResponse"
+            x-oaiMeta:
+                name: List run steps
+                group: threads
+                beta: true
+                returns: A list of [run step](/docs/api-reference/runs/step-object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/steps \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            run_steps = client.beta.threads.runs.steps.list(
+                                thread_id="thread_abc123",
+                                run_id="run_abc123"
+                            )
+
+                            print(run_steps)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const runStep = await openai.beta.threads.runs.steps.list(
+                                "thread_abc123",
+                                "run_abc123"
+                              );
+                              console.log(runStep);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "step_abc123",
+                              "object": "thread.run.step",
+                              "created_at": 1699063291,
+                              "run_id": "run_abc123",
+                              "assistant_id": "asst_abc123",
+                              "thread_id": "thread_abc123",
+                              "type": "message_creation",
+                              "status": "completed",
+                              "cancelled_at": null,
+                              "completed_at": 1699063291,
+                              "expired_at": null,
+                              "failed_at": null,
+                              "last_error": null,
+                              "step_details": {
+                                "type": "message_creation",
+                                "message_creation": {
+                                  "message_id": "msg_abc123"
+                                }
+                              },
+                              "usage": {
+                                "prompt_tokens": 123,
+                                "completion_tokens": 456,
+                                "total_tokens": 579
+                              }
+                            }
+                          ],
+                          "first_id": "step_abc123",
+                          "last_id": "step_abc456",
+                          "has_more": false
+                        }
+
+    /threads/{thread_id}/runs/{run_id}/steps/{step_id}:
+        get:
+            operationId: getRunStep
+            tags:
+                - Assistants
+            summary: Retrieves a run step.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to which the run and run step belongs.
+                - in: path
+                  name: run_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run to which the run step belongs.
+                - in: path
+                  name: step_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run step to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunStepObject"
+            x-oaiMeta:
+                name: Retrieve run step
+                group: threads
+                beta: true
+                returns: The [run step](/docs/api-reference/runs/step-object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            run_step = client.beta.threads.runs.steps.retrieve(
+                                thread_id="thread_abc123",
+                                run_id="run_abc123",
+                                step_id="step_abc123"
+                            )
+
+                            print(run_step)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const runStep = await openai.beta.threads.runs.steps.retrieve(
+                                "thread_abc123",
+                                "run_abc123",
+                                "step_abc123"
+                              );
+                              console.log(runStep);
+                            }
+
+                            main();
+                    response: &run_step_object_example |
+                        {
+                          "id": "step_abc123",
+                          "object": "thread.run.step",
+                          "created_at": 1699063291,
+                          "run_id": "run_abc123",
+                          "assistant_id": "asst_abc123",
+                          "thread_id": "thread_abc123",
+                          "type": "message_creation",
+                          "status": "completed",
+                          "cancelled_at": null,
+                          "completed_at": 1699063291,
+                          "expired_at": null,
+                          "failed_at": null,
+                          "last_error": null,
+                          "step_details": {
+                            "type": "message_creation",
+                            "message_creation": {
+                              "message_id": "msg_abc123"
+                            }
+                          },
+                          "usage": {
+                            "prompt_tokens": 123,
+                            "completion_tokens": 456,
+                            "total_tokens": 579
+                          }
+                        }
+
+    /vector_stores:
+        get:
+            operationId: listVectorStores
+            tags:
+                - Vector Stores
+            summary: Returns a list of vector stores.
+            parameters:
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListVectorStoresResponse"
+            x-oaiMeta:
+                name: List vector stores
+                group: vector_stores
+                beta: true
+                returns: A list of [vector store](/docs/api-reference/vector-stores/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_stores = client.beta.vector_stores.list()
+                            print(vector_stores)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStores = await openai.beta.vectorStores.list();
+                              console.log(vectorStores);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "vs_abc123",
+                              "object": "vector_store",
+                              "created_at": 1699061776,
+                              "name": "Support FAQ",
+                              "bytes": 139920,
+                              "file_counts": {
+                                "in_progress": 0,
+                                "completed": 3,
+                                "failed": 0,
+                                "cancelled": 0,
+                                "total": 3
+                              }
+                            },
+                            {
+                              "id": "vs_abc456",
+                              "object": "vector_store",
+                              "created_at": 1699061776,
+                              "name": "Support FAQ v2",
+                              "bytes": 139920,
+                              "file_counts": {
+                                "in_progress": 0,
+                                "completed": 3,
+                                "failed": 0,
+                                "cancelled": 0,
+                                "total": 3
+                              }
+                            }
+                          ],
+                          "first_id": "vs_abc123",
+                          "last_id": "vs_abc456",
+                          "has_more": false
+                        }
+        post:
+            operationId: createVectorStore
+            tags:
+                - Vector Stores
+            summary: Create a vector store.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateVectorStoreRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreObject"
+            x-oaiMeta:
+                name: Create vector store
+                group: vector_stores
+                beta: true
+                returns: A [vector store](/docs/api-reference/vector-stores/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                              -d '{
+                                "name": "Support FAQ"
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store = client.beta.vector_stores.create(
+                              name="Support FAQ"
+                            )
+                            print(vector_store)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStore = await openai.beta.vectorStores.create({
+                                name: "Support FAQ"
+                              });
+                              console.log(vectorStore);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vs_abc123",
+                          "object": "vector_store",
+                          "created_at": 1699061776,
+                          "name": "Support FAQ",
+                          "bytes": 139920,
+                          "file_counts": {
+                            "in_progress": 0,
+                            "completed": 3,
+                            "failed": 0,
+                            "cancelled": 0,
+                            "total": 3
+                          }
+                        }
+
+    /vector_stores/{vector_store_id}:
+        get:
+            operationId: getVectorStore
+            tags:
+                - Vector Stores
+            summary: Retrieves a vector store.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the vector store to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreObject"
+            x-oaiMeta:
+                name: Retrieve vector store
+                group: vector_stores
+                beta: true
+                returns: The [vector store](/docs/api-reference/vector-stores/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store = client.beta.vector_stores.retrieve(
+                              vector_store_id="vs_abc123"
+                            )
+                            print(vector_store)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStore = await openai.beta.vectorStores.retrieve(
+                                "vs_abc123"
+                              );
+                              console.log(vectorStore);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vs_abc123",
+                          "object": "vector_store",
+                          "created_at": 1699061776
+                        }
+        post:
+            operationId: modifyVectorStore
+            tags:
+                - Vector Stores
+            summary: Modifies a vector store.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the vector store to modify.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/UpdateVectorStoreRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreObject"
+            x-oaiMeta:
+                name: Modify vector store
+                group: vector_stores
+                beta: true
+                returns: The modified [vector store](/docs/api-reference/vector-stores/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                              -d '{
+                                "name": "Support FAQ"
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store = client.beta.vector_stores.update(
+                              vector_store_id="vs_abc123",
+                              name="Support FAQ"
+                            )
+                            print(vector_store)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStore = await openai.beta.vectorStores.update(
+                                "vs_abc123",
+                                {
+                                  name: "Support FAQ"
+                                }
+                              );
+                              console.log(vectorStore);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vs_abc123",
+                          "object": "vector_store",
+                          "created_at": 1699061776,
+                          "name": "Support FAQ",
+                          "bytes": 139920,
+                          "file_counts": {
+                            "in_progress": 0,
+                            "completed": 3,
+                            "failed": 0,
+                            "cancelled": 0,
+                            "total": 3
+                          }
+                        }
+
+        delete:
+            operationId: deleteVectorStore
+            tags:
+                - Vector Stores
+            summary: Delete a vector store.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the vector store to delete.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteVectorStoreResponse"
+            x-oaiMeta:
+                name: Delete vector store
+                group: vector_stores
+                beta: true
+                returns: Deletion status
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X DELETE
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            deleted_vector_store = client.beta.vector_stores.delete(
+                              vector_store_id="vs_abc123"
+                            )
+                            print(deleted_vector_store)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const deletedVectorStore = await openai.beta.vectorStores.del(
+                                "vs_abc123"
+                              );
+                              console.log(deletedVectorStore);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          id: "vs_abc123",
+                          object: "vector_store.deleted",
+                          deleted: true
+                        }
+
+    /vector_stores/{vector_store_id}/files:
+        get:
+            operationId: listVectorStoreFiles
+            tags:
+                - Vector Stores
+            summary: Returns a list of vector store files.
+            parameters:
+                - name: vector_store_id
+                  in: path
+                  description: The ID of the vector store that the files belong to.
+                  required: true
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+                - name: filter
+                  in: query
+                  description: "Filter by file status. One of `in_progress`, `completed`, `failed`, `cancelled`."
+                  schema:
+                      type: string
+                      enum: ["in_progress", "completed", "failed", "cancelled"]
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+            x-oaiMeta:
+                name: List vector store files
+                group: vector_stores
+                beta: true
+                returns: A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_files = client.beta.vector_stores.files.list(
+                              vector_store_id="vs_abc123"
+                            )
+                            print(vector_store_files)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStoreFiles = await openai.beta.vectorStores.files.list(
+                                "vs_abc123"
+                              );
+                              console.log(vectorStoreFiles);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "file-abc123",
+                              "object": "vector_store.file",
+                              "created_at": 1699061776,
+                              "vector_store_id": "vs_abc123"
+                            },
+                            {
+                              "id": "file-abc456",
+                              "object": "vector_store.file",
+                              "created_at": 1699061776,
+                              "vector_store_id": "vs_abc123"
+                            }
+                          ],
+                          "first_id": "file-abc123",
+                          "last_id": "file-abc456",
+                          "has_more": false
+                        }
+        post:
+            operationId: createVectorStoreFile
+            tags:
+                - Vector Stores
+            summary: Create a vector store file by attaching a [File](/docs/api-reference/files) to a [vector store](/docs/api-reference/vector-stores/object).
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                      example: vs_abc123
+                  description: |
+                      The ID of the vector store for which to create a File.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateVectorStoreFileRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreFileObject"
+            x-oaiMeta:
+                name: Create vector store file
+                group: vector_stores
+                beta: true
+                returns: A [vector store file](/docs/api-reference/vector-stores-files/file-object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "file_id": "file-abc123"
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_file = client.beta.vector_stores.files.create(
+                              vector_store_id="vs_abc123",
+                              file_id="file-abc123"
+                            )
+                            print(vector_store_file)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myVectorStoreFile = await openai.beta.vectorStores.files.create(
+                                "vs_abc123",
+                                {
+                                  file_id: "file-abc123"
+                                }
+                              );
+                              console.log(myVectorStoreFile);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "file-abc123",
+                          "object": "vector_store.file",
+                          "created_at": 1699061776,
+                          "usage_bytes": 1234,
+                          "vector_store_id": "vs_abcd",
+                          "status": "completed",
+                          "last_error": null
+                        }
+
+    /vector_stores/{vector_store_id}/files/{file_id}:
+        get:
+            operationId: getVectorStoreFile
+            tags:
+                - Vector Stores
+            summary: Retrieves a vector store file.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                      example: vs_abc123
+                  description: The ID of the vector store that the file belongs to.
+                - in: path
+                  name: file_id
+                  required: true
+                  schema:
+                      type: string
+                      example: file-abc123
+                  description: The ID of the file being retrieved.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreFileObject"
+            x-oaiMeta:
+                name: Retrieve vector store file
+                group: vector_stores
+                beta: true
+                returns: The [vector store file](/docs/api-reference/vector-stores-files/file-object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files/file-abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_file = client.beta.vector_stores.files.retrieve(
+                              vector_store_id="vs_abc123",
+                              file_id="file-abc123"
+                            )
+                            print(vector_store_file)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStoreFile = await openai.beta.vectorStores.files.retrieve(
+                                "vs_abc123",
+                                "file-abc123"
+                              );
+                              console.log(vectorStoreFile);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "file-abc123",
+                          "object": "vector_store.file",
+                          "created_at": 1699061776,
+                          "vector_store_id": "vs_abcd",
+                          "status": "completed",
+                          "last_error": null
+                        }
+        delete:
+            operationId: deleteVectorStoreFile
+            tags:
+                - Vector Stores
+            summary: Delete a vector store file. This will remove the file from the vector store but the file itself will not be deleted. To delete the file, use the [delete file](/docs/api-reference/files/delete) endpoint.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the vector store that the file belongs to.
+                - in: path
+                  name: file_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the file to delete.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteVectorStoreFileResponse"
+            x-oaiMeta:
+                name: Delete vector store file
+                group: vector_stores
+                beta: true
+                returns: Deletion status
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files/file-abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X DELETE
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            deleted_vector_store_file = client.beta.vector_stores.files.delete(
+                                vector_store_id="vs_abc123",
+                                file_id="file-abc123"
+                            )
+                            print(deleted_vector_store_file)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const deletedVectorStoreFile = await openai.beta.vectorStores.files.del(
+                                "vs_abc123",
+                                "file-abc123"
+                              );
+                              console.log(deletedVectorStoreFile);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          id: "file-abc123",
+                          object: "vector_store.file.deleted",
+                          deleted: true
+                        }
+
+    /vector_stores/{vector_store_id}/file_batches:
+        post:
+            operationId: createVectorStoreFileBatch
+            tags:
+                - Vector Stores
+            summary: Create a vector store file batch.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                      example: vs_abc123
+                  description: |
+                      The ID of the vector store for which to create a File Batch.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateVectorStoreFileBatchRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            x-oaiMeta:
+                name: Create vector store file batch
+                group: vector_stores
+                beta: true
+                returns: A [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/file_batches \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "file_ids": ["file-abc123", "file-abc456"]
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_file_batch = client.beta.vector_stores.file_batches.create(
+                              vector_store_id="vs_abc123",
+                              file_ids=["file-abc123", "file-abc456"]
+                            )
+                            print(vector_store_file_batch)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myVectorStoreFileBatch = await openai.beta.vectorStores.fileBatches.create(
+                                "vs_abc123",
+                                {
+                                  file_ids: ["file-abc123", "file-abc456"]
+                                }
+                              );
+                              console.log(myVectorStoreFileBatch);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vsfb_abc123",
+                          "object": "vector_store.file_batch",
+                          "created_at": 1699061776,
+                          "vector_store_id": "vs_abc123",
+                          "status": "in_progress",
+                          "file_counts": {
+                            "in_progress": 1,
+                            "completed": 1,
+                            "failed": 0,
+                            "cancelled": 0,
+                            "total": 0,
+                          }
+                        }
+
+    /vector_stores/{vector_store_id}/file_batches/{batch_id}:
+        get:
+            operationId: getVectorStoreFileBatch
+            tags:
+                - Vector Stores
+            summary: Retrieves a vector store file batch.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                      example: vs_abc123
+                  description: The ID of the vector store that the file batch belongs to.
+                - in: path
+                  name: batch_id
+                  required: true
+                  schema:
+                      type: string
+                      example: vsfb_abc123
+                  description: The ID of the file batch being retrieved.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            x-oaiMeta:
+                name: Retrieve vector store file batch
+                group: vector_stores
+                beta: true
+                returns: The [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_file_batch = client.beta.vector_stores.file_batches.retrieve(
+                              vector_store_id="vs_abc123",
+                              batch_id="vsfb_abc123"
+                            )
+                            print(vector_store_file_batch)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStoreFileBatch = await openai.beta.vectorStores.fileBatches.retrieve(
+                                "vs_abc123",
+                                "vsfb_abc123"
+                              );
+                              console.log(vectorStoreFileBatch);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vsfb_abc123",
+                          "object": "vector_store.file_batch",
+                          "created_at": 1699061776,
+                          "vector_store_id": "vs_abc123",
+                          "status": "in_progress",
+                          "file_counts": {
+                            "in_progress": 1,
+                            "completed": 1,
+                            "failed": 0,
+                            "cancelled": 0,
+                            "total": 0,
+                          }
+                        }
+
+    /vector_stores/{vector_store_id}/file_batches/{batch_id}/cancel:
+        post:
+            operationId: cancelVectorStoreFileBatch
+            tags:
+                - Vector Stores
+            summary: Cancel a vector store file batch. This attempts to cancel the processing of files in this batch as soon as possible.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the vector store that the file batch belongs to.
+                - in: path
+                  name: batch_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the file batch to cancel.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            x-oaiMeta:
+                name: Cancel vector store file batch
+                group: vector_stores
+                beta: true
+                returns: The modified vector store file batch object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123/cancel \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X POST
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            deleted_vector_store_file_batch = client.beta.vector_stores.file_batches.cancel(
+                                vector_store_id="vs_abc123",
+                                file_batch_id="vsfb_abc123"
+                            )
+                            print(deleted_vector_store_file_batch)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const deletedVectorStoreFileBatch = await openai.vector_stores.fileBatches.cancel(
+                                "vs_abc123",
+                                "vsfb_abc123"
+                              );
+                              console.log(deletedVectorStoreFileBatch);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vsfb_abc123",
+                          "object": "vector_store.file_batch",
+                          "created_at": 1699061776,
+                          "vector_store_id": "vs_abc123",
+                          "status": "cancelling",
+                          "file_counts": {
+                            "in_progress": 12,
+                            "completed": 3,
+                            "failed": 0,
+                            "cancelled": 0,
+                            "total": 15,
+                          }
+                        }
+
+    /vector_stores/{vector_store_id}/file_batches/{batch_id}/files:
+        get:
+            operationId: listFilesInVectorStoreBatch
+            tags:
+                - Vector Stores
+            summary: Returns a list of vector store files in a batch.
+            parameters:
+                - name: vector_store_id
+                  in: path
+                  description: The ID of the vector store that the files belong to.
+                  required: true
+                  schema:
+                      type: string
+                - name: batch_id
+                  in: path
+                  description: The ID of the file batch that the files belong to.
+                  required: true
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+                - name: filter
+                  in: query
+                  description: "Filter by file status. One of `in_progress`, `completed`, `failed`, `cancelled`."
+                  schema:
+                      type: string
+                      enum: ["in_progress", "completed", "failed", "cancelled"]
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+            x-oaiMeta:
+                name: List vector store files in a batch
+                group: vector_stores
+                beta: true
+                returns: A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123/files \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_files = client.beta.vector_stores.file_batches.list_files(
+                              vector_store_id="vs_abc123",
+                              batch_id="vsfb_abc123"
+                            )
+                            print(vector_store_files)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStoreFiles = await openai.beta.vectorStores.fileBatches.listFiles(
+                                "vs_abc123",
+                                "vsfb_abc123"
+                              );
+                              console.log(vectorStoreFiles);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "file-abc123",
+                              "object": "vector_store.file",
+                              "created_at": 1699061776,
+                              "vector_store_id": "vs_abc123"
+                            },
+                            {
+                              "id": "file-abc456",
+                              "object": "vector_store.file",
+                              "created_at": 1699061776,
+                              "vector_store_id": "vs_abc123"
+                            }
+                          ],
+                          "first_id": "file-abc123",
+                          "last_id": "file-abc456",
+                          "has_more": false
+                        }
+
+    /batches:
+        post:
+            summary: Creates and executes a batch from an uploaded file of requests
+            operationId: createBatch
+            tags:
+                - Batch
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - input_file_id
+                                - endpoint
+                                - completion_window
+                            properties:
+                                input_file_id:
+                                    type: string
+                                    description: |
+                                        The ID of an uploaded file that contains requests for the new batch.
+
+                                        See [upload file](/docs/api-reference/files/create) for how to upload a file.
+
+                                        Your input file must be formatted as a [JSONL file](/docs/api-reference/batch/request-input), and must be uploaded with the purpose `batch`. The file can contain up to 50,000 requests, and can be up to 100 MB in size.
+                                endpoint:
+                                    type: string
+                                    enum:
+                                        [
+                                            "/v1/chat/completions",
+                                            "/v1/embeddings",
+                                            "/v1/completions",
+                                        ]
+                                    description: The endpoint to be used for all requests in the batch. Currently `/v1/chat/completions`, `/v1/embeddings`, and `/v1/completions` are supported. Note that `/v1/embeddings` batches are also restricted to a maximum of 50,000 embedding inputs across all requests in the batch.
+                                completion_window:
+                                    type: string
+                                    enum: ["24h"]
+                                    description: The time frame within which the batch should be processed. Currently only `24h` is supported.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: Optional custom metadata for the batch.
+                                    nullable: true
+            responses:
+                "200":
+                    description: Batch created successfully.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Batch"
+            x-oaiMeta:
+                name: Create batch
+                group: batch
+                returns: The created [Batch](/docs/api-reference/batch/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/batches \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -d '{
+                                "input_file_id": "file-abc123",
+                                "endpoint": "/v1/chat/completions",
+                                "completion_window": "24h"
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.batches.create(
+                              input_file_id="file-abc123",
+                              endpoint="/v1/chat/completions",
+                              completion_window="24h"
+                            )
+                        node: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const batch = await openai.batches.create({
+                                input_file_id: "file-abc123",
+                                endpoint: "/v1/chat/completions",
+                                completion_window: "24h"
+                              });
+
+                              console.log(batch);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "batch_abc123",
+                          "object": "batch",
+                          "endpoint": "/v1/chat/completions",
+                          "errors": null,
+                          "input_file_id": "file-abc123",
+                          "completion_window": "24h",
+                          "status": "validating",
+                          "output_file_id": null,
+                          "error_file_id": null,
+                          "created_at": 1711471533,
+                          "in_progress_at": null,
+                          "expires_at": null,
+                          "finalizing_at": null,
+                          "completed_at": null,
+                          "failed_at": null,
+                          "expired_at": null,
+                          "cancelling_at": null,
+                          "cancelled_at": null,
+                          "request_counts": {
+                            "total": 0,
+                            "completed": 0,
+                            "failed": 0
+                          },
+                          "metadata": {
+                            "customer_id": "user_123456789",
+                            "batch_description": "Nightly eval job",
+                          }
+                        }
+        get:
+            operationId: listBatches
+            tags:
+                - Batch
+            summary: List your organization's batches.
+            parameters:
+                - in: query
+                  name: after
+                  required: false
+                  schema:
+                      type: string
+                  description: *pagination_after_param_description
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+            responses:
+                "200":
+                    description: Batch listed successfully.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListBatchesResponse"
+            x-oaiMeta:
+                name: List batch
+                group: batch
+                returns: A list of paginated [Batch](/docs/api-reference/batch/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/batches?limit=2 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.batches.list()
+                        node: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const list = await openai.batches.list();
+
+                              for await (const batch of list) {
+                                console.log(batch);
+                              }
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "batch_abc123",
+                              "object": "batch",
+                              "endpoint": "/v1/chat/completions",
+                              "errors": null,
+                              "input_file_id": "file-abc123",
+                              "completion_window": "24h",
+                              "status": "completed",
+                              "output_file_id": "file-cvaTdG",
+                              "error_file_id": "file-HOWS94",
+                              "created_at": 1711471533,
+                              "in_progress_at": 1711471538,
+                              "expires_at": 1711557933,
+                              "finalizing_at": 1711493133,
+                              "completed_at": 1711493163,
+                              "failed_at": null,
+                              "expired_at": null,
+                              "cancelling_at": null,
+                              "cancelled_at": null,
+                              "request_counts": {
+                                "total": 100,
+                                "completed": 95,
+                                "failed": 5
+                              },
+                              "metadata": {
+                                "customer_id": "user_123456789",
+                                "batch_description": "Nightly job",
+                              }
+                            },
+                            { ... },
+                          ],
+                          "first_id": "batch_abc123",
+                          "last_id": "batch_abc456",
+                          "has_more": true
+                        }
+
+    /batches/{batch_id}:
+        get:
+            operationId: retrieveBatch
+            tags:
+                - Batch
+            summary: Retrieves a batch.
+            parameters:
+                - in: path
+                  name: batch_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the batch to retrieve.
+            responses:
+                "200":
+                    description: Batch retrieved successfully.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Batch"
+            x-oaiMeta:
+                name: Retrieve batch
+                group: batch
+                returns: The [Batch](/docs/api-reference/batch/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/batches/batch_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.batches.retrieve("batch_abc123")
+                        node: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const batch = await openai.batches.retrieve("batch_abc123");
+
+                              console.log(batch);
+                            }
+
+                            main();
+                    response: &batch_object |
+                        {
+                          "id": "batch_abc123",
+                          "object": "batch",
+                          "endpoint": "/v1/completions",
+                          "errors": null,
+                          "input_file_id": "file-abc123",
+                          "completion_window": "24h",
+                          "status": "completed",
+                          "output_file_id": "file-cvaTdG",
+                          "error_file_id": "file-HOWS94",
+                          "created_at": 1711471533,
+                          "in_progress_at": 1711471538,
+                          "expires_at": 1711557933,
+                          "finalizing_at": 1711493133,
+                          "completed_at": 1711493163,
+                          "failed_at": null,
+                          "expired_at": null,
+                          "cancelling_at": null,
+                          "cancelled_at": null,
+                          "request_counts": {
+                            "total": 100,
+                            "completed": 95,
+                            "failed": 5
+                          },
+                          "metadata": {
+                            "customer_id": "user_123456789",
+                            "batch_description": "Nightly eval job",
+                          }
+                        }
+
+    /batches/{batch_id}/cancel:
+        post:
+            operationId: cancelBatch
+            tags:
+                - Batch
+            summary: Cancels an in-progress batch. The batch will be in status `cancelling` for up to 10 minutes, before changing to `cancelled`, where it will have partial results (if any) available in the output file.
+            parameters:
+                - in: path
+                  name: batch_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the batch to cancel.
+            responses:
+                "200":
+                    description: Batch is cancelling. Returns the cancelling batch's details.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Batch"
+            x-oaiMeta:
+                name: Cancel batch
+                group: batch
+                returns: The [Batch](/docs/api-reference/batch/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/batches/batch_abc123/cancel \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -X POST
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.batches.cancel("batch_abc123")
+                        node: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const batch = await openai.batches.cancel("batch_abc123");
+
+                              console.log(batch);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "batch_abc123",
+                          "object": "batch",
+                          "endpoint": "/v1/chat/completions",
+                          "errors": null,
+                          "input_file_id": "file-abc123",
+                          "completion_window": "24h",
+                          "status": "cancelling",
+                          "output_file_id": null,
+                          "error_file_id": null,
+                          "created_at": 1711471533,
+                          "in_progress_at": 1711471538,
+                          "expires_at": 1711557933,
+                          "finalizing_at": null,
+                          "completed_at": null,
+                          "failed_at": null,
+                          "expired_at": null,
+                          "cancelling_at": 1711475133,
+                          "cancelled_at": null,
+                          "request_counts": {
+                            "total": 100,
+                            "completed": 23,
+                            "failed": 1
+                          },
+                          "metadata": {
+                            "customer_id": "user_123456789",
+                            "batch_description": "Nightly eval job",
+                          }
+                        }
+
+components:
+    securitySchemes:
+        ApiKeyAuth:
+            type: http
+            scheme: "bearer"
+
+    schemas:
+        Error:
+            type: object
+            properties:
+                code:
+                    type: string
+                    nullable: true
+                message:
+                    type: string
+                    nullable: false
+                param:
+                    type: string
+                    nullable: true
+                type:
+                    type: string
+                    nullable: false
+            required:
+                - type
+                - message
+                - param
+                - code
+        ErrorResponse:
+            type: object
+            properties:
+                error:
+                    $ref: "#/components/schemas/Error"
+            required:
+                - error
+
+        ListModelsResponse:
+            type: object
+            properties:
+                object:
+                    type: string
+                    enum: [list]
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/Model"
+            required:
+                - object
+                - data
+        DeleteModelResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+            required:
+                - id
+                - object
+                - deleted
+
+        CreateCompletionRequest:
+            type: object
+            properties:
+                model:
+                    description: &model_description |
+                        ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["gpt-3.5-turbo-instruct", "davinci-002", "babbage-002"]
+                    x-oaiTypeLabel: string
+                prompt:
+                    description: &completions_prompt_description |
+                        The prompt(s) to generate completions for, encoded as a string, array of strings, array of tokens, or array of token arrays.
+
+                        Note that <|endoftext|> is the document separator that the model sees during training, so if a prompt is not specified the model will generate as if from the beginning of a new document.
+                    default: "<|endoftext|>"
+                    nullable: true
+                    oneOf:
+                        - type: string
+                          default: ""
+                          example: "This is a test."
+                        - type: array
+                          items:
+                              type: string
+                              default: ""
+                              example: "This is a test."
+                        - type: array
+                          minItems: 1
+                          items:
+                              type: integer
+                          example: "[1212, 318, 257, 1332, 13]"
+                        - type: array
+                          minItems: 1
+                          items:
+                              type: array
+                              minItems: 1
+                              items:
+                                  type: integer
+                          example: "[[1212, 318, 257, 1332, 13]]"
+                best_of:
+                    type: integer
+                    default: 1
+                    minimum: 0
+                    maximum: 20
+                    nullable: true
+                    description: &completions_best_of_description |
+                        Generates `best_of` completions server-side and returns the "best" (the one with the highest log probability per token). Results cannot be streamed.
+
+                        When used with `n`, `best_of` controls the number of candidate completions and `n` specifies how many to return – `best_of` must be greater than `n`.
+
+                        **Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
+                echo:
+                    type: boolean
+                    default: false
+                    nullable: true
+                    description: &completions_echo_description >
+                        Echo back the prompt in addition to the completion
+                frequency_penalty:
+                    type: number
+                    default: 0
+                    minimum: -2
+                    maximum: 2
+                    nullable: true
+                    description: &completions_frequency_penalty_description |
+                        Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+
+                        [See more information about frequency and presence penalties.](/docs/guides/text-generation/parameter-details)
+                logit_bias: &completions_logit_bias
+                    type: object
+                    x-oaiTypeLabel: map
+                    default: null
+                    nullable: true
+                    additionalProperties:
+                        type: integer
+                    description: &completions_logit_bias_description |
+                        Modify the likelihood of specified tokens appearing in the completion.
+
+                        Accepts a JSON object that maps tokens (specified by their token ID in the GPT tokenizer) to an associated bias value from -100 to 100. You can use this [tokenizer tool](/tokenizer?view=bpe) to convert text to token IDs. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
+
+                        As an example, you can pass `{"50256": -100}` to prevent the <|endoftext|> token from being generated.
+                logprobs: &completions_logprobs_configuration
+                    type: integer
+                    minimum: 0
+                    maximum: 5
+                    default: null
+                    nullable: true
+                    description: &completions_logprobs_description |
+                        Include the log probabilities on the `logprobs` most likely output tokens, as well the chosen tokens. For example, if `logprobs` is 5, the API will return a list of the 5 most likely tokens. The API will always return the `logprob` of the sampled token, so there may be up to `logprobs+1` elements in the response.
+
+                        The maximum value for `logprobs` is 5.
+                max_tokens:
+                    type: integer
+                    minimum: 0
+                    default: 16
+                    example: 16
+                    nullable: true
+                    description: &completions_max_tokens_description |
+                        The maximum number of [tokens](/tokenizer) that can be generated in the completion.
+
+                        The token count of your prompt plus `max_tokens` cannot exceed the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
+                n:
+                    type: integer
+                    minimum: 1
+                    maximum: 128
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &completions_completions_description |
+                        How many completions to generate for each prompt.
+
+                        **Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
+                presence_penalty:
+                    type: number
+                    default: 0
+                    minimum: -2
+                    maximum: 2
+                    nullable: true
+                    description: &completions_presence_penalty_description |
+                        Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
+
+                        [See more information about frequency and presence penalties.](/docs/guides/text-generation/parameter-details)
+                seed: &completions_seed_param
+                    type: integer
+                    minimum: -9223372036854775808
+                    maximum: 9223372036854775807
+                    nullable: true
+                    description: |
+                        If specified, our system will make a best effort to sample deterministically, such that repeated requests with the same `seed` and parameters should return the same result.
+
+                        Determinism is not guaranteed, and you should refer to the `system_fingerprint` response parameter to monitor changes in the backend.
+                stop:
+                    description: &completions_stop_description >
+                        Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.
+                    default: null
+                    nullable: true
+                    oneOf:
+                        - type: string
+                          default: <|endoftext|>
+                          example: "\n"
+                          nullable: true
+                        - type: array
+                          minItems: 1
+                          maxItems: 4
+                          items:
+                              type: string
+                              example: '["\n"]'
+                stream:
+                    description: >
+                        Whether to stream back partial progress. If set, tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
+                        as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).
+                    type: boolean
+                    nullable: true
+                    default: false
+                stream_options:
+                    $ref: "#/components/schemas/ChatCompletionStreamOptions"
+                suffix:
+                    description: |
+                        The suffix that comes after a completion of inserted text.
+
+                        This parameter is only supported for `gpt-3.5-turbo-instruct`.
+                    default: null
+                    nullable: true
+                    type: string
+                    example: "test."
+                temperature:
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &completions_temperature_description |
+                        What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+
+                        We generally recommend altering this or `top_p` but not both.
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &completions_top_p_description |
+                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                        We generally recommend altering this or `temperature` but not both.
+                user: &end_user_param_configuration
+                    type: string
+                    example: user-1234
+                    description: |
+                        A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).
+            required:
+                - model
+                - prompt
+
+        CreateCompletionResponse:
+            type: object
+            description: |
+                Represents a completion response from the API. Note: both the streamed and non-streamed response objects share the same shape (unlike the chat endpoint).
+            properties:
+                id:
+                    type: string
+                    description: A unique identifier for the completion.
+                choices:
+                    type: array
+                    description: The list of completion choices the model generated for the input prompt.
+                    items:
+                        type: object
+                        required:
+                            - finish_reason
+                            - index
+                            - logprobs
+                            - text
+                        properties:
+                            finish_reason:
+                                type: string
+                                description: &completion_finish_reason_description |
+                                    The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
+                                    `length` if the maximum number of tokens specified in the request was reached,
+                                    or `content_filter` if content was omitted due to a flag from our content filters.
+                                enum: ["stop", "length", "content_filter"]
+                            index:
+                                type: integer
+                            logprobs:
+                                type: object
+                                nullable: true
+                                properties:
+                                    text_offset:
+                                        type: array
+                                        items:
+                                            type: integer
+                                    token_logprobs:
+                                        type: array
+                                        items:
+                                            type: number
+                                    tokens:
+                                        type: array
+                                        items:
+                                            type: string
+                                    top_logprobs:
+                                        type: array
+                                        items:
+                                            type: object
+                                            additionalProperties:
+                                                type: number
+                            text:
+                                type: string
+                created:
+                    type: integer
+                    description: The Unix timestamp (in seconds) of when the completion was created.
+                model:
+                    type: string
+                    description: The model used for completion.
+                system_fingerprint:
+                    type: string
+                    description: |
+                        This fingerprint represents the backend configuration that the model runs with.
+
+                        Can be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.
+                object:
+                    type: string
+                    description: The object type, which is always "text_completion"
+                    enum: [text_completion]
+                usage:
+                    $ref: "#/components/schemas/CompletionUsage"
+            required:
+                - id
+                - object
+                - created
+                - model
+                - choices
+            x-oaiMeta:
+                name: The completion object
+                legacy: true
+                example: |
+                    {
+                      "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+                      "object": "text_completion",
+                      "created": 1589478378,
+                      "model": "gpt-4-turbo",
+                      "choices": [
+                        {
+                          "text": "\n\nThis is indeed a test",
+                          "index": 0,
+                          "logprobs": null,
+                          "finish_reason": "length"
+                        }
+                      ],
+                      "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 7,
+                        "total_tokens": 12
+                      }
+                    }
+
+        ChatCompletionRequestMessageContentPart:
+            oneOf:
+                - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+                - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartImage"
+            x-oaiExpandable: true
+
+        ChatCompletionRequestMessageContentPartImage:
+            type: object
+            title: Image content part
+            properties:
+                type:
+                    type: string
+                    enum: ["image_url"]
+                    description: The type of the content part.
+                image_url:
+                    type: object
+                    properties:
+                        url:
+                            type: string
+                            description: Either a URL of the image or the base64 encoded image data.
+                            format: uri
+                        detail:
+                            type: string
+                            description: Specifies the detail level of the image. Learn more in the [Vision guide](/docs/guides/vision/low-or-high-fidelity-image-understanding).
+                            enum: ["auto", "low", "high"]
+                            default: "auto"
+                    required:
+                        - url
+            required:
+                - type
+                - image_url
+
+        ChatCompletionRequestMessageContentPartText:
+            type: object
+            title: Text content part
+            properties:
+                type:
+                    type: string
+                    enum: ["text"]
+                    description: The type of the content part.
+                text:
+                    type: string
+                    description: The text content.
+            required:
+                - type
+                - text
+
+        ChatCompletionRequestMessage:
+            oneOf:
+                - $ref: "#/components/schemas/ChatCompletionRequestSystemMessage"
+                - $ref: "#/components/schemas/ChatCompletionRequestUserMessage"
+                - $ref: "#/components/schemas/ChatCompletionRequestAssistantMessage"
+                - $ref: "#/components/schemas/ChatCompletionRequestToolMessage"
+                - $ref: "#/components/schemas/ChatCompletionRequestFunctionMessage"
+            x-oaiExpandable: true
+
+        ChatCompletionRequestSystemMessage:
+            type: object
+            title: System message
+            properties:
+                content:
+                    description: The contents of the system message.
+                    type: string
+                role:
+                    type: string
+                    enum: ["system"]
+                    description: The role of the messages author, in this case `system`.
+                name:
+                    type: string
+                    description: An optional name for the participant. Provides the model information to differentiate between participants of the same role.
+            required:
+                - content
+                - role
+
+        ChatCompletionRequestUserMessage:
+            type: object
+            title: User message
+            properties:
+                content:
+                    description: |
+                        The contents of the user message.
+                    oneOf:
+                        - type: string
+                          description: The text contents of the message.
+                          title: Text content
+                        - type: array
+                          description: An array of content parts with a defined type, each can be of type `text` or `image_url` when passing in images. You can pass multiple images by adding multiple `image_url` content parts. Image input is only supported when using the `gpt-4o` model.
+                          title: Array of content parts
+                          items:
+                              $ref: "#/components/schemas/ChatCompletionRequestMessageContentPart"
+                          minItems: 1
+                    x-oaiExpandable: true
+                role:
+                    type: string
+                    enum: ["user"]
+                    description: The role of the messages author, in this case `user`.
+                name:
+                    type: string
+                    description: An optional name for the participant. Provides the model information to differentiate between participants of the same role.
+            required:
+                - content
+                - role
+
+        ChatCompletionRequestAssistantMessage:
+            type: object
+            title: Assistant message
+            properties:
+                content:
+                    nullable: true
+                    type: string
+                    description: |
+                        The contents of the assistant message. Required unless `tool_calls` or `function_call` is specified.
+                role:
+                    type: string
+                    enum: ["assistant"]
+                    description: The role of the messages author, in this case `assistant`.
+                name:
+                    type: string
+                    description: An optional name for the participant. Provides the model information to differentiate between participants of the same role.
+                tool_calls:
+                    $ref: "#/components/schemas/ChatCompletionMessageToolCalls"
+                function_call:
+                    type: object
+                    deprecated: true
+                    description: "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model."
+                    nullable: true
+                    properties:
+                        arguments:
+                            type: string
+                            description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                    required:
+                        - arguments
+                        - name
+            required:
+                - role
+        
+        FineTuneChatCompletionRequestAssistantMessage:
+            allOf:
+                - type: object
+                  title: Assistant message
+                  deprecated: false
+                  properties:
+                    weight:
+                      type: integer
+                      enum: [0, 1]
+                      description: "Controls whether the assistant message is trained against (0 or 1)"
+                - $ref: "#/components/schemas/ChatCompletionRequestAssistantMessage"
+            required:
+                - role                    
+
+        ChatCompletionRequestToolMessage:
+            type: object
+            title: Tool message
+            properties:
+                role:
+                    type: string
+                    enum: ["tool"]
+                    description: The role of the messages author, in this case `tool`.
+                content:
+                    type: string
+                    description: The contents of the tool message.
+                tool_call_id:
+                    type: string
+                    description: Tool call that this message is responding to.
+            required:
+                - role
+                - content
+                - tool_call_id
+
+        ChatCompletionRequestFunctionMessage:
+            type: object
+            title: Function message
+            deprecated: true
+            properties:
+                role:
+                    type: string
+                    enum: ["function"]
+                    description: The role of the messages author, in this case `function`.
+                content:
+                    nullable: true
+                    type: string
+                    description: The contents of the function message.
+                name:
+                    type: string
+                    description: The name of the function to call.
+            required:
+                - role
+                - content
+                - name
+
+        FunctionParameters:
+            type: object
+            description: "The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format. \n\nOmitting `parameters` defines a function with an empty parameter list."
+            additionalProperties: true
+
+        ChatCompletionFunctions:
+            type: object
+            deprecated: true
+            properties:
+                description:
+                    type: string
+                    description: A description of what the function does, used by the model to choose when and how to call the function.
+                name:
+                    type: string
+                    description: The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.
+                parameters:
+                    $ref: "#/components/schemas/FunctionParameters"
+            required:
+                - name
+
+        ChatCompletionFunctionCallOption:
+            type: object
+            description: >
+                Specifying a particular function via `{"name": "my_function"}` forces the model to call that function.
+            properties:
+                name:
+                    type: string
+                    description: The name of the function to call.
+            required:
+                - name
+
+        ChatCompletionTool:
+            type: object
+            properties:
+                type:
+                    type: string
+                    enum: ["function"]
+                    description: The type of the tool. Currently, only `function` is supported.
+                function:
+                    $ref: "#/components/schemas/FunctionObject"
+            required:
+                - type
+                - function
+
+        FunctionObject:
+            type: object
+            properties:
+                description:
+                    type: string
+                    description: A description of what the function does, used by the model to choose when and how to call the function.
+                name:
+                    type: string
+                    description: The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.
+                parameters:
+                    $ref: "#/components/schemas/FunctionParameters"
+            required:
+                - name
+
+        ChatCompletionToolChoiceOption:
+            description: |
+                Controls which (if any) tool is called by the model.
+                `none` means the model will not call any tool and instead generates a message.
+                `auto` means the model can pick between generating a message or calling one or more tools.
+                `required` means the model must call one or more tools.
+                Specifying a particular tool via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool.
+
+                `none` is the default when no tools are present. `auto` is the default if tools are present.
+            oneOf:
+                - type: string
+                  description: >
+                      `none` means the model will not call any tool and instead generates a message.
+                      `auto` means the model can pick between generating a message or calling one or more tools.
+                      `required` means the model must call one or more tools.
+                  enum: [none, auto, required]
+                - $ref: "#/components/schemas/ChatCompletionNamedToolChoice"
+            x-oaiExpandable: true
+
+        ChatCompletionNamedToolChoice:
+            type: object
+            description: Specifies a tool the model should use. Use to force the model to call a specific function.
+            properties:
+                type:
+                    type: string
+                    enum: ["function"]
+                    description: The type of the tool. Currently, only `function` is supported.
+                function:
+                    type: object
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                    required:
+                        - name
+            required:
+                - type
+                - function
+
+        ParallelToolCalls:
+            description: Whether to enable [parallel function calling](/docs/guides/function-calling/parallel-function-calling) during tool use.
+            type: boolean
+            default: true
+
+        ChatCompletionMessageToolCalls:
+            type: array
+            description: The tool calls generated by the model, such as function calls.
+            items:
+                $ref: "#/components/schemas/ChatCompletionMessageToolCall"
+
+        ChatCompletionMessageToolCall:
+            type: object
+            properties:
+                # TODO: index included when streaming
+                id:
+                    type: string
+                    description: The ID of the tool call.
+                type:
+                    type: string
+                    enum: ["function"]
+                    description: The type of the tool. Currently, only `function` is supported.
+                function:
+                    type: object
+                    description: The function that the model called.
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                        arguments:
+                            type: string
+                            description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+                    required:
+                        - name
+                        - arguments
+            required:
+                - id
+                - type
+                - function
+
+        ChatCompletionMessageToolCallChunk:
+            type: object
+            properties:
+                index:
+                    type: integer
+                id:
+                    type: string
+                    description: The ID of the tool call.
+                type:
+                    type: string
+                    enum: ["function"]
+                    description: The type of the tool. Currently, only `function` is supported.
+                function:
+                    type: object
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                        arguments:
+                            type: string
+                            description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+            required:
+                - index
+
+        # Note, this isn't referenced anywhere, but is kept as a convenience to record all possible roles in one place.
+        ChatCompletionRole:
+            type: string
+            description: The role of the author of a message
+            enum:
+                - system
+                - user
+                - assistant
+                - tool
+                - function
+
+        ChatCompletionStreamOptions:
+            description: |
+                Options for streaming response. Only set this when you set `stream: true`.
+            type: object
+            nullable: true
+            default: null
+            properties:
+                include_usage:
+                    type: boolean
+                    description: |
+                        If set, an additional chunk will be streamed before the `data: [DONE]` message. The `usage` field on this chunk shows the token usage statistics for the entire request, and the `choices` field will always be an empty array. All other chunks will also include a `usage` field, but with a null value.
+
+        ChatCompletionResponseMessage:
+            type: object
+            description: A chat completion message generated by the model.
+            properties:
+                content:
+                    type: string
+                    description: The contents of the message.
+                    nullable: true
+                tool_calls:
+                    $ref: "#/components/schemas/ChatCompletionMessageToolCalls"
+                role:
+                    type: string
+                    enum: ["assistant"]
+                    description: The role of the author of this message.
+                function_call:
+                    type: object
+                    deprecated: true
+                    description: "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model."
+                    properties:
+                        arguments:
+                            type: string
+                            description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                    required:
+                        - name
+                        - arguments
+            required:
+                - role
+                - content
+
+        ChatCompletionStreamResponseDelta:
+            type: object
+            description: A chat completion delta generated by streamed model responses.
+            properties:
+                content:
+                    type: string
+                    description: The contents of the chunk message.
+                    nullable: true
+                function_call:
+                    deprecated: true
+                    type: object
+                    description: "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model."
+                    properties:
+                        arguments:
+                            type: string
+                            description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                tool_calls:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionMessageToolCallChunk"
+                role:
+                    type: string
+                    enum: ["system", "user", "assistant", "tool"]
+                    description: The role of the author of this message.
+
+        CreateChatCompletionRequest:
+            type: object
+            properties:
+                messages:
+                    description: A list of messages comprising the conversation so far. [Example Python code](https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models).
+                    type: array
+                    minItems: 1
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionRequestMessage"
+                model:
+                    description: ID of the model to use. See the [model endpoint compatibility](/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.
+                    example: "gpt-4-turbo"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "gpt-4o",
+                                  "gpt-4o-2024-05-13",
+                                  "gpt-4o-mini",
+                                  "gpt-4o-mini-2024-07-18",
+                                  "gpt-4-turbo",
+                                  "gpt-4-turbo-2024-04-09",
+                                  "gpt-4-0125-preview",
+                                  "gpt-4-turbo-preview",
+                                  "gpt-4-1106-preview",
+                                  "gpt-4-vision-preview",
+                                  "gpt-4",
+                                  "gpt-4-0314",
+                                  "gpt-4-0613",
+                                  "gpt-4-32k",
+                                  "gpt-4-32k-0314",
+                                  "gpt-4-32k-0613",
+                                  "gpt-3.5-turbo",
+                                  "gpt-3.5-turbo-16k",
+                                  "gpt-3.5-turbo-0301",
+                                  "gpt-3.5-turbo-0613",
+                                  "gpt-3.5-turbo-1106",
+                                  "gpt-3.5-turbo-0125",
+                                  "gpt-3.5-turbo-16k-0613",
+                              ]
+                    x-oaiTypeLabel: string
+                frequency_penalty:
+                    type: number
+                    default: 0
+                    minimum: -2
+                    maximum: 2
+                    nullable: true
+                    description: *completions_frequency_penalty_description
+                logit_bias:
+                    type: object
+                    x-oaiTypeLabel: map
+                    default: null
+                    nullable: true
+                    additionalProperties:
+                        type: integer
+                    description: |
+                        Modify the likelihood of specified tokens appearing in the completion.
+
+                        Accepts a JSON object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
+                logprobs:
+                    description: Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the `content` of `message`.
+                    type: boolean
+                    default: false
+                    nullable: true
+                top_logprobs:
+                    description: An integer between 0 and 20 specifying the number of most likely tokens to return at each token position, each with an associated log probability. `logprobs` must be set to `true` if this parameter is used.
+                    type: integer
+                    minimum: 0
+                    maximum: 20
+                    nullable: true
+                max_tokens:
+                    description: |
+                        The maximum number of [tokens](/tokenizer) that can be generated in the chat completion.
+
+                        The total length of input tokens and generated tokens is limited by the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
+                    type: integer
+                    nullable: true
+                n:
+                    type: integer
+                    minimum: 1
+                    maximum: 128
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Keep `n` as `1` to minimize costs.
+                presence_penalty:
+                    type: number
+                    default: 0
+                    minimum: -2
+                    maximum: 2
+                    nullable: true
+                    description: *completions_presence_penalty_description
+                response_format:
+                    type: object
+                    description: |
+                        An object specifying the format that the model must output. Compatible with [GPT-4 Turbo](/docs/models/gpt-4-and-gpt-4-turbo) and all GPT-3.5 Turbo models newer than `gpt-3.5-turbo-1106`.
+
+                        Setting to `{ "type": "json_object" }` enables JSON mode, which guarantees the message the model generates is valid JSON.
+
+                        **Important:** when using JSON mode, you **must** also instruct the model to produce JSON yourself via a system or user message. Without this, the model may generate an unending stream of whitespace until the generation reaches the token limit, resulting in a long-running and seemingly "stuck" request. Also note that the message content may be partially cut off if `finish_reason="length"`, which indicates the generation exceeded `max_tokens` or the conversation exceeded the max context length.
+                    properties:
+                        type:
+                            type: string
+                            enum: ["text", "json_object"]
+                            example: "json_object"
+                            default: "text"
+                            description: Must be one of `text` or `json_object`.
+                seed:
+                    type: integer
+                    minimum: -9223372036854775808
+                    maximum: 9223372036854775807
+                    nullable: true
+                    description: |
+                        This feature is in Beta.
+                        If specified, our system will make a best effort to sample deterministically, such that repeated requests with the same `seed` and parameters should return the same result.
+                        Determinism is not guaranteed, and you should refer to the `system_fingerprint` response parameter to monitor changes in the backend.
+                    x-oaiMeta:
+                        beta: true
+                service_tier:
+                  description: |
+                      Specifies the latency tier to use for processing the request. This parameter is relevant for customers subscribed to the scale tier service:
+                        - If set to 'auto', the system will utilize scale tier credits until they are exhausted.
+                        - If set to 'default', the request will be processed using the default service tier with a lower uptime SLA and no latency guarentee.
+                        - When not set, the default behavior is 'auto'.
+
+                        When this parameter is set, the response body will include the `service_tier` utilized.
+                  type: string
+                  enum: ["auto", "default"]
+                  nullable: true
+                  default: null
+                stop:
+                    description: |
+                        Up to 4 sequences where the API will stop generating further tokens.
+                    default: null
+                    oneOf:
+                        - type: string
+                          nullable: true
+                        - type: array
+                          minItems: 1
+                          maxItems: 4
+                          items:
+                              type: string
+                stream:
+                    description: >
+                        If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
+                        as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).
+                    type: boolean
+                    nullable: true
+                    default: false
+                stream_options:
+                    $ref: "#/components/schemas/ChatCompletionStreamOptions"
+                temperature:
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: *completions_temperature_description
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: *completions_top_p_description
+                tools:
+                    type: array
+                    description: >
+                        A list of tools the model may call. Currently, only functions are supported as a tool.
+                        Use this to provide a list of functions the model may generate JSON inputs for. A max of 128 functions are supported.
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionTool"
+                tool_choice:
+                    $ref: "#/components/schemas/ChatCompletionToolChoiceOption"
+                parallel_tool_calls:
+                    $ref: "#/components/schemas/ParallelToolCalls"
+                user: *end_user_param_configuration
+                function_call:
+                    deprecated: true
+                    description: |
+                        Deprecated in favor of `tool_choice`.
+
+                        Controls which (if any) function is called by the model.
+                        `none` means the model will not call a function and instead generates a message.
+                        `auto` means the model can pick between generating a message or calling a function.
+                        Specifying a particular function via `{"name": "my_function"}` forces the model to call that function.
+
+                        `none` is the default when no functions are present. `auto` is the default if functions are present.
+                    oneOf:
+                        - type: string
+                          description: >
+                              `none` means the model will not call a function and instead generates a message.
+                              `auto` means the model can pick between generating a message or calling a function.
+                          enum: [none, auto]
+                        - $ref: "#/components/schemas/ChatCompletionFunctionCallOption"
+                    x-oaiExpandable: true
+                functions:
+                    deprecated: true
+                    description: |
+                        Deprecated in favor of `tools`.
+
+                        A list of functions the model may generate JSON inputs for.
+                    type: array
+                    minItems: 1
+                    maxItems: 128
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionFunctions"
+
+            required:
+                - model
+                - messages
+
+        CreateChatCompletionResponse:
+            type: object
+            description: Represents a chat completion response returned by model, based on the provided input.
+            properties:
+                id:
+                    type: string
+                    description: A unique identifier for the chat completion.
+                choices:
+                    type: array
+                    description: A list of chat completion choices. Can be more than one if `n` is greater than 1.
+                    items:
+                        type: object
+                        required:
+                            - finish_reason
+                            - index
+                            - message
+                            - logprobs
+                        properties:
+                            finish_reason:
+                                type: string
+                                description: &chat_completion_finish_reason_description |
+                                    The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
+                                    `length` if the maximum number of tokens specified in the request was reached,
+                                    `content_filter` if content was omitted due to a flag from our content filters,
+                                    `tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.
+                                enum:
+                                    [
+                                        "stop",
+                                        "length",
+                                        "tool_calls",
+                                        "content_filter",
+                                        "function_call",
+                                    ]
+                            index:
+                                type: integer
+                                description: The index of the choice in the list of choices.
+                            message:
+                                $ref: "#/components/schemas/ChatCompletionResponseMessage"
+                            logprobs: &chat_completion_response_logprobs
+                                description: Log probability information for the choice.
+                                type: object
+                                nullable: true
+                                properties:
+                                    content:
+                                        description: A list of message content tokens with log probability information.
+                                        type: array
+                                        items:
+                                            $ref: "#/components/schemas/ChatCompletionTokenLogprob"
+                                        nullable: true
+                                required:
+                                    - content
+                created:
+                    type: integer
+                    description: The Unix timestamp (in seconds) of when the chat completion was created.
+                model:
+                    type: string
+                    description: The model used for the chat completion.
+                service_tier:
+                    description: The service tier used for processing the request. This field is only included if the `service_tier` parameter is specified in the request.
+                    type: string
+                    enum: ["scale", "default"]
+                    example: "scale"
+                    nullable: true
+                system_fingerprint:
+                    type: string
+                    description: |
+                        This fingerprint represents the backend configuration that the model runs with.
+
+                        Can be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.
+                object:
+                    type: string
+                    description: The object type, which is always `chat.completion`.
+                    enum: [chat.completion]
+                usage:
+                    $ref: "#/components/schemas/CompletionUsage"
+            required:
+                - choices
+                - created
+                - id
+                - model
+                - object
+            x-oaiMeta:
+                name: The chat completion object
+                group: chat
+                example: *chat_completion_example
+
+        CreateChatCompletionFunctionResponse:
+            type: object
+            description: Represents a chat completion response returned by model, based on the provided input.
+            properties:
+                id:
+                    type: string
+                    description: A unique identifier for the chat completion.
+                choices:
+                    type: array
+                    description: A list of chat completion choices. Can be more than one if `n` is greater than 1.
+                    items:
+                        type: object
+                        required:
+                            - finish_reason
+                            - index
+                            - message
+                            - logprobs
+                        properties:
+                            finish_reason:
+                                type: string
+                                description:
+                                    &chat_completion_function_finish_reason_description |
+                                    The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence, `length` if the maximum number of tokens specified in the request was reached, `content_filter` if content was omitted due to a flag from our content filters, or `function_call` if the model called a function.
+                                enum:
+                                    ["stop", "length", "function_call", "content_filter"]
+                            index:
+                                type: integer
+                                description: The index of the choice in the list of choices.
+                            message:
+                                $ref: "#/components/schemas/ChatCompletionResponseMessage"
+                created:
+                    type: integer
+                    description: The Unix timestamp (in seconds) of when the chat completion was created.
+                model:
+                    type: string
+                    description: The model used for the chat completion.
+                system_fingerprint:
+                    type: string
+                    description: |
+                        This fingerprint represents the backend configuration that the model runs with.
+
+                        Can be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.
+                object:
+                    type: string
+                    description: The object type, which is always `chat.completion`.
+                    enum: [chat.completion]
+                usage:
+                    $ref: "#/components/schemas/CompletionUsage"
+            required:
+                - choices
+                - created
+                - id
+                - model
+                - object
+            x-oaiMeta:
+                name: The chat completion object
+                group: chat
+                example: *chat_completion_function_example
+
+        ChatCompletionTokenLogprob:
+            type: object
+            properties:
+                token: &chat_completion_response_logprobs_token
+                    description: The token.
+                    type: string
+                logprob: &chat_completion_response_logprobs_token_logprob
+                    description: The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely.
+                    type: number
+                bytes: &chat_completion_response_logprobs_bytes
+                    description: A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token.
+                    type: array
+                    items:
+                        type: integer
+                    nullable: true
+                top_logprobs:
+                    description: List of the most likely tokens and their log probability, at this token position. In rare cases, there may be fewer than the number of requested `top_logprobs` returned.
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            token: *chat_completion_response_logprobs_token
+                            logprob: *chat_completion_response_logprobs_token_logprob
+                            bytes: *chat_completion_response_logprobs_bytes
+                        required:
+                            - token
+                            - logprob
+                            - bytes
+            required:
+                - token
+                - logprob
+                - bytes
+                - top_logprobs
+
+        ListPaginatedFineTuningJobsResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FineTuningJob"
+                has_more:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [list]
+            required:
+                - object
+                - data
+                - has_more
+
+        CreateChatCompletionStreamResponse:
+            type: object
+            description: Represents a streamed chunk of a chat completion response returned by model, based on the provided input.
+            properties:
+                id:
+                    type: string
+                    description: A unique identifier for the chat completion. Each chunk has the same ID.
+                choices:
+                    type: array
+                    description: |
+                        A list of chat completion choices. Can contain more than one elements if `n` is greater than 1. Can also be empty for the
+                        last chunk if you set `stream_options: {"include_usage": true}`.
+                    items:
+                        type: object
+                        required:
+                            - delta
+                            - finish_reason
+                            - index
+                        properties:
+                            delta:
+                                $ref: "#/components/schemas/ChatCompletionStreamResponseDelta"
+                            logprobs: *chat_completion_response_logprobs
+                            finish_reason:
+                                type: string
+                                description: *chat_completion_finish_reason_description
+                                enum:
+                                    [
+                                        "stop",
+                                        "length",
+                                        "tool_calls",
+                                        "content_filter",
+                                        "function_call",
+                                    ]
+                                nullable: true
+                            index:
+                                type: integer
+                                description: The index of the choice in the list of choices.
+                created:
+                    type: integer
+                    description: The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp.
+                model:
+                    type: string
+                    description: The model to generate the completion.
+                service_tier:
+                    description: The service tier used for processing the request. This field is only included if the `service_tier` parameter is specified in the request.
+                    type: string
+                    enum: ["scale", "default"]
+                    example: "scale"
+                    nullable: true
+                system_fingerprint:
+                    type: string
+                    description: |
+                        This fingerprint represents the backend configuration that the model runs with.
+                        Can be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.
+                object:
+                    type: string
+                    description: The object type, which is always `chat.completion.chunk`.
+                    enum: [chat.completion.chunk]
+                usage:
+                    type: object
+                    description: |
+                        An optional field that will only be present when you set `stream_options: {"include_usage": true}` in your request.
+                        When present, it contains a null value except for the last chunk which contains the token usage statistics for the entire request.
+                    properties:
+                        completion_tokens:
+                            type: integer
+                            description: Number of tokens in the generated completion.
+                        prompt_tokens:
+                            type: integer
+                            description: Number of tokens in the prompt.
+                        total_tokens:
+                            type: integer
+                            description: Total number of tokens used in the request (prompt + completion).
+                    required:
+                        - prompt_tokens
+                        - completion_tokens
+                        - total_tokens
+            required:
+                - choices
+                - created
+                - id
+                - model
+                - object
+            x-oaiMeta:
+                name: The chat completion chunk object
+                group: chat
+                example: *chat_completion_chunk_example
+
+        CreateChatCompletionImageResponse:
+            type: object
+            description: Represents a streamed chunk of a chat completion response returned by model, based on the provided input.
+            x-oaiMeta:
+                name: The chat completion chunk object
+                group: chat
+                example: *chat_completion_image_example
+
+        CreateImageRequest:
+            type: object
+            properties:
+                prompt:
+                    description: A text description of the desired image(s). The maximum length is 1000 characters for `dall-e-2` and 4000 characters for `dall-e-3`.
+                    type: string
+                    example: "A cute baby sea otter"
+                model:
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["dall-e-2", "dall-e-3"]
+                    x-oaiTypeLabel: string
+                    default: "dall-e-2"
+                    example: "dall-e-3"
+                    nullable: true
+                    description: The model to use for image generation.
+                n: &images_n
+                    type: integer
+                    minimum: 1
+                    maximum: 10
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: The number of images to generate. Must be between 1 and 10. For `dall-e-3`, only `n=1` is supported.
+                quality:
+                    type: string
+                    enum: ["standard", "hd"]
+                    default: "standard"
+                    example: "standard"
+                    description: The quality of the image that will be generated. `hd` creates images with finer details and greater consistency across the image. This param is only supported for `dall-e-3`.
+                response_format: &images_response_format
+                    type: string
+                    enum: ["url", "b64_json"]
+                    default: "url"
+                    example: "url"
+                    nullable: true
+                    description: The format in which the generated images are returned. Must be one of `url` or `b64_json`. URLs are only valid for 60 minutes after the image has been generated.
+                size: &images_size
+                    type: string
+                    enum: ["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]
+                    default: "1024x1024"
+                    example: "1024x1024"
+                    nullable: true
+                    description: The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024` for `dall-e-2`. Must be one of `1024x1024`, `1792x1024`, or `1024x1792` for `dall-e-3` models.
+                style:
+                    type: string
+                    enum: ["vivid", "natural"]
+                    default: "vivid"
+                    example: "vivid"
+                    nullable: true
+                    description: The style of the generated images. Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images. This param is only supported for `dall-e-3`.
+                user: *end_user_param_configuration
+            required:
+                - prompt
+
+        ImagesResponse:
+            properties:
+                created:
+                    type: integer
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/Image"
+            required:
+                - created
+                - data
+
+        Image:
+            type: object
+            description: Represents the url or the content of an image generated by the OpenAI API.
+            properties:
+                b64_json:
+                    type: string
+                    description: The base64-encoded JSON of the generated image, if `response_format` is `b64_json`.
+                url:
+                    type: string
+                    description: The URL of the generated image, if `response_format` is `url` (default).
+                revised_prompt:
+                    type: string
+                    description: The prompt that was used to generate the image, if there was any revision to the prompt.
+            x-oaiMeta:
+                name: The image object
+                example: |
+                    {
+                      "url": "...",
+                      "revised_prompt": "..."
+                    }
+
+        CreateImageEditRequest:
+            type: object
+            properties:
+                image:
+                    description: The image to edit. Must be a valid PNG file, less than 4MB, and square. If mask is not provided, image must have transparency, which will be used as the mask.
+                    type: string
+                    format: binary
+                prompt:
+                    description: A text description of the desired image(s). The maximum length is 1000 characters.
+                    type: string
+                    example: "A cute baby sea otter wearing a beret"
+                mask:
+                    description: An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where `image` should be edited. Must be a valid PNG file, less than 4MB, and have the same dimensions as `image`.
+                    type: string
+                    format: binary
+                model:
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["dall-e-2"]
+                    x-oaiTypeLabel: string
+                    default: "dall-e-2"
+                    example: "dall-e-2"
+                    nullable: true
+                    description: The model to use for image generation. Only `dall-e-2` is supported at this time.
+                n:
+                    type: integer
+                    minimum: 1
+                    maximum: 10
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: The number of images to generate. Must be between 1 and 10.
+                size: &dalle2_images_size
+                    type: string
+                    enum: ["256x256", "512x512", "1024x1024"]
+                    default: "1024x1024"
+                    example: "1024x1024"
+                    nullable: true
+                    description: The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`.
+                response_format: *images_response_format
+                user: *end_user_param_configuration
+            required:
+                - prompt
+                - image
+
+        CreateImageVariationRequest:
+            type: object
+            properties:
+                image:
+                    description: The image to use as the basis for the variation(s). Must be a valid PNG file, less than 4MB, and square.
+                    type: string
+                    format: binary
+                model:
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["dall-e-2"]
+                    x-oaiTypeLabel: string
+                    default: "dall-e-2"
+                    example: "dall-e-2"
+                    nullable: true
+                    description: The model to use for image generation. Only `dall-e-2` is supported at this time.
+                n: *images_n
+                response_format: *images_response_format
+                size: *dalle2_images_size
+                user: *end_user_param_configuration
+            required:
+                - image
+
+        CreateModerationRequest:
+            type: object
+            properties:
+                input:
+                    description: The input text to classify
+                    oneOf:
+                        - type: string
+                          default: ""
+                          example: "I want to kill them."
+                        - type: array
+                          items:
+                              type: string
+                              default: ""
+                              example: "I want to kill them."
+                model:
+                    description: |
+                        Two content moderations models are available: `text-moderation-stable` and `text-moderation-latest`.
+
+                        The default is `text-moderation-latest` which will be automatically upgraded over time. This ensures you are always using our most accurate model. If you use `text-moderation-stable`, we will provide advanced notice before updating the model. Accuracy of `text-moderation-stable` may be slightly lower than for `text-moderation-latest`.
+                    nullable: false
+                    default: "text-moderation-latest"
+                    example: "text-moderation-stable"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["text-moderation-latest", "text-moderation-stable"]
+                    x-oaiTypeLabel: string
+            required:
+                - input
+
+        CreateModerationResponse:
+            type: object
+            description: Represents if a given text input is potentially harmful.
+            properties:
+                id:
+                    type: string
+                    description: The unique identifier for the moderation request.
+                model:
+                    type: string
+                    description: The model used to generate the moderation results.
+                results:
+                    type: array
+                    description: A list of moderation objects.
+                    items:
+                        type: object
+                        properties:
+                            flagged:
+                                type: boolean
+                                description: Whether any of the below categories are flagged.
+                            categories:
+                                type: object
+                                description: A list of the categories, and whether they are flagged or not.
+                                properties:
+                                    hate:
+                                        type: boolean
+                                        description: Content that expresses, incites, or promotes hate based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste. Hateful content aimed at non-protected groups (e.g., chess players) is harassment.
+                                    hate/threatening:
+                                        type: boolean
+                                        description: Hateful content that also includes violence or serious harm towards the targeted group based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste.
+                                    harassment:
+                                        type: boolean
+                                        description: Content that expresses, incites, or promotes harassing language towards any target.
+                                    harassment/threatening:
+                                        type: boolean
+                                        description: Harassment content that also includes violence or serious harm towards any target.
+                                    self-harm:
+                                        type: boolean
+                                        description: Content that promotes, encourages, or depicts acts of self-harm, such as suicide, cutting, and eating disorders.
+                                    self-harm/intent:
+                                        type: boolean
+                                        description: Content where the speaker expresses that they are engaging or intend to engage in acts of self-harm, such as suicide, cutting, and eating disorders.
+                                    self-harm/instructions:
+                                        type: boolean
+                                        description: Content that encourages performing acts of self-harm, such as suicide, cutting, and eating disorders, or that gives instructions or advice on how to commit such acts.
+                                    sexual:
+                                        type: boolean
+                                        description: Content meant to arouse sexual excitement, such as the description of sexual activity, or that promotes sexual services (excluding sex education and wellness).
+                                    sexual/minors:
+                                        type: boolean
+                                        description: Sexual content that includes an individual who is under 18 years old.
+                                    violence:
+                                        type: boolean
+                                        description: Content that depicts death, violence, or physical injury.
+                                    violence/graphic:
+                                        type: boolean
+                                        description: Content that depicts death, violence, or physical injury in graphic detail.
+                                required:
+                                    - hate
+                                    - hate/threatening
+                                    - harassment
+                                    - harassment/threatening
+                                    - self-harm
+                                    - self-harm/intent
+                                    - self-harm/instructions
+                                    - sexual
+                                    - sexual/minors
+                                    - violence
+                                    - violence/graphic
+                            category_scores:
+                                type: object
+                                description: A list of the categories along with their scores as predicted by model.
+                                properties:
+                                    hate:
+                                        type: number
+                                        description: The score for the category 'hate'.
+                                    hate/threatening:
+                                        type: number
+                                        description: The score for the category 'hate/threatening'.
+                                    harassment:
+                                        type: number
+                                        description: The score for the category 'harassment'.
+                                    harassment/threatening:
+                                        type: number
+                                        description: The score for the category 'harassment/threatening'.
+                                    self-harm:
+                                        type: number
+                                        description: The score for the category 'self-harm'.
+                                    self-harm/intent:
+                                        type: number
+                                        description: The score for the category 'self-harm/intent'.
+                                    self-harm/instructions:
+                                        type: number
+                                        description: The score for the category 'self-harm/instructions'.
+                                    sexual:
+                                        type: number
+                                        description: The score for the category 'sexual'.
+                                    sexual/minors:
+                                        type: number
+                                        description: The score for the category 'sexual/minors'.
+                                    violence:
+                                        type: number
+                                        description: The score for the category 'violence'.
+                                    violence/graphic:
+                                        type: number
+                                        description: The score for the category 'violence/graphic'.
+                                required:
+                                    - hate
+                                    - hate/threatening
+                                    - harassment
+                                    - harassment/threatening
+                                    - self-harm
+                                    - self-harm/intent
+                                    - self-harm/instructions
+                                    - sexual
+                                    - sexual/minors
+                                    - violence
+                                    - violence/graphic
+                        required:
+                            - flagged
+                            - categories
+                            - category_scores
+            required:
+                - id
+                - model
+                - results
+            x-oaiMeta:
+                name: The moderation object
+                example: *moderation_example
+
+        ListFilesResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/OpenAIFile"
+                object:
+                    type: string
+                    enum: [list]
+            required:
+                - object
+                - data
+
+        CreateFileRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file:
+                    description: |
+                        The File object (not file name) to be uploaded.
+                    type: string
+                    format: binary
+                purpose:
+                    description: |
+                        The intended purpose of the uploaded file.
+
+                        Use "assistants" for [Assistants](/docs/api-reference/assistants) and [Message](/docs/api-reference/messages) files, "vision" for Assistants image file inputs, "batch" for [Batch API](/docs/guides/batch), and "fine-tune" for [Fine-tuning](/docs/api-reference/fine-tuning).
+                    type: string
+                    enum: ["assistants", "batch", "fine-tune", "vision"]
+            required:
+                - file
+                - purpose
+
+        DeleteFileResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                object:
+                    type: string
+                    enum: [file]
+                deleted:
+                    type: boolean
+            required:
+                - id
+                - object
+                - deleted
+
+        CreateUploadRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                filename:
+                    description: |
+                        The name of the file to upload.
+                    type: string
+                purpose:
+                    description: |
+                        The intended purpose of the uploaded file.
+            
+                        See the [documentation on File purposes](/docs/api-reference/files/create#files-create-purpose).
+                    type: string
+                    enum: ["assistants", "batch", "fine-tune", "vision"]
+                bytes:
+                    description: |
+                        The number of bytes in the file you are uploading.
+                    type: integer
+                mime_type:
+                    description: |
+                        The MIME type of the file.
+                        
+                        This must fall within the supported MIME types for your file purpose. See the supported MIME types for assistants and vision.
+                    type: string
+            required:
+                - filename
+                - purpose
+                - bytes
+                - mime_type
+
+        AddUploadPartRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                data:
+                    description: |
+                        The chunk of bytes for this Part.
+                    type: string
+                    format: binary
+            required:
+                - data
+
+        CompleteUploadRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                part_ids:
+                    type: array
+                    description: |
+                        The ordered list of Part IDs.
+                    items:
+                        type: string
+                md5:
+                    description: |
+                        The optional md5 checksum for the file contents to verify if the bytes uploaded matches what you expect.
+                    type: string
+            required:
+                - part_ids
+
+        CancelUploadRequest:
+            type: object
+            additionalProperties: false
+
+        CreateFineTuningJobRequest:
+            type: object
+            properties:
+                model:
+                    description: |
+                        The name of the model to fine-tune. You can select one of the
+                        [supported models](/docs/guides/fine-tuning/what-models-can-be-fine-tuned).
+                    example: "gpt-3.5-turbo"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["babbage-002", "davinci-002", "gpt-3.5-turbo"]
+                    x-oaiTypeLabel: string
+                training_file:
+                    description: |
+                        The ID of an uploaded file that contains training data.
+
+                        See [upload file](/docs/api-reference/files/create) for how to upload a file.
+
+                        Your dataset must be formatted as a JSONL file. Additionally, you must upload your file with the purpose `fine-tune`.
+
+                        The contents of the file should differ depending on if the model uses the [chat](/docs/api-reference/fine-tuning/chat-input) or [completions](/docs/api-reference/fine-tuning/completions-input) format.
+
+                        See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.
+                    type: string
+                    example: "file-abc123"
+                hyperparameters:
+                    type: object
+                    description: The hyperparameters used for the fine-tuning job.
+                    properties:
+                        batch_size:
+                            description: |
+                                Number of examples in each batch. A larger batch size means that model parameters
+                                are updated less frequently, but with lower variance.
+                            oneOf:
+                                - type: string
+                                  enum: [auto]
+                                - type: integer
+                                  minimum: 1
+                                  maximum: 256
+                            default: auto
+                        learning_rate_multiplier:
+                            description: |
+                                Scaling factor for the learning rate. A smaller learning rate may be useful to avoid
+                                overfitting.
+                            oneOf:
+                                - type: string
+                                  enum: [auto]
+                                - type: number
+                                  minimum: 0
+                                  exclusiveMinimum: true
+                            default: auto
+                        n_epochs:
+                            description: |
+                                The number of epochs to train the model for. An epoch refers to one full cycle
+                                through the training dataset.
+                            oneOf:
+                                - type: string
+                                  enum: [auto]
+                                - type: integer
+                                  minimum: 1
+                                  maximum: 50
+                            default: auto
+                suffix:
+                    description: |
+                        A string of up to 18 characters that will be added to your fine-tuned model name.
+
+                        For example, a `suffix` of "custom-model-name" would produce a model name like `ft:gpt-3.5-turbo:openai:custom-model-name:7p4lURel`.
+                    type: string
+                    minLength: 1
+                    maxLength: 40
+                    default: null
+                    nullable: true
+                validation_file:
+                    description: |
+                        The ID of an uploaded file that contains validation data.
+
+                        If you provide this file, the data is used to generate validation
+                        metrics periodically during fine-tuning. These metrics can be viewed in
+                        the fine-tuning results file.
+                        The same data should not be present in both train and validation files.
+
+                        Your dataset must be formatted as a JSONL file. You must upload your file with the purpose `fine-tune`.
+
+                        See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.
+                    type: string
+                    nullable: true
+                    example: "file-abc123"
+                integrations:
+                    type: array
+                    description: A list of integrations to enable for your fine-tuning job.
+                    nullable: true
+                    items:
+                        type: object
+                        required:
+                            - type
+                            - wandb
+                        properties:
+                            type:
+                                description: |
+                                    The type of integration to enable. Currently, only "wandb" (Weights and Biases) is supported.
+                                oneOf:
+                                    - type: string
+                                      enum: [wandb]
+                            wandb:
+                                type: object
+                                description: |
+                                    The settings for your integration with Weights and Biases. This payload specifies the project that
+                                    metrics will be sent to. Optionally, you can set an explicit display name for your run, add tags
+                                    to your run, and set a default entity (team, username, etc) to be associated with your run.
+                                required:
+                                    - project
+                                properties:
+                                    project:
+                                        description: |
+                                            The name of the project that the new run will be created under.
+                                        type: string
+                                        example: "my-wandb-project"
+                                    name:
+                                        description: |
+                                            A display name to set for the run. If not set, we will use the Job ID as the name.
+                                        nullable: true
+                                        type: string
+                                    entity:
+                                        description: |
+                                            The entity to use for the run. This allows you to set the team or username of the WandB user that you would
+                                            like associated with the run. If not set, the default entity for the registered WandB API key is used.
+                                        nullable: true
+                                        type: string
+                                    tags:
+                                        description: |
+                                            A list of tags to be attached to the newly created run. These tags are passed through directly to WandB. Some
+                                            default tags are generated by OpenAI: "openai/finetune", "openai/{base-model}", "openai/{ftjob-abcdef}".
+                                        type: array
+                                        items:
+                                            type: string
+                                            example: "custom-tag"
+
+                seed:
+                    description: |
+                        The seed controls the reproducibility of the job. Passing in the same seed and job parameters should produce the same results, but may differ in rare cases.
+                        If a seed is not specified, one will be generated for you.
+                    type: integer
+                    nullable: true
+                    minimum: 0
+                    maximum: 2147483647
+                    example: 42
+            required:
+                - model
+                - training_file
+
+        ListFineTuningJobEventsResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FineTuningJobEvent"
+                object:
+                    type: string
+                    enum: [list]
+            required:
+                - object
+                - data
+
+        ListFineTuningJobCheckpointsResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FineTuningJobCheckpoint"
+                object:
+                    type: string
+                    enum: [list]
+                first_id:
+                    type: string
+                    nullable: true
+                last_id:
+                    type: string
+                    nullable: true
+                has_more:
+                    type: boolean
+            required:
+                - object
+                - data
+                - has_more
+
+        CreateEmbeddingRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                input:
+                    description: |
+                        Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `text-embedding-ada-002`), cannot be an empty string, and any array must be 2048 dimensions or less. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
+                    example: "The quick brown fox jumped over the lazy dog"
+                    oneOf:
+                        - type: string
+                          title: string
+                          description: The string that will be turned into an embedding.
+                          default: ""
+                          example: "This is a test."
+                        - type: array
+                          title: array
+                          description: The array of strings that will be turned into an embedding.
+                          minItems: 1
+                          maxItems: 2048
+                          items:
+                              type: string
+                              default: ""
+                              example: "['This is a test.']"
+                        - type: array
+                          title: array
+                          description: The array of integers that will be turned into an embedding.
+                          minItems: 1
+                          maxItems: 2048
+                          items:
+                              type: integer
+                          example: "[1212, 318, 257, 1332, 13]"
+                        - type: array
+                          title: array
+                          description: The array of arrays containing integers that will be turned into an embedding.
+                          minItems: 1
+                          maxItems: 2048
+                          items:
+                              type: array
+                              minItems: 1
+                              items:
+                                  type: integer
+                          example: "[[1212, 318, 257, 1332, 13]]"
+                    x-oaiExpandable: true
+                model:
+                    description: *model_description
+                    example: "text-embedding-3-small"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "text-embedding-ada-002",
+                                  "text-embedding-3-small",
+                                  "text-embedding-3-large",
+                              ]
+                    x-oaiTypeLabel: string
+                encoding_format:
+                    description: "The format to return the embeddings in. Can be either `float` or [`base64`](https://pypi.org/project/pybase64/)."
+                    example: "float"
+                    default: "float"
+                    type: string
+                    enum: ["float", "base64"]
+                dimensions:
+                    description: |
+                        The number of dimensions the resulting output embeddings should have. Only supported in `text-embedding-3` and later models.
+                    type: integer
+                    minimum: 1
+                user: *end_user_param_configuration
+            required:
+                - model
+                - input
+
+        CreateEmbeddingResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    description: The list of embeddings generated by the model.
+                    items:
+                        $ref: "#/components/schemas/Embedding"
+                model:
+                    type: string
+                    description: The name of the model used to generate the embedding.
+                object:
+                    type: string
+                    description: The object type, which is always "list".
+                    enum: [list]
+                usage:
+                    type: object
+                    description: The usage information for the request.
+                    properties:
+                        prompt_tokens:
+                            type: integer
+                            description: The number of tokens used by the prompt.
+                        total_tokens:
+                            type: integer
+                            description: The total number of tokens used by the request.
+                    required:
+                        - prompt_tokens
+                        - total_tokens
+            required:
+                - object
+                - model
+                - data
+                - usage
+
+        CreateTranscriptionRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file:
+                    description: |
+                        The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+                    type: string
+                    x-oaiTypeLabel: file
+                    format: binary
+                model:
+                    description: |
+                        ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.
+                    example: whisper-1
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["whisper-1"]
+                    x-oaiTypeLabel: string
+                language:
+                    description: |
+                        The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format will improve accuracy and latency.
+                    type: string
+                prompt:
+                    description: |
+                        An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text/prompting) should match the audio language.
+                    type: string
+                response_format:
+                    description: |
+                        The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.
+                    type: string
+                    enum:
+                        - json
+                        - text
+                        - srt
+                        - verbose_json
+                        - vtt
+                    default: json
+                temperature:
+                    description: |
+                        The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.
+                    type: number
+                    default: 0
+                timestamp_granularities[]:
+                    description: |
+                        The timestamp granularities to populate for this transcription. `response_format` must be set `verbose_json` to use timestamp granularities. Either or both of these options are supported: `word`, or `segment`. Note: There is no additional latency for segment timestamps, but generating word timestamps incurs additional latency.
+                    type: array
+                    items:
+                        type: string
+                        enum:
+                            - word
+                            - segment
+                    default: [segment]
+            required:
+                - file
+                - model
+
+        # Note: This does not currently support the non-default response format types.
+        CreateTranscriptionResponseJson:
+            type: object
+            description: Represents a transcription response returned by model, based on the provided input.
+            properties:
+                text:
+                    type: string
+                    description: The transcribed text.
+            required:
+                - text
+            x-oaiMeta:
+                name: The transcription object (JSON)
+                group: audio
+                example: *basic_transcription_response_example
+
+        TranscriptionSegment:
+            type: object
+            properties:
+                id:
+                    type: integer
+                    description: Unique identifier of the segment.
+                seek:
+                    type: integer
+                    description: Seek offset of the segment.
+                start:
+                    type: number
+                    format: float
+                    description: Start time of the segment in seconds.
+                end:
+                    type: number
+                    format: float
+                    description: End time of the segment in seconds.
+                text:
+                    type: string
+                    description: Text content of the segment.
+                tokens:
+                    type: array
+                    items:
+                        type: integer
+                    description: Array of token IDs for the text content.
+                temperature:
+                    type: number
+                    format: float
+                    description: Temperature parameter used for generating the segment.
+                avg_logprob:
+                    type: number
+                    format: float
+                    description: Average logprob of the segment. If the value is lower than -1, consider the logprobs failed.
+                compression_ratio:
+                    type: number
+                    format: float
+                    description: Compression ratio of the segment. If the value is greater than 2.4, consider the compression failed.
+                no_speech_prob:
+                    type: number
+                    format: float
+                    description: Probability of no speech in the segment. If the value is higher than 1.0 and the `avg_logprob` is below -1, consider this segment silent.
+            required:
+                - id
+                - seek
+                - start
+                - end
+                - text
+                - tokens
+                - temperature
+                - avg_logprob
+                - compression_ratio
+                - no_speech_prob
+
+        TranscriptionWord:
+            type: object
+            properties:
+                word:
+                    type: string
+                    description: The text content of the word.
+                start:
+                    type: number
+                    format: float
+                    description: Start time of the word in seconds.
+                end:
+                    type: number
+                    format: float
+                    description: End time of the word in seconds.
+            required: [word, start, end]
+
+        CreateTranscriptionResponseVerboseJson:
+            type: object
+            description: Represents a verbose json transcription response returned by model, based on the provided input.
+            properties:
+                language:
+                    type: string
+                    description: The language of the input audio.
+                duration:
+                    type: string
+                    description: The duration of the input audio.
+                text:
+                    type: string
+                    description: The transcribed text.
+                words:
+                    type: array
+                    description: Extracted words and their corresponding timestamps.
+                    items:
+                        $ref: "#/components/schemas/TranscriptionWord"
+                segments:
+                    type: array
+                    description: Segments of the transcribed text and their corresponding details.
+                    items:
+                        $ref: "#/components/schemas/TranscriptionSegment"
+            required: [language, duration, text]
+            x-oaiMeta:
+                name: The transcription object (Verbose JSON)
+                group: audio
+                example: *verbose_transcription_response_example
+
+        CreateTranslationRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file:
+                    description: |
+                        The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+                    type: string
+                    x-oaiTypeLabel: file
+                    format: binary
+                model:
+                    description: |
+                        ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.
+                    example: whisper-1
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["whisper-1"]
+                    x-oaiTypeLabel: string
+                prompt:
+                    description: |
+                        An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text/prompting) should be in English.
+                    type: string
+                response_format:
+                    description: |
+                        The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.
+                    type: string
+                    default: json
+                temperature:
+                    description: |
+                        The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.
+                    type: number
+                    default: 0
+            required:
+                - file
+                - model
+
+        # Note: This does not currently support the non-default response format types.
+        CreateTranslationResponseJson:
+            type: object
+            properties:
+                text:
+                    type: string
+            required:
+                - text
+
+        CreateTranslationResponseVerboseJson:
+            type: object
+            properties:
+                language:
+                    type: string
+                    description: The language of the output translation (always `english`).
+                duration:
+                    type: string
+                    description: The duration of the input audio.
+                text:
+                    type: string
+                    description: The translated text.
+                segments:
+                    type: array
+                    description: Segments of the translated text and their corresponding details.
+                    items:
+                        $ref: "#/components/schemas/TranscriptionSegment"
+            required: [language, duration, text]
+
+        CreateSpeechRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                model:
+                    description: |
+                        One of the available [TTS models](/docs/models/tts): `tts-1` or `tts-1-hd`
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["tts-1", "tts-1-hd"]
+                    x-oaiTypeLabel: string
+                input:
+                    type: string
+                    description: The text to generate audio for. The maximum length is 4096 characters.
+                    maxLength: 4096
+                voice:
+                    description: The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`. Previews of the voices are available in the [Text to speech guide](/docs/guides/text-to-speech/voice-options).
+                    type: string
+                    enum: ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
+                response_format:
+                    description: "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`."
+                    default: "mp3"
+                    type: string
+                    enum: ["mp3", "opus", "aac", "flac", "wav", "pcm"]
+                speed:
+                    description: "The speed of the generated audio. Select a value from `0.25` to `4.0`. `1.0` is the default."
+                    type: number
+                    default: 1.0
+                    minimum: 0.25
+                    maximum: 4.0
+            required:
+                - model
+                - input
+                - voice
+
+        Model:
+            title: Model
+            description: Describes an OpenAI model offering that can be used with the API.
+            properties:
+                id:
+                    type: string
+                    description: The model identifier, which can be referenced in the API endpoints.
+                created:
+                    type: integer
+                    description: The Unix timestamp (in seconds) when the model was created.
+                object:
+                    type: string
+                    description: The object type, which is always "model".
+                    enum: [model]
+                owned_by:
+                    type: string
+                    description: The organization that owns the model.
+            required:
+                - id
+                - object
+                - created
+                - owned_by
+            x-oaiMeta:
+                name: The model object
+                example: *retrieve_model_response
+
+        OpenAIFile:
+            title: OpenAIFile
+            description: The `File` object represents a document that has been uploaded to OpenAI.
+            properties:
+                id:
+                    type: string
+                    description: The file identifier, which can be referenced in the API endpoints.
+                bytes:
+                    type: integer
+                    description: The size of the file, in bytes.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the file was created.
+                filename:
+                    type: string
+                    description: The name of the file.
+                object:
+                    type: string
+                    description: The object type, which is always `file`.
+                    enum: ["file"]
+                purpose:
+                    type: string
+                    description: The intended purpose of the file. Supported values are `assistants`, `assistants_output`, `batch`, `batch_output`, `fine-tune`, `fine-tune-results` and `vision`.
+                    enum:
+                        [
+                            "assistants",
+                            "assistants_output",
+                            "batch",
+                            "batch_output",
+                            "fine-tune",
+                            "fine-tune-results",
+                            "vision",
+                        ]
+                status:
+                    type: string
+                    deprecated: true
+                    description: Deprecated. The current status of the file, which can be either `uploaded`, `processed`, or `error`.
+                    enum: ["uploaded", "processed", "error"]
+                status_details:
+                    type: string
+                    deprecated: true
+                    description: Deprecated. For details on why a fine-tuning training file failed validation, see the `error` field on `fine_tuning.job`.
+            required:
+                - id
+                - object
+                - bytes
+                - created_at
+                - filename
+                - purpose
+                - status
+            x-oaiMeta:
+                name: The file object
+                example: |
+                    {
+                      "id": "file-abc123",
+                      "object": "file",
+                      "bytes": 120000,
+                      "created_at": 1677610602,
+                      "filename": "salesOverview.pdf",
+                      "purpose": "assistants",
+                    }
+        Upload:
+            type: object
+            title: Upload
+            description: |
+                The Upload object can accept byte chunks in the form of Parts.
+            properties:
+                id:
+                    type: string
+                    description: The Upload unique identifier, which can be referenced in API endpoints.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the Upload was created.
+                filename:
+                    type: string
+                    description: The name of the file to be uploaded.
+                bytes:
+                    type: integer
+                    description: The intended number of bytes to be uploaded.
+                purpose:
+                    type: string
+                    description: The intended purpose of the file. [Please refer here](/docs/api-reference/files/object#files/object-purpose) for acceptable values.
+                status:
+                    type: string
+                    description: The status of the Upload.
+                    enum: ["pending", "completed", "cancelled", "expired"]
+                expires_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the Upload was created.
+                object:
+                    type: string
+                    description: The object type, which is always "upload".
+                    enum: [upload]
+                file: 
+                    $ref: "#/components/schemas/OpenAIFile"
+                    nullable: true
+                    description: The ready File object after the Upload is completed.
+            required:
+                - bytes
+                - created_at
+                - expires_at
+                - filename
+                - id
+                - purpose
+                - status
+                - step_number
+            x-oaiMeta:
+                name: The upload object
+                example: |
+                    {
+                      "id": "upload_abc123",
+                      "object": "upload",
+                      "bytes": 2147483648,
+                      "created_at": 1719184911,
+                      "filename": "training_examples.jsonl",
+                      "purpose": "fine-tune",
+                      "status": "completed",
+                      "expires_at": 1719127296,
+                      "file": {
+                        "id": "file-xyz321",
+                        "object": "file",
+                        "bytes": 2147483648,
+                        "created_at": 1719186911,
+                        "filename": "training_examples.jsonl",
+                        "purpose": "fine-tune",
+                      }
+                    }
+        UploadPart:
+            type: object
+            title: UploadPart
+            description: |
+                The upload Part represents a chunk of bytes we can add to an Upload object.
+            properties:
+                id:
+                    type: string
+                    description: The upload Part unique identifier, which can be referenced in API endpoints.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the Part was created.
+                upload_id:
+                    type: string
+                    description: The ID of the Upload object that this Part was added to.
+                object:
+                    type: string
+                    description: The object type, which is always `upload.part`.
+                    enum: ['upload.part']
+            required:
+                - created_at
+                - id
+                - object
+                - upload_id
+            x-oaiMeta:
+                name: The upload part object
+                example: |
+                    {
+                        "id": "part_def456",
+                        "object": "upload.part",
+                        "created_at": 1719186911,
+                        "upload_id": "upload_abc123"
+                    }
+        Embedding:
+            type: object
+            description: |
+                Represents an embedding vector returned by embedding endpoint.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the embedding in the list of embeddings.
+                embedding:
+                    type: array
+                    description: |
+                        The embedding vector, which is a list of floats. The length of vector depends on the model as listed in the [embedding guide](/docs/guides/embeddings).
+                    items:
+                        type: number
+                object:
+                    type: string
+                    description: The object type, which is always "embedding".
+                    enum: [embedding]
+            required:
+                - index
+                - object
+                - embedding
+            x-oaiMeta:
+                name: The embedding object
+                example: |
+                    {
+                      "object": "embedding",
+                      "embedding": [
+                        0.0023064255,
+                        -0.009327292,
+                        .... (1536 floats total for ada-002)
+                        -0.0028842222,
+                      ],
+                      "index": 0
+                    }
+
+        FineTuningJob:
+            type: object
+            title: FineTuningJob
+            description: |
+                The `fine_tuning.job` object represents a fine-tuning job that has been created through the API.
+            properties:
+                id:
+                    type: string
+                    description: The object identifier, which can be referenced in the API endpoints.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the fine-tuning job was created.
+                error:
+                    type: object
+                    nullable: true
+                    description: For fine-tuning jobs that have `failed`, this will contain more information on the cause of the failure.
+                    properties:
+                        code:
+                            type: string
+                            description: A machine-readable error code.
+                        message:
+                            type: string
+                            description: A human-readable error message.
+                        param:
+                            type: string
+                            description: The parameter that was invalid, usually `training_file` or `validation_file`. This field will be null if the failure was not parameter-specific.
+                            nullable: true
+                    required:
+                        - code
+                        - message
+                        - param
+                fine_tuned_model:
+                    type: string
+                    nullable: true
+                    description: The name of the fine-tuned model that is being created. The value will be null if the fine-tuning job is still running.
+                finished_at:
+                    type: integer
+                    nullable: true
+                    description: The Unix timestamp (in seconds) for when the fine-tuning job was finished. The value will be null if the fine-tuning job is still running.
+                hyperparameters:
+                    type: object
+                    description: The hyperparameters used for the fine-tuning job. See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.
+                    properties:
+                        n_epochs:
+                            oneOf:
+                                - type: string
+                                  enum: [auto]
+                                - type: integer
+                                  minimum: 1
+                                  maximum: 50
+                            default: auto
+                            description:
+                                The number of epochs to train the model for. An epoch refers to one full cycle through the training dataset.
+
+                                "auto" decides the optimal number of epochs based on the size of the dataset. If setting the number manually, we support any number between 1 and 50 epochs.
+                    required:
+                        - n_epochs
+                model:
+                    type: string
+                    description: The base model that is being fine-tuned.
+                object:
+                    type: string
+                    description: The object type, which is always "fine_tuning.job".
+                    enum: [fine_tuning.job]
+                organization_id:
+                    type: string
+                    description: The organization that owns the fine-tuning job.
+                result_files:
+                    type: array
+                    description: The compiled results file ID(s) for the fine-tuning job. You can retrieve the results with the [Files API](/docs/api-reference/files/retrieve-contents).
+                    items:
+                        type: string
+                        example: file-abc123
+                status:
+                    type: string
+                    description: The current status of the fine-tuning job, which can be either `validating_files`, `queued`, `running`, `succeeded`, `failed`, or `cancelled`.
+                    enum:
+                        [
+                            "validating_files",
+                            "queued",
+                            "running",
+                            "succeeded",
+                            "failed",
+                            "cancelled",
+                        ]
+                trained_tokens:
+                    type: integer
+                    nullable: true
+                    description: The total number of billable tokens processed by this fine-tuning job. The value will be null if the fine-tuning job is still running.
+                training_file:
+                    type: string
+                    description: The file ID used for training. You can retrieve the training data with the [Files API](/docs/api-reference/files/retrieve-contents).
+                validation_file:
+                    type: string
+                    nullable: true
+                    description: The file ID used for validation. You can retrieve the validation results with the [Files API](/docs/api-reference/files/retrieve-contents).
+                integrations:
+                    type: array
+                    nullable: true
+                    description: A list of integrations to enable for this fine-tuning job.
+                    maxItems: 5
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/FineTuningIntegration"
+                        x-oaiExpandable: true
+                seed:
+                    type: integer
+                    description: The seed used for the fine-tuning job.
+                estimated_finish:
+                    type: integer
+                    nullable: true
+                    description: The Unix timestamp (in seconds) for when the fine-tuning job is estimated to finish. The value will be null if the fine-tuning job is not running.
+            required:
+                - created_at
+                - error
+                - finished_at
+                - fine_tuned_model
+                - hyperparameters
+                - id
+                - model
+                - object
+                - organization_id
+                - result_files
+                - status
+                - trained_tokens
+                - training_file
+                - validation_file
+                - seed
+            x-oaiMeta:
+                name: The fine-tuning job object
+                example: *fine_tuning_example
+
+        FineTuningIntegration:
+            type: object
+            title: Fine-Tuning Job Integration
+            required:
+                - type
+                - wandb
+            properties:
+                type:
+                    type: string
+                    description: "The type of the integration being enabled for the fine-tuning job"
+                    enum: ["wandb"]
+                wandb:
+                    type: object
+                    description: |
+                        The settings for your integration with Weights and Biases. This payload specifies the project that
+                        metrics will be sent to. Optionally, you can set an explicit display name for your run, add tags
+                        to your run, and set a default entity (team, username, etc) to be associated with your run.
+                    required:
+                        - project
+                    properties:
+                        project:
+                            description: |
+                                The name of the project that the new run will be created under.
+                            type: string
+                            example: "my-wandb-project"
+                        name:
+                            description: |
+                                A display name to set for the run. If not set, we will use the Job ID as the name.
+                            nullable: true
+                            type: string
+                        entity:
+                            description: |
+                                The entity to use for the run. This allows you to set the team or username of the WandB user that you would
+                                like associated with the run. If not set, the default entity for the registered WandB API key is used.
+                            nullable: true
+                            type: string
+                        tags:
+                            description: |
+                                A list of tags to be attached to the newly created run. These tags are passed through directly to WandB. Some
+                                default tags are generated by OpenAI: "openai/finetune", "openai/{base-model}", "openai/{ftjob-abcdef}".
+                            type: array
+                            items:
+                                type: string
+                                example: "custom-tag"
+
+        FineTuningJobEvent:
+            type: object
+            description: Fine-tuning job event object
+            properties:
+                id:
+                    type: string
+                created_at:
+                    type: integer
+                level:
+                    type: string
+                    enum: ["info", "warn", "error"]
+                message:
+                    type: string
+                object:
+                    type: string
+                    enum: [fine_tuning.job.event]
+            required:
+                - id
+                - object
+                - created_at
+                - level
+                - message
+            x-oaiMeta:
+                name: The fine-tuning job event object
+                example: |
+                    {
+                      "object": "fine_tuning.job.event",
+                      "id": "ftevent-abc123"
+                      "created_at": 1677610602,
+                      "level": "info",
+                      "message": "Created fine-tuning job"
+                    }
+
+        FineTuningJobCheckpoint:
+            type: object
+            title: FineTuningJobCheckpoint
+            description: |
+                The `fine_tuning.job.checkpoint` object represents a model checkpoint for a fine-tuning job that is ready to use.
+            properties:
+                id:
+                    type: string
+                    description: The checkpoint identifier, which can be referenced in the API endpoints.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the checkpoint was created.
+                fine_tuned_model_checkpoint:
+                    type: string
+                    description: The name of the fine-tuned checkpoint model that is created.
+                step_number:
+                    type: integer
+                    description: The step number that the checkpoint was created at.
+                metrics:
+                    type: object
+                    description: Metrics at the step number during the fine-tuning job.
+                    properties:
+                        step:
+                            type: number
+                        train_loss:
+                            type: number
+                        train_mean_token_accuracy:
+                            type: number
+                        valid_loss:
+                            type: number
+                        valid_mean_token_accuracy:
+                            type: number
+                        full_valid_loss:
+                            type: number
+                        full_valid_mean_token_accuracy:
+                            type: number
+                fine_tuning_job_id:
+                    type: string
+                    description: The name of the fine-tuning job that this checkpoint was created from.
+                object:
+                    type: string
+                    description: The object type, which is always "fine_tuning.job.checkpoint".
+                    enum: [fine_tuning.job.checkpoint]
+            required:
+                - created_at
+                - fine_tuning_job_id
+                - fine_tuned_model_checkpoint
+                - id
+                - metrics
+                - object
+                - step_number
+            x-oaiMeta:
+                name: The fine-tuning job checkpoint object
+                example: |
+                    {
+                      "object": "fine_tuning.job.checkpoint",
+                      "id": "ftckpt_qtZ5Gyk4BLq1SfLFWp3RtO3P",
+                      "created_at": 1712211699,
+                      "fine_tuned_model_checkpoint": "ft:gpt-3.5-turbo-0125:my-org:custom_suffix:9ABel2dg:ckpt-step-88",
+                      "fine_tuning_job_id": "ftjob-fpbNQ3H1GrMehXRf8cO97xTN",
+                      "metrics": {
+                        "step": 88,
+                        "train_loss": 0.478,
+                        "train_mean_token_accuracy": 0.924,
+                        "valid_loss": 10.112,
+                        "valid_mean_token_accuracy": 0.145,
+                        "full_valid_loss": 0.567,
+                        "full_valid_mean_token_accuracy": 0.944
+                      },
+                      "step_number": 88
+                    }
+
+        FinetuneChatRequestInput:
+            type: object
+            description: The per-line training example of a fine-tuning input file for chat models
+            properties:
+                messages:
+                    type: array
+                    minItems: 1
+                    items:
+                      oneOf:
+                      - $ref: "#/components/schemas/ChatCompletionRequestSystemMessage"
+                      - $ref: "#/components/schemas/ChatCompletionRequestUserMessage"
+                      - $ref: "#/components/schemas/FineTuneChatCompletionRequestAssistantMessage"
+                      - $ref: "#/components/schemas/ChatCompletionRequestToolMessage"
+                      - $ref: "#/components/schemas/ChatCompletionRequestFunctionMessage"
+                      x-oaiExpandable: true
+                tools:
+                    type: array
+                    description: A list of tools the model may generate JSON inputs for.
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionTool"
+                parallel_tool_calls:
+                    $ref: "#/components/schemas/ParallelToolCalls"
+                functions:
+                    deprecated: true
+                    description:
+                        A list of functions the model may generate JSON inputs for.
+                    type: array
+                    minItems: 1
+                    maxItems: 128
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionFunctions"
+            x-oaiMeta:
+                name: Training format for chat models
+                example: |
+                  {
+                    "messages": [
+                      { "role": "user", "content": "What is the weather in San Francisco?" },
+                      {
+                        "role": "assistant",
+                        "tool_calls": [
+                          {
+                            "id": "call_id",
+                            "type": "function",
+                            "function": {
+                              "name": "get_current_weather",
+                              "arguments": "{\"location\": \"San Francisco, USA\", \"format\": \"celsius\"}"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "parallel_tool_calls": false,
+                    "tools": [
+                      {
+                        "type": "function",
+                        "function": {
+                          "name": "get_current_weather",
+                          "description": "Get the current weather",
+                          "parameters": {
+                            "type": "object",
+                            "properties": {
+                              "location": {
+                                  "type": "string",
+                                  "description": "The city and country, eg. San Francisco, USA"
+                              },
+                              "format": { "type": "string", "enum": ["celsius", "fahrenheit"] }
+                            },
+                            "required": ["location", "format"]
+                          }
+                        }
+                      }
+                    ]
+                  }
+        
+        FinetuneCompletionRequestInput:
+            type: object
+            description: The per-line training example of a fine-tuning input file for completions models
+            properties:
+                prompt:
+                    type: string
+                    description: The input prompt for this training example.
+                completion:
+                    type: string
+                    description: The desired completion for this training example.
+            x-oaiMeta:
+                name: Training format for completions models
+                example: |
+                    {
+                      "prompt": "What is the answer to 2+2",
+                      "completion": "4"
+                    }
+
+        CompletionUsage:
+            type: object
+            description: Usage statistics for the completion request.
+            properties:
+                completion_tokens:
+                    type: integer
+                    description: Number of tokens in the generated completion.
+                prompt_tokens:
+                    type: integer
+                    description: Number of tokens in the prompt.
+                total_tokens:
+                    type: integer
+                    description: Total number of tokens used in the request (prompt + completion).
+            required:
+                - prompt_tokens
+                - completion_tokens
+                - total_tokens
+
+        RunCompletionUsage:
+            type: object
+            description: Usage statistics related to the run. This value will be `null` if the run is not in a terminal state (i.e. `in_progress`, `queued`, etc.).
+            properties:
+                completion_tokens:
+                    type: integer
+                    description: Number of completion tokens used over the course of the run.
+                prompt_tokens:
+                    type: integer
+                    description: Number of prompt tokens used over the course of the run.
+                total_tokens:
+                    type: integer
+                    description: Total number of tokens used (prompt + completion).
+            required:
+                - prompt_tokens
+                - completion_tokens
+                - total_tokens
+            nullable: true
+
+        RunStepCompletionUsage:
+            type: object
+            description: Usage statistics related to the run step. This value will be `null` while the run step's status is `in_progress`.
+            properties:
+                completion_tokens:
+                    type: integer
+                    description: Number of completion tokens used over the course of the run step.
+                prompt_tokens:
+                    type: integer
+                    description: Number of prompt tokens used over the course of the run step.
+                total_tokens:
+                    type: integer
+                    description: Total number of tokens used (prompt + completion).
+            required:
+                - prompt_tokens
+                - completion_tokens
+                - total_tokens
+            nullable: true
+
+        AssistantsApiResponseFormatOption:
+            description: |
+                Specifies the format that the model must output. Compatible with [GPT-4o](/docs/models/gpt-4o), [GPT-4 Turbo](/docs/models/gpt-4-turbo-and-gpt-4), and all GPT-3.5 Turbo models since `gpt-3.5-turbo-1106`.
+
+                Setting to `{ "type": "json_object" }` enables JSON mode, which guarantees the message the model generates is valid JSON.
+
+                **Important:** when using JSON mode, you **must** also instruct the model to produce JSON yourself via a system or user message. Without this, the model may generate an unending stream of whitespace until the generation reaches the token limit, resulting in a long-running and seemingly "stuck" request. Also note that the message content may be partially cut off if `finish_reason="length"`, which indicates the generation exceeded `max_tokens` or the conversation exceeded the max context length.
+            oneOf:
+                - type: string
+                  description: >
+                      `auto` is the default value
+                  enum: [none, auto]
+                - $ref: "#/components/schemas/AssistantsApiResponseFormat"
+            x-oaiExpandable: true
+
+        AssistantsApiResponseFormat:
+            type: object
+            description: |
+                An object describing the expected output of the model. If `json_object` only `function` type `tools` are allowed to be passed to the Run. If `text` the model can return text or any value needed.
+            properties:
+                type:
+                    type: string
+                    enum: ["text", "json_object"]
+                    example: "json_object"
+                    default: "text"
+                    description: Must be one of `text` or `json_object`.
+
+        AssistantObject:
+            type: object
+            title: Assistant
+            description: Represents an `assistant` that can call the model and use tools.
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `assistant`.
+                    type: string
+                    enum: [assistant]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the assistant was created.
+                    type: integer
+                name:
+                    description: &assistant_name_param_description |
+                        The name of the assistant. The maximum length is 256 characters.
+                    type: string
+                    maxLength: 256
+                    nullable: true
+                description:
+                    description: &assistant_description_param_description |
+                        The description of the assistant. The maximum length is 512 characters.
+                    type: string
+                    maxLength: 512
+                    nullable: true
+                model:
+                    description: *model_description
+                    type: string
+                instructions:
+                    description: &assistant_instructions_param_description |
+                        The system instructions that the assistant uses. The maximum length is 256,000 characters.
+                    type: string
+                    maxLength: 256000
+                    nullable: true
+                tools:
+                    description: &assistant_tools_param_description |
+                        A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `file_search`, or `function`.
+                    default: []
+                    type: array
+                    maxItems: 128
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                        x-oaiExpandable: true
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter`` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The ID of the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                    nullable: true
+                metadata:
+                    description: &metadata_description |
+                        Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                temperature:
+                    description: &run_temperature_description |
+                        What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &run_top_p_description |
+                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                        We generally recommend altering this or temperature but not both.
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+            required:
+                - id
+                - object
+                - created_at
+                - name
+                - description
+                - model
+                - instructions
+                - tools
+                - metadata
+            x-oaiMeta:
+                name: The assistant object
+                beta: true
+                example: *create_assistants_example
+
+        CreateAssistantRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                model:
+                    description: *model_description
+                    example: "gpt-4-turbo"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "gpt-4o",
+                                  "gpt-4o-2024-05-13",
+                                  "gpt-4o-mini",
+                                  "gpt-4o-mini-2024-07-18",
+                                  "gpt-4-turbo",
+                                  "gpt-4-turbo-2024-04-09",
+                                  "gpt-4-0125-preview",
+                                  "gpt-4-turbo-preview",
+                                  "gpt-4-1106-preview",
+                                  "gpt-4-vision-preview",
+                                  "gpt-4",
+                                  "gpt-4-0314",
+                                  "gpt-4-0613",
+                                  "gpt-4-32k",
+                                  "gpt-4-32k-0314",
+                                  "gpt-4-32k-0613",
+                                  "gpt-3.5-turbo",
+                                  "gpt-3.5-turbo-16k",
+                                  "gpt-3.5-turbo-0613",
+                                  "gpt-3.5-turbo-1106",
+                                  "gpt-3.5-turbo-0125",
+                                  "gpt-3.5-turbo-16k-0613",
+                              ]
+                    x-oaiTypeLabel: string
+                name:
+                    description: *assistant_name_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 256
+                description:
+                    description: *assistant_description_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 512
+                instructions:
+                    description: *assistant_instructions_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 256000
+                tools:
+                    description: *assistant_tools_param_description
+                    default: []
+                    type: array
+                    maxItems: 128
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                        x-oaiExpandable: true
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                                vector_stores:
+                                    type: array
+                                    description: |
+                                        A helper to create a [vector store](/docs/api-reference/vector-stores/object) with file_ids and attach it to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                                    maxItems: 1
+                                    items:
+                                        type: object
+                                        properties:
+                                            file_ids:
+                                                type: array
+                                                description: |
+                                                    A list of [file](/docs/api-reference/files) IDs to add to the vector store. There can be a maximum of 10000 files in a vector store.
+                                                maxItems: 10000
+                                                items:
+                                                    type: string
+                                            chunking_strategy:
+                                                # Ideally we'd reuse the chunking strategy schema here, but it doesn't expand properly
+                                                type: object
+                                                description: The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.
+                                                oneOf:
+                                                    - type: object
+                                                      title: Auto Chunking Strategy
+                                                      description: The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.
+                                                      additionalProperties: false
+                                                      properties:
+                                                          type:
+                                                              type: string
+                                                              description: Always `auto`.
+                                                              enum: ["auto"]
+                                                      required:
+                                                          - type 
+                                                    - type: object
+                                                      title: Static Chunking Strategy
+                                                      additionalProperties: false
+                                                      properties:
+                                                          type:
+                                                              type: string
+                                                              description: Always `static`.
+                                                              enum: ["static"]
+                                                          static:
+                                                              type: object
+                                                              additionalProperties: false
+                                                              properties:
+                                                                  max_chunk_size_tokens:
+                                                                      type: integer
+                                                                      minimum: 100
+                                                                      maximum: 4096
+                                                                      description: The maximum number of tokens in each chunk. The default value is `800`. The minimum value is `100` and the maximum value is `4096`.
+                                                                  chunk_overlap_tokens:
+                                                                      type: integer
+                                                                      description: |
+                                                                          The number of tokens that overlap between chunks. The default value is `400`.
+                                                                          
+                                                                          Note that the overlap must not exceed half of `max_chunk_size_tokens`.
+                                                              required:
+                                                                  - max_chunk_size_tokens
+                                                                  - chunk_overlap_tokens
+                                                      required:
+                                                          - type
+                                                          - static
+                                                x-oaiExpandable: true
+                                            metadata:
+                                                type: object
+                                                description: |
+                                                    Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                                                x-oaiTypeLabel: map
+                            oneOf:
+                                - required: [vector_store_ids]
+                                - required: [vector_stores]
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                temperature:
+                    description: &run_temperature_description |
+                        What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &run_top_p_description |
+                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                        We generally recommend altering this or temperature but not both.
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+            required:
+                - model
+
+        ModifyAssistantRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                model:
+                    description: *model_description
+                    anyOf:
+                        - type: string
+                name:
+                    description: *assistant_name_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 256
+                description:
+                    description: *assistant_description_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 512
+                instructions:
+                    description: *assistant_instructions_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 256000
+                tools:
+                    description: *assistant_tools_param_description
+                    default: []
+                    type: array
+                    maxItems: 128
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                        x-oaiExpandable: true
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        Overrides the list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        Overrides the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                temperature:
+                    description: *run_temperature_description
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &run_top_p_description |
+                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                        We generally recommend altering this or temperature but not both.
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+
+        DeleteAssistantResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [assistant.deleted]
+            required:
+                - id
+                - object
+                - deleted
+
+        ListAssistantsResponse:
+            type: object
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AssistantObject"
+                first_id:
+                    type: string
+                    example: "asst_abc123"
+                last_id:
+                    type: string
+                    example: "asst_abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+            x-oaiMeta:
+                name: List assistants response object
+                group: chat
+                example: *list_assistants_example
+
+        AssistantToolsCode:
+            type: object
+            title: Code interpreter tool
+            properties:
+                type:
+                    type: string
+                    description: "The type of tool being defined: `code_interpreter`"
+                    enum: ["code_interpreter"]
+            required:
+                - type
+
+        AssistantToolsFileSearch:
+            type: object
+            title: FileSearch tool
+            properties:
+                type:
+                    type: string
+                    description: "The type of tool being defined: `file_search`"
+                    enum: ["file_search"]
+                file_search:
+                    type: object
+                    description: Overrides for the file search tool.
+                    properties:
+                        max_num_results:
+                            type: integer
+                            minimum: 1
+                            maximum: 50
+                            description: |
+                                The maximum number of results the file search tool should output. The default is 20 for gpt-4* models and 5 for gpt-3.5-turbo. This number should be between 1 and 50 inclusive.
+
+                                Note that the file search tool may output fewer than `max_num_results` results. See the [file search tool documentation](/docs/assistants/tools/file-search/number-of-chunks-returned) for more information.
+            required:
+                - type
+
+        AssistantToolsFileSearchTypeOnly:
+            type: object
+            title: FileSearch tool
+            properties:
+                type:
+                    type: string
+                    description: "The type of tool being defined: `file_search`"
+                    enum: ["file_search"]
+            required:
+                - type
+
+        AssistantToolsFunction:
+            type: object
+            title: Function tool
+            properties:
+                type:
+                    type: string
+                    description: "The type of tool being defined: `function`"
+                    enum: ["function"]
+                function:
+                    $ref: "#/components/schemas/FunctionObject"
+            required:
+                - type
+                - function
+
+        TruncationObject:
+            type: object
+            title: Thread Truncation Controls
+            description: Controls for how a thread will be truncated prior to the run. Use this to control the intial context window of the run.
+            properties:
+                type:
+                    type: string
+                    description: The truncation strategy to use for the thread. The default is `auto`. If set to `last_messages`, the thread will be truncated to the n most recent messages in the thread. When set to `auto`, messages in the middle of the thread will be dropped to fit the context length of the model, `max_prompt_tokens`.
+                    enum: ["auto", "last_messages"]
+                last_messages:
+                    type: integer
+                    description: The number of most recent messages from the thread when constructing the context for the run.
+                    minimum: 1
+                    nullable: true
+            required:
+                - type
+
+        AssistantsApiToolChoiceOption:
+            description: |
+                Controls which (if any) tool is called by the model.
+                `none` means the model will not call any tools and instead generates a message.
+                `auto` is the default value and means the model can pick between generating a message or calling one or more tools.
+                `required` means the model must call one or more tools before responding to the user.
+                Specifying a particular tool like `{"type": "file_search"}` or `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool.
+
+            oneOf:
+                - type: string
+                  description: >
+                      `none` means the model will not call any tools and instead generates a message.
+                      `auto` means the model can pick between generating a message or calling one or more tools.
+                      `required` means the model must call one or more tools before responding to the user.
+                  enum: [none, auto, required]
+                - $ref: "#/components/schemas/AssistantsNamedToolChoice"
+            x-oaiExpandable: true
+
+        AssistantsNamedToolChoice:
+            type: object
+            description: Specifies a tool the model should use. Use to force the model to call a specific tool.
+            properties:
+                type:
+                    type: string
+                    enum: ["function", "code_interpreter", "file_search"]
+                    description: The type of the tool. If type is `function`, the function name must be set
+                function:
+                    type: object
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                    required:
+                        - name
+            required:
+                - type
+
+        RunObject:
+            type: object
+            title: A run on a thread
+            description: Represents an execution run on a [thread](/docs/api-reference/threads).
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread.run`.
+                    type: string
+                    enum: ["thread.run"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the run was created.
+                    type: integer
+                thread_id:
+                    description: The ID of the [thread](/docs/api-reference/threads) that was executed on as a part of this run.
+                    type: string
+                assistant_id:
+                    description: The ID of the [assistant](/docs/api-reference/assistants) used for execution of this run.
+                    type: string
+                status:
+                    description: The status of the run, which can be either `queued`, `in_progress`, `requires_action`, `cancelling`, `cancelled`, `failed`, `completed`, `incomplete`, or `expired`.
+                    type: string
+                    enum:
+                        [
+                            "queued",
+                            "in_progress",
+                            "requires_action",
+                            "cancelling",
+                            "cancelled",
+                            "failed",
+                            "completed",
+                            "incomplete",
+                            "expired",
+                        ]
+                required_action:
+                    type: object
+                    description: Details on the action required to continue the run. Will be `null` if no action is required.
+                    nullable: true
+                    properties:
+                        type:
+                            description: For now, this is always `submit_tool_outputs`.
+                            type: string
+                            enum: ["submit_tool_outputs"]
+                        submit_tool_outputs:
+                            type: object
+                            description: Details on the tool outputs needed for this run to continue.
+                            properties:
+                                tool_calls:
+                                    type: array
+                                    description: A list of the relevant tool calls.
+                                    items:
+                                        $ref: "#/components/schemas/RunToolCallObject"
+                            required:
+                                - tool_calls
+                    required:
+                        - type
+                        - submit_tool_outputs
+                last_error:
+                    type: object
+                    description: The last error associated with this run. Will be `null` if there are no errors.
+                    nullable: true
+                    properties:
+                        code:
+                            type: string
+                            description: One of `server_error`, `rate_limit_exceeded`, or `invalid_prompt`.
+                            enum:
+                                ["server_error", "rate_limit_exceeded", "invalid_prompt"]
+                        message:
+                            type: string
+                            description: A human-readable description of the error.
+                    required:
+                        - code
+                        - message
+                expires_at:
+                    description: The Unix timestamp (in seconds) for when the run will expire.
+                    type: integer
+                    nullable: true
+                started_at:
+                    description: The Unix timestamp (in seconds) for when the run was started.
+                    type: integer
+                    nullable: true
+                cancelled_at:
+                    description: The Unix timestamp (in seconds) for when the run was cancelled.
+                    type: integer
+                    nullable: true
+                failed_at:
+                    description: The Unix timestamp (in seconds) for when the run failed.
+                    type: integer
+                    nullable: true
+                completed_at:
+                    description: The Unix timestamp (in seconds) for when the run was completed.
+                    type: integer
+                    nullable: true
+                incomplete_details:
+                    description: Details on why the run is incomplete. Will be `null` if the run is not incomplete.
+                    type: object
+                    nullable: true
+                    properties:
+                        reason:
+                            description: The reason why the run is incomplete. This will point to which specific token limit was reached over the course of the run.
+                            type: string
+                            enum: ["max_completion_tokens", "max_prompt_tokens"]
+                model:
+                    description: The model that the [assistant](/docs/api-reference/assistants) used for this run.
+                    type: string
+                instructions:
+                    description: The instructions that the [assistant](/docs/api-reference/assistants) used for this run.
+                    type: string
+                tools:
+                    description: The list of tools that the [assistant](/docs/api-reference/assistants) used for this run.
+                    default: []
+                    type: array
+                    maxItems: 20
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                        x-oaiExpandable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                usage:
+                    $ref: "#/components/schemas/RunCompletionUsage"
+                temperature:
+                    description: The sampling temperature used for this run. If not set, defaults to 1.
+                    type: number
+                    nullable: true
+                top_p:
+                    description: The nucleus sampling value used for this run. If not set, defaults to 1.
+                    type: number
+                    nullable: true
+                max_prompt_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of prompt tokens specified to have been used over the course of the run.
+                    minimum: 256
+                max_completion_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of completion tokens specified to have been used over the course of the run.
+                    minimum: 256
+                truncation_strategy:
+                    $ref: "#/components/schemas/TruncationObject"
+                    nullable: true
+                tool_choice:
+                    $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+                    nullable: true
+                parallel_tool_calls:
+                    $ref: "#/components/schemas/ParallelToolCalls"
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+            required:
+                - id
+                - object
+                - created_at
+                - thread_id
+                - assistant_id
+                - status
+                - required_action
+                - last_error
+                - expires_at
+                - started_at
+                - cancelled_at
+                - failed_at
+                - completed_at
+                - model
+                - instructions
+                - tools
+                - metadata
+                - usage
+                - incomplete_details
+                - max_prompt_tokens
+                - max_completion_tokens
+                - truncation_strategy
+                - tool_choice
+                - parallel_tool_calls
+                - response_format
+            x-oaiMeta:
+                name: The run object
+                beta: true
+                example: |
+                    {
+                      "id": "run_abc123",
+                      "object": "thread.run",
+                      "created_at": 1698107661,
+                      "assistant_id": "asst_abc123",
+                      "thread_id": "thread_abc123",
+                      "status": "completed",
+                      "started_at": 1699073476,
+                      "expires_at": null,
+                      "cancelled_at": null,
+                      "failed_at": null,
+                      "completed_at": 1699073498,
+                      "last_error": null,
+                      "model": "gpt-4-turbo",
+                      "instructions": null,
+                      "tools": [{"type": "file_search"}, {"type": "code_interpreter"}],
+                      "metadata": {},
+                      "incomplete_details": null,
+                      "usage": {
+                        "prompt_tokens": 123,
+                        "completion_tokens": 456,
+                        "total_tokens": 579
+                      },
+                      "temperature": 1.0,
+                      "top_p": 1.0,
+                      "max_prompt_tokens": 1000,
+                      "max_completion_tokens": 1000,
+                      "truncation_strategy": {
+                        "type": "auto",
+                        "last_messages": null
+                      },
+                      "response_format": "auto",
+                      "tool_choice": "auto",
+                      "parallel_tool_calls": true
+                    }
+        CreateRunRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                assistant_id:
+                    description: The ID of the [assistant](/docs/api-reference/assistants) to use to execute this run.
+                    type: string
+                model:
+                    description: The ID of the [Model](/docs/api-reference/models) to be used to execute this run. If a value is provided here, it will override the model associated with the assistant. If not, the model associated with the assistant will be used.
+                    example: "gpt-4-turbo"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "gpt-4o",
+                                  "gpt-4o-2024-05-13",
+                                  "gpt-4o-mini",
+                                  "gpt-4o-mini-2024-07-18",
+                                  "gpt-4-turbo",
+                                  "gpt-4-turbo-2024-04-09",
+                                  "gpt-4-0125-preview",
+                                  "gpt-4-turbo-preview",
+                                  "gpt-4-1106-preview",
+                                  "gpt-4-vision-preview",
+                                  "gpt-4",
+                                  "gpt-4-0314",
+                                  "gpt-4-0613",
+                                  "gpt-4-32k",
+                                  "gpt-4-32k-0314",
+                                  "gpt-4-32k-0613",
+                                  "gpt-3.5-turbo",
+                                  "gpt-3.5-turbo-16k",
+                                  "gpt-3.5-turbo-0613",
+                                  "gpt-3.5-turbo-1106",
+                                  "gpt-3.5-turbo-0125",
+                                  "gpt-3.5-turbo-16k-0613",
+                              ]
+                    x-oaiTypeLabel: string
+                    nullable: true
+                instructions:
+                    description: Overrides the [instructions](/docs/api-reference/assistants/createAssistant) of the assistant. This is useful for modifying the behavior on a per-run basis.
+                    type: string
+                    nullable: true
+                additional_instructions:
+                    description: Appends additional instructions at the end of the instructions for the run. This is useful for modifying the behavior on a per-run basis without overriding other instructions.
+                    type: string
+                    nullable: true
+                additional_messages:
+                    description: Adds additional messages to the thread before creating the run.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/CreateMessageRequest"
+                    nullable: true
+                tools:
+                    description: Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis.
+                    nullable: true
+                    type: array
+                    maxItems: 20
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                        x-oaiExpandable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                temperature:
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: *run_temperature_description
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &run_top_p_description |
+                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                        We generally recommend altering this or temperature but not both.
+                stream:
+                    type: boolean
+                    nullable: true
+                    description: |
+                        If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
+                max_prompt_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only the number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+                    minimum: 256
+                max_completion_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+                    minimum: 256
+                truncation_strategy:
+                    $ref: "#/components/schemas/TruncationObject"
+                    nullable: true
+                tool_choice:
+                    $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+                    nullable: true
+                parallel_tool_calls:
+                    $ref: "#/components/schemas/ParallelToolCalls"
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+            required:
+                - thread_id
+                - assistant_id
+        ListRunsResponse:
+            type: object
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/RunObject"
+                first_id:
+                    type: string
+                    example: "run_abc123"
+                last_id:
+                    type: string
+                    example: "run_abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+        ModifyRunRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+        SubmitToolOutputsRunRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                tool_outputs:
+                    description: A list of tools for which the outputs are being submitted.
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            tool_call_id:
+                                type: string
+                                description: The ID of the tool call in the `required_action` object within the run object the output is being submitted for.
+                            output:
+                                type: string
+                                description: The output of the tool call to be submitted to continue the run.
+                stream:
+                    type: boolean
+                    nullable: true
+                    description: |
+                        If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
+            required:
+                - tool_outputs
+
+        RunToolCallObject:
+            type: object
+            description: Tool call objects
+            properties:
+                id:
+                    type: string
+                    description: The ID of the tool call. This ID must be referenced when you submit the tool outputs in using the [Submit tool outputs to run](/docs/api-reference/runs/submitToolOutputs) endpoint.
+                type:
+                    type: string
+                    description: The type of tool call the output is required for. For now, this is always `function`.
+                    enum: ["function"]
+                function:
+                    type: object
+                    description: The function definition.
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function.
+                        arguments:
+                            type: string
+                            description: The arguments that the model expects you to pass to the function.
+                    required:
+                        - name
+                        - arguments
+            required:
+                - id
+                - type
+                - function
+
+        CreateThreadAndRunRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                assistant_id:
+                    description: The ID of the [assistant](/docs/api-reference/assistants) to use to execute this run.
+                    type: string
+                thread:
+                    $ref: "#/components/schemas/CreateThreadRequest"
+                    description: If no thread is provided, an empty thread will be created.
+                model:
+                    description: The ID of the [Model](/docs/api-reference/models) to be used to execute this run. If a value is provided here, it will override the model associated with the assistant. If not, the model associated with the assistant will be used.
+                    example: "gpt-4-turbo"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "gpt-4o",
+                                  "gpt-4o-2024-05-13",
+                                  "gpt-4o-mini",
+                                  "gpt-4o-mini-2024-07-18",
+                                  "gpt-4-turbo",
+                                  "gpt-4-turbo-2024-04-09",
+                                  "gpt-4-0125-preview",
+                                  "gpt-4-turbo-preview",
+                                  "gpt-4-1106-preview",
+                                  "gpt-4-vision-preview",
+                                  "gpt-4",
+                                  "gpt-4-0314",
+                                  "gpt-4-0613",
+                                  "gpt-4-32k",
+                                  "gpt-4-32k-0314",
+                                  "gpt-4-32k-0613",
+                                  "gpt-3.5-turbo",
+                                  "gpt-3.5-turbo-16k",
+                                  "gpt-3.5-turbo-0613",
+                                  "gpt-3.5-turbo-1106",
+                                  "gpt-3.5-turbo-0125",
+                                  "gpt-3.5-turbo-16k-0613",
+                              ]
+                    x-oaiTypeLabel: string
+                    nullable: true
+                instructions:
+                    description: Override the default system message of the assistant. This is useful for modifying the behavior on a per-run basis.
+                    type: string
+                    nullable: true
+                tools:
+                    description: Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis.
+                    nullable: true
+                    type: array
+                    maxItems: 20
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The ID of the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                temperature:
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: *run_temperature_description
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: *run_top_p_description
+                stream:
+                    type: boolean
+                    nullable: true
+                    description: |
+                        If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
+                max_prompt_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only the number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+                    minimum: 256
+                max_completion_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+                    minimum: 256
+                truncation_strategy:
+                    $ref: "#/components/schemas/TruncationObject"
+                    nullable: true
+                tool_choice:
+                    $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+                    nullable: true
+                parallel_tool_calls:
+                    $ref: "#/components/schemas/ParallelToolCalls"
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+            required:
+                - thread_id
+                - assistant_id
+
+        ThreadObject:
+            type: object
+            title: Thread
+            description: Represents a thread that contains [messages](/docs/api-reference/messages).
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread`.
+                    type: string
+                    enum: ["thread"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the thread was created.
+                    type: integer
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+            required:
+                - id
+                - object
+                - created_at
+                - tool_resources
+                - metadata
+            x-oaiMeta:
+                name: The thread object
+                beta: true
+                example: |
+                    {
+                      "id": "thread_abc123",
+                      "object": "thread",
+                      "created_at": 1698107661,
+                      "metadata": {}
+                    }
+
+        CreateThreadRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                messages:
+                    description: A list of [messages](/docs/api-reference/messages) to start the thread with.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/CreateMessageRequest"
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                                vector_stores:
+                                    type: array
+                                    description: |
+                                        A helper to create a [vector store](/docs/api-reference/vector-stores/object) with file_ids and attach it to this thread. There can be a maximum of 1 vector store attached to the thread.
+                                    maxItems: 1
+                                    items:
+                                        type: object
+                                        properties:
+                                            file_ids:
+                                                type: array
+                                                description: |
+                                                    A list of [file](/docs/api-reference/files) IDs to add to the vector store. There can be a maximum of 10000 files in a vector store.
+                                                maxItems: 10000
+                                                items:
+                                                    type: string
+                                            chunking_strategy:
+                                                # Ideally we'd reuse the chunking strategy schema here, but it doesn't expand properly
+                                                type: object
+                                                description: The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.
+                                                oneOf:
+                                                    - type: object
+                                                      title: Auto Chunking Strategy
+                                                      description: The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.
+                                                      additionalProperties: false
+                                                      properties:
+                                                          type:
+                                                              type: string
+                                                              description: Always `auto`.
+                                                              enum: ["auto"]
+                                                      required:
+                                                          - type 
+                                                    - type: object
+                                                      title: Static Chunking Strategy
+                                                      additionalProperties: false
+                                                      properties:
+                                                          type:
+                                                              type: string
+                                                              description: Always `static`.
+                                                              enum: ["static"]
+                                                          static:
+                                                              type: object
+                                                              additionalProperties: false
+                                                              properties:
+                                                                  max_chunk_size_tokens:
+                                                                      type: integer
+                                                                      minimum: 100
+                                                                      maximum: 4096
+                                                                      description: The maximum number of tokens in each chunk. The default value is `800`. The minimum value is `100` and the maximum value is `4096`.
+                                                                  chunk_overlap_tokens:
+                                                                      type: integer
+                                                                      description: |
+                                                                          The number of tokens that overlap between chunks. The default value is `400`.
+                                                                          
+                                                                          Note that the overlap must not exceed half of `max_chunk_size_tokens`.
+                                                              required:
+                                                                  - max_chunk_size_tokens
+                                                                  - chunk_overlap_tokens
+                                                      required:
+                                                          - type
+                                                          - static
+                                                x-oaiExpandable: true
+                                            metadata:
+                                                type: object
+                                                description: |
+                                                    Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                                                x-oaiTypeLabel: map
+                                        x-oaiExpandable: true
+                            oneOf:
+                                - required: [vector_store_ids]
+                                - required: [vector_stores]
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        ModifyThreadRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        DeleteThreadResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [thread.deleted]
+            required:
+                - id
+                - object
+                - deleted
+
+        ListThreadsResponse:
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ThreadObject"
+                first_id:
+                    type: string
+                    example: "asst_abc123"
+                last_id:
+                    type: string
+                    example: "asst_abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
+        MessageObject:
+            type: object
+            title: The message object
+            description: Represents a message within a [thread](/docs/api-reference/threads).
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread.message`.
+                    type: string
+                    enum: ["thread.message"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the message was created.
+                    type: integer
+                thread_id:
+                    description: The [thread](/docs/api-reference/threads) ID that this message belongs to.
+                    type: string
+                status:
+                    description: The status of the message, which can be either `in_progress`, `incomplete`, or `completed`.
+                    type: string
+                    enum: ["in_progress", "incomplete", "completed"]
+                incomplete_details:
+                    description: On an incomplete message, details about why the message is incomplete.
+                    type: object
+                    properties:
+                        reason:
+                            type: string
+                            description: The reason the message is incomplete.
+                            enum:
+                                [
+                                    "content_filter",
+                                    "max_tokens",
+                                    "run_cancelled",
+                                    "run_expired",
+                                    "run_failed",
+                                ]
+                    nullable: true
+                    required:
+                        - reason
+                completed_at:
+                    description: The Unix timestamp (in seconds) for when the message was completed.
+                    type: integer
+                    nullable: true
+                incomplete_at:
+                    description: The Unix timestamp (in seconds) for when the message was marked as incomplete.
+                    type: integer
+                    nullable: true
+                role:
+                    description: The entity that produced the message. One of `user` or `assistant`.
+                    type: string
+                    enum: ["user", "assistant"]
+                content:
+                    description: The content of the message in array of text and/or images.
+                    type: array
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/MessageContentImageFileObject"
+                            - $ref: "#/components/schemas/MessageContentImageUrlObject"
+                            - $ref: "#/components/schemas/MessageContentTextObject"
+                        x-oaiExpandable: true
+                assistant_id:
+                    description: If applicable, the ID of the [assistant](/docs/api-reference/assistants) that authored this message.
+                    type: string
+                    nullable: true
+                run_id:
+                    description: The ID of the [run](/docs/api-reference/runs) associated with the creation of this message. Value is `null` when messages are created manually using the create message or create thread endpoints.
+                    type: string
+                    nullable: true
+                attachments:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            file_id:
+                                type: string
+                                description: The ID of the file to attach to the message.
+                            tools:
+                                description: The tools to add this file to.
+                                type: array
+                                items:
+                                    oneOf:
+                                        - $ref: "#/components/schemas/AssistantToolsCode"
+                                        - $ref: "#/components/schemas/AssistantToolsFileSearchTypeOnly"
+                                    x-oaiExpandable: true
+                    description: A list of files attached to the message, and the tools they were added to.
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+            required:
+                - id
+                - object
+                - created_at
+                - thread_id
+                - status
+                - incomplete_details
+                - completed_at
+                - incomplete_at
+                - role
+                - content
+                - assistant_id
+                - run_id
+                - attachments
+                - metadata
+            x-oaiMeta:
+                name: The message object
+                beta: true
+                example: |
+                    {
+                      "id": "msg_abc123",
+                      "object": "thread.message",
+                      "created_at": 1698983503,
+                      "thread_id": "thread_abc123",
+                      "role": "assistant",
+                      "content": [
+                        {
+                          "type": "text",
+                          "text": {
+                            "value": "Hi! How can I help you today?",
+                            "annotations": []
+                          }
+                        }
+                      ],
+                      "assistant_id": "asst_abc123",
+                      "run_id": "run_abc123",
+                      "attachments": [],
+                      "metadata": {}
+                    }
+
+        MessageDeltaObject:
+            type: object
+            title: Message delta object
+            description: |
+                Represents a message delta i.e. any changed fields on a message during streaming.
+            properties:
+                id:
+                    description: The identifier of the message, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread.message.delta`.
+                    type: string
+                    enum: ["thread.message.delta"]
+                delta:
+                    description: The delta containing the fields that have changed on the Message.
+                    type: object
+                    properties:
+                        role:
+                            description: The entity that produced the message. One of `user` or `assistant`.
+                            type: string
+                            enum: ["user", "assistant"]
+                        content:
+                            description: The content of the message in array of text and/or images.
+                            type: array
+                            items:
+                                oneOf:
+                                    - $ref: "#/components/schemas/MessageDeltaContentImageFileObject"
+                                    - $ref: "#/components/schemas/MessageDeltaContentTextObject"
+                                    - $ref: "#/components/schemas/MessageDeltaContentImageUrlObject"
+                                x-oaiExpandable: true
+            required:
+                - id
+                - object
+                - delta
+            x-oaiMeta:
+                name: The message delta object
+                beta: true
+                example: |
+                    {
+                      "id": "msg_123",
+                      "object": "thread.message.delta",
+                      "delta": {
+                        "content": [
+                          {
+                            "index": 0,
+                            "type": "text",
+                            "text": { "value": "Hello", "annotations": [] }
+                          }
+                        ]
+                      }
+                    }
+
+        CreateMessageRequest:
+            type: object
+            additionalProperties: false
+            required:
+                - role
+                - content
+            properties:
+                role:
+                    type: string
+                    enum: ["user", "assistant"]
+                    description: |
+                        The role of the entity that is creating the message. Allowed values include:
+                        - `user`: Indicates the message is sent by an actual user and should be used in most cases to represent user-generated messages.
+                        - `assistant`: Indicates the message is generated by the assistant. Use this value to insert messages from the assistant into the conversation.
+                content:
+                    oneOf:
+                        - type: string
+                          description: The text contents of the message.
+                          title: Text content
+                        - type: array
+                          description: An array of content parts with a defined type, each can be of type `text` or images can be passed with `image_url` or `image_file`. Image types are only supported on [Vision-compatible models](/docs/models/overview).
+                          title: Array of content parts
+                          items:
+                              oneOf:
+                                  - $ref: "#/components/schemas/MessageContentImageFileObject"
+                                  - $ref: "#/components/schemas/MessageContentImageUrlObject"
+                                  - $ref: "#/components/schemas/MessageRequestContentTextObject"
+                              x-oaiExpandable: true
+                          minItems: 1
+                    x-oaiExpandable: true
+                attachments:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            file_id:
+                                type: string
+                                description: The ID of the file to attach to the message.
+                            tools:
+                                description: The tools to add this file to.
+                                type: array
+                                items:
+                                    oneOf:
+                                        - $ref: "#/components/schemas/AssistantToolsCode"
+                                        - $ref: "#/components/schemas/AssistantToolsFileSearchTypeOnly"
+                                    x-oaiExpandable: true
+                    description: A list of files attached to the message, and the tools they should be added to.
+                    required:
+                        - file_id
+                        - tools
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        ModifyMessageRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        DeleteMessageResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [thread.message.deleted]
+            required:
+                - id
+                - object
+                - deleted
+
+        ListMessagesResponse:
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/MessageObject"
+                first_id:
+                    type: string
+                    example: "msg_abc123"
+                last_id:
+                    type: string
+                    example: "msg_abc123"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
+        MessageContentImageFileObject:
+            title: Image file
+            type: object
+            description: References an image [File](/docs/api-reference/files) in the content of a message.
+            properties:
+                type:
+                    description: Always `image_file`.
+                    type: string
+                    enum: ["image_file"]
+                image_file:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The [File](/docs/api-reference/files) ID of the image in the message content. Set `purpose="vision"` when uploading the File if you need to later display the file content.
+                            type: string
+                        detail:
+                            type: string
+                            description: Specifies the detail level of the image if specified by the user. `low` uses fewer tokens, you can opt in to high resolution using `high`.
+                            enum: ["auto", "low", "high"]
+                            default: "auto"
+                    required:
+                        - file_id
+            required:
+                - type
+                - image_file
+
+        MessageDeltaContentImageFileObject:
+            title: Image file
+            type: object
+            description: References an image [File](/docs/api-reference/files) in the content of a message.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the content part in the message.
+                type:
+                    description: Always `image_file`.
+                    type: string
+                    enum: ["image_file"]
+                image_file:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The [File](/docs/api-reference/files) ID of the image in the message content. Set `purpose="vision"` when uploading the File if you need to later display the file content.
+                            type: string
+                        detail:
+                            type: string
+                            description: Specifies the detail level of the image if specified by the user. `low` uses fewer tokens, you can opt in to high resolution using `high`.
+                            enum: ["auto", "low", "high"]
+                            default: "auto"
+            required:
+                - index
+                - type
+
+        MessageContentImageUrlObject:
+            title: Image URL
+            type: object
+            description: References an image URL in the content of a message.
+            properties:
+                type:
+                    type: string
+                    enum: ["image_url"]
+                    description: The type of the content part.
+                image_url:
+                    type: object
+                    properties:
+                        url:
+                            type: string
+                            description: "The external URL of the image, must be a supported image types: jpeg, jpg, png, gif, webp."
+                            format: uri
+                        detail:
+                            type: string
+                            description: Specifies the detail level of the image. `low` uses fewer tokens, you can opt in to high resolution using `high`. Default value is `auto`
+                            enum: ["auto", "low", "high"]
+                            default: "auto"
+                    required:
+                        - url
+            required:
+                - type
+                - image_url
+
+        MessageDeltaContentImageUrlObject:
+            title: Image URL
+            type: object
+            description: References an image URL in the content of a message.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the content part in the message.
+                type:
+                    description: Always `image_url`.
+                    type: string
+                    enum: ["image_url"]
+                image_url:
+                    type: object
+                    properties:
+                        url:
+                            description: "The URL of the image, must be a supported image types: jpeg, jpg, png, gif, webp."
+                            type: string
+                        detail:
+                            type: string
+                            description: Specifies the detail level of the image. `low` uses fewer tokens, you can opt in to high resolution using `high`.
+                            enum: ["auto", "low", "high"]
+                            default: "auto"
+            required:
+                - index
+                - type
+
+        MessageContentTextObject:
+            title: Text
+            type: object
+            description: The text content that is part of a message.
+            properties:
+                type:
+                    description: Always `text`.
+                    type: string
+                    enum: ["text"]
+                text:
+                    type: object
+                    properties:
+                        value:
+                            description: The data that makes up the text.
+                            type: string
+                        annotations:
+                            type: array
+                            items:
+                                oneOf:
+                                    - $ref: "#/components/schemas/MessageContentTextAnnotationsFileCitationObject"
+                                    - $ref: "#/components/schemas/MessageContentTextAnnotationsFilePathObject"
+                                x-oaiExpandable: true
+                    required:
+                        - value
+                        - annotations
+            required:
+                - type
+                - text
+
+        MessageRequestContentTextObject:
+            title: Text
+            type: object
+            description: The text content that is part of a message.
+            properties:
+                type:
+                    description: Always `text`.
+                    type: string
+                    enum: ["text"]
+                text:
+                    type: string
+                    description: Text content to be sent to the model
+            required:
+                - type
+                - text
+
+        MessageContentTextAnnotationsFileCitationObject:
+            title: File citation
+            type: object
+            description: A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the "file_search" tool to search files.
+            properties:
+                type:
+                    description: Always `file_citation`.
+                    type: string
+                    enum: ["file_citation"]
+                text:
+                    description: The text in the message content that needs to be replaced.
+                    type: string
+                file_citation:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The ID of the specific File the citation is from.
+                            type: string
+                    required:
+                        - file_id
+                start_index:
+                    type: integer
+                    minimum: 0
+                end_index:
+                    type: integer
+                    minimum: 0
+            required:
+                - type
+                - text
+                - file_citation
+                - start_index
+                - end_index
+
+        MessageContentTextAnnotationsFilePathObject:
+            title: File path
+            type: object
+            description: A URL for the file that's generated when the assistant used the `code_interpreter` tool to generate a file.
+            properties:
+                type:
+                    description: Always `file_path`.
+                    type: string
+                    enum: ["file_path"]
+                text:
+                    description: The text in the message content that needs to be replaced.
+                    type: string
+                file_path:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The ID of the file that was generated.
+                            type: string
+                    required:
+                        - file_id
+                start_index:
+                    type: integer
+                    minimum: 0
+                end_index:
+                    type: integer
+                    minimum: 0
+            required:
+                - type
+                - text
+                - file_path
+                - start_index
+                - end_index
+
+        MessageDeltaContentTextObject:
+            title: Text
+            type: object
+            description: The text content that is part of a message.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the content part in the message.
+                type:
+                    description: Always `text`.
+                    type: string
+                    enum: ["text"]
+                text:
+                    type: object
+                    properties:
+                        value:
+                            description: The data that makes up the text.
+                            type: string
+                        annotations:
+                            type: array
+                            items:
+                                oneOf:
+                                    - $ref: "#/components/schemas/MessageDeltaContentTextAnnotationsFileCitationObject"
+                                    - $ref: "#/components/schemas/MessageDeltaContentTextAnnotationsFilePathObject"
+                                x-oaiExpandable: true
+            required:
+                - index
+                - type
+
+        MessageDeltaContentTextAnnotationsFileCitationObject:
+            title: File citation
+            type: object
+            description: A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the "file_search" tool to search files.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the annotation in the text content part.
+                type:
+                    description: Always `file_citation`.
+                    type: string
+                    enum: ["file_citation"]
+                text:
+                    description: The text in the message content that needs to be replaced.
+                    type: string
+                file_citation:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The ID of the specific File the citation is from.
+                            type: string
+                        quote:
+                            description: The specific quote in the file.
+                            type: string
+                start_index:
+                    type: integer
+                    minimum: 0
+                end_index:
+                    type: integer
+                    minimum: 0
+            required:
+                - index
+                - type
+
+        MessageDeltaContentTextAnnotationsFilePathObject:
+            title: File path
+            type: object
+            description: A URL for the file that's generated when the assistant used the `code_interpreter` tool to generate a file.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the annotation in the text content part.
+                type:
+                    description: Always `file_path`.
+                    type: string
+                    enum: ["file_path"]
+                text:
+                    description: The text in the message content that needs to be replaced.
+                    type: string
+                file_path:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The ID of the file that was generated.
+                            type: string
+                start_index:
+                    type: integer
+                    minimum: 0
+                end_index:
+                    type: integer
+                    minimum: 0
+            required:
+                - index
+                - type
+
+        RunStepObject:
+            type: object
+            title: Run steps
+            description: |
+                Represents a step in execution of a run.
+            properties:
+                id:
+                    description: The identifier of the run step, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread.run.step`.
+                    type: string
+                    enum: ["thread.run.step"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the run step was created.
+                    type: integer
+                assistant_id:
+                    description: The ID of the [assistant](/docs/api-reference/assistants) associated with the run step.
+                    type: string
+                thread_id:
+                    description: The ID of the [thread](/docs/api-reference/threads) that was run.
+                    type: string
+                run_id:
+                    description: The ID of the [run](/docs/api-reference/runs) that this run step is a part of.
+                    type: string
+                type:
+                    description: The type of run step, which can be either `message_creation` or `tool_calls`.
+                    type: string
+                    enum: ["message_creation", "tool_calls"]
+                status:
+                    description: The status of the run step, which can be either `in_progress`, `cancelled`, `failed`, `completed`, or `expired`.
+                    type: string
+                    enum: ["in_progress", "cancelled", "failed", "completed", "expired"]
+                step_details:
+                    type: object
+                    description: The details of the run step.
+                    oneOf:
+                        - $ref: "#/components/schemas/RunStepDetailsMessageCreationObject"
+                        - $ref: "#/components/schemas/RunStepDetailsToolCallsObject"
+                    x-oaiExpandable: true
+                last_error:
+                    type: object
+                    description: The last error associated with this run step. Will be `null` if there are no errors.
+                    nullable: true
+                    properties:
+                        code:
+                            type: string
+                            description: One of `server_error` or `rate_limit_exceeded`.
+                            enum: ["server_error", "rate_limit_exceeded"]
+                        message:
+                            type: string
+                            description: A human-readable description of the error.
+                    required:
+                        - code
+                        - message
+                expired_at:
+                    description: The Unix timestamp (in seconds) for when the run step expired. A step is considered expired if the parent run is expired.
+                    type: integer
+                    nullable: true
+                cancelled_at:
+                    description: The Unix timestamp (in seconds) for when the run step was cancelled.
+                    type: integer
+                    nullable: true
+                failed_at:
+                    description: The Unix timestamp (in seconds) for when the run step failed.
+                    type: integer
+                    nullable: true
+                completed_at:
+                    description: The Unix timestamp (in seconds) for when the run step completed.
+                    type: integer
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                usage:
+                    $ref: "#/components/schemas/RunStepCompletionUsage"
+            required:
+                - id
+                - object
+                - created_at
+                - assistant_id
+                - thread_id
+                - run_id
+                - type
+                - status
+                - step_details
+                - last_error
+                - expired_at
+                - cancelled_at
+                - failed_at
+                - completed_at
+                - metadata
+                - usage
+            x-oaiMeta:
+                name: The run step object
+                beta: true
+                example: *run_step_object_example
+
+        RunStepDeltaObject:
+            type: object
+            title: Run step delta object
+            description: |
+                Represents a run step delta i.e. any changed fields on a run step during streaming.
+            properties:
+                id:
+                    description: The identifier of the run step, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread.run.step.delta`.
+                    type: string
+                    enum: ["thread.run.step.delta"]
+                delta:
+                    description: The delta containing the fields that have changed on the run step.
+                    type: object
+                    properties:
+                        step_details:
+                            type: object
+                            description: The details of the run step.
+                            oneOf:
+                                - $ref: "#/components/schemas/RunStepDeltaStepDetailsMessageCreationObject"
+                                - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsObject"
+                            x-oaiExpandable: true
+            required:
+                - id
+                - object
+                - delta
+            x-oaiMeta:
+                name: The run step delta object
+                beta: true
+                example: |
+                    {
+                      "id": "step_123",
+                      "object": "thread.run.step.delta",
+                      "delta": {
+                        "step_details": {
+                          "type": "tool_calls",
+                          "tool_calls": [
+                            {
+                              "index": 0,
+                              "id": "call_123",
+                              "type": "code_interpreter",
+                              "code_interpreter": { "input": "", "outputs": [] }
+                            }
+                          ]
+                        }
+                      }
+                    }
+
+        ListRunStepsResponse:
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/RunStepObject"
+                first_id:
+                    type: string
+                    example: "step_abc123"
+                last_id:
+                    type: string
+                    example: "step_abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
+        RunStepDetailsMessageCreationObject:
+            title: Message creation
+            type: object
+            description: Details of the message creation by the run step.
+            properties:
+                type:
+                    description: Always `message_creation`.
+                    type: string
+                    enum: ["message_creation"]
+                message_creation:
+                    type: object
+                    properties:
+                        message_id:
+                            type: string
+                            description: The ID of the message that was created by this run step.
+                    required:
+                        - message_id
+            required:
+                - type
+                - message_creation
+
+        RunStepDeltaStepDetailsMessageCreationObject:
+            title: Message creation
+            type: object
+            description: Details of the message creation by the run step.
+            properties:
+                type:
+                    description: Always `message_creation`.
+                    type: string
+                    enum: ["message_creation"]
+                message_creation:
+                    type: object
+                    properties:
+                        message_id:
+                            type: string
+                            description: The ID of the message that was created by this run step.
+            required:
+                - type
+
+        RunStepDetailsToolCallsObject:
+            title: Tool calls
+            type: object
+            description: Details of the tool call.
+            properties:
+                type:
+                    description: Always `tool_calls`.
+                    type: string
+                    enum: ["tool_calls"]
+                tool_calls:
+                    type: array
+                    description: |
+                        An array of tool calls the run step was involved in. These can be associated with one of three types of tools: `code_interpreter`, `file_search`, or `function`.
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/RunStepDetailsToolCallsCodeObject"
+                            - $ref: "#/components/schemas/RunStepDetailsToolCallsFileSearchObject"
+                            - $ref: "#/components/schemas/RunStepDetailsToolCallsFunctionObject"
+                        x-oaiExpandable: true
+            required:
+                - type
+                - tool_calls
+
+        RunStepDeltaStepDetailsToolCallsObject:
+            title: Tool calls
+            type: object
+            description: Details of the tool call.
+            properties:
+                type:
+                    description: Always `tool_calls`.
+                    type: string
+                    enum: ["tool_calls"]
+                tool_calls:
+                    type: array
+                    description: |
+                        An array of tool calls the run step was involved in. These can be associated with one of three types of tools: `code_interpreter`, `file_search`, or `function`.
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeObject"
+                            - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsFileSearchObject"
+                            - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsFunctionObject"
+                        x-oaiExpandable: true
+            required:
+                - type
+
+        RunStepDetailsToolCallsCodeObject:
+            title: Code Interpreter tool call
+            type: object
+            description: Details of the Code Interpreter tool call the run step was involved in.
+            properties:
+                id:
+                    type: string
+                    description: The ID of the tool call.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `code_interpreter` for this type of tool call.
+                    enum: ["code_interpreter"]
+                code_interpreter:
+                    type: object
+                    description: The Code Interpreter tool call definition.
+                    required:
+                        - input
+                        - outputs
+                    properties:
+                        input:
+                            type: string
+                            description: The input to the Code Interpreter tool call.
+                        outputs:
+                            type: array
+                            description: The outputs from the Code Interpreter tool call. Code Interpreter can output one or more items, including text (`logs`) or images (`image`). Each of these are represented by a different object type.
+                            items:
+                                type: object
+                                oneOf:
+                                    - $ref: "#/components/schemas/RunStepDetailsToolCallsCodeOutputLogsObject"
+                                    - $ref: "#/components/schemas/RunStepDetailsToolCallsCodeOutputImageObject"
+                                x-oaiExpandable: true
+            required:
+                - id
+                - type
+                - code_interpreter
+
+        RunStepDeltaStepDetailsToolCallsCodeObject:
+            title: Code interpreter tool call
+            type: object
+            description: Details of the Code Interpreter tool call the run step was involved in.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the tool call in the tool calls array.
+                id:
+                    type: string
+                    description: The ID of the tool call.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `code_interpreter` for this type of tool call.
+                    enum: ["code_interpreter"]
+                code_interpreter:
+                    type: object
+                    description: The Code Interpreter tool call definition.
+                    properties:
+                        input:
+                            type: string
+                            description: The input to the Code Interpreter tool call.
+                        outputs:
+                            type: array
+                            description: The outputs from the Code Interpreter tool call. Code Interpreter can output one or more items, including text (`logs`) or images (`image`). Each of these are represented by a different object type.
+                            items:
+                                type: object
+                                oneOf:
+                                    - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeOutputLogsObject"
+                                    - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeOutputImageObject"
+                                x-oaiExpandable: true
+            required:
+                - index
+                - type
+
+        RunStepDetailsToolCallsCodeOutputLogsObject:
+            title: Code Interpreter log output
+            type: object
+            description: Text output from the Code Interpreter tool call as part of a run step.
+            properties:
+                type:
+                    description: Always `logs`.
+                    type: string
+                    enum: ["logs"]
+                logs:
+                    type: string
+                    description: The text output from the Code Interpreter tool call.
+            required:
+                - type
+                - logs
+
+        RunStepDeltaStepDetailsToolCallsCodeOutputLogsObject:
+            title: Code interpreter log output
+            type: object
+            description: Text output from the Code Interpreter tool call as part of a run step.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the output in the outputs array.
+                type:
+                    description: Always `logs`.
+                    type: string
+                    enum: ["logs"]
+                logs:
+                    type: string
+                    description: The text output from the Code Interpreter tool call.
+            required:
+                - index
+                - type
+
+        RunStepDetailsToolCallsCodeOutputImageObject:
+            title: Code Interpreter image output
+            type: object
+            properties:
+                type:
+                    description: Always `image`.
+                    type: string
+                    enum: ["image"]
+                image:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The [file](/docs/api-reference/files) ID of the image.
+                            type: string
+                    required:
+                        - file_id
+            required:
+                - type
+                - image
+
+        RunStepDeltaStepDetailsToolCallsCodeOutputImageObject:
+            title: Code interpreter image output
+            type: object
+            properties:
+                index:
+                    type: integer
+                    description: The index of the output in the outputs array.
+                type:
+                    description: Always `image`.
+                    type: string
+                    enum: ["image"]
+                image:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The [file](/docs/api-reference/files) ID of the image.
+                            type: string
+            required:
+                - index
+                - type
+
+        RunStepDetailsToolCallsFileSearchObject:
+            title: File search tool call
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: The ID of the tool call object.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `file_search` for this type of tool call.
+                    enum: ["file_search"]
+                file_search:
+                    type: object
+                    description: For now, this is always going to be an empty object.
+                    x-oaiTypeLabel: map
+            required:
+                - id
+                - type
+                - file_search
+
+        RunStepDeltaStepDetailsToolCallsFileSearchObject:
+            title: File search tool call
+            type: object
+            properties:
+                index:
+                    type: integer
+                    description: The index of the tool call in the tool calls array.
+                id:
+                    type: string
+                    description: The ID of the tool call object.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `file_search` for this type of tool call.
+                    enum: ["file_search"]
+                file_search:
+                    type: object
+                    description: For now, this is always going to be an empty object.
+                    x-oaiTypeLabel: map
+            required:
+                - index
+                - type
+                - file_search
+
+        RunStepDetailsToolCallsFunctionObject:
+            type: object
+            title: Function tool call
+            properties:
+                id:
+                    type: string
+                    description: The ID of the tool call object.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `function` for this type of tool call.
+                    enum: ["function"]
+                function:
+                    type: object
+                    description: The definition of the function that was called.
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function.
+                        arguments:
+                            type: string
+                            description: The arguments passed to the function.
+                        output:
+                            type: string
+                            description: The output of the function. This will be `null` if the outputs have not been [submitted](/docs/api-reference/runs/submitToolOutputs) yet.
+                            nullable: true
+                    required:
+                        - name
+                        - arguments
+                        - output
+            required:
+                - id
+                - type
+                - function
+
+        RunStepDeltaStepDetailsToolCallsFunctionObject:
+            type: object
+            title: Function tool call
+            properties:
+                index:
+                    type: integer
+                    description: The index of the tool call in the tool calls array.
+                id:
+                    type: string
+                    description: The ID of the tool call object.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `function` for this type of tool call.
+                    enum: ["function"]
+                function:
+                    type: object
+                    description: The definition of the function that was called.
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function.
+                        arguments:
+                            type: string
+                            description: The arguments passed to the function.
+                        output:
+                            type: string
+                            description: The output of the function. This will be `null` if the outputs have not been [submitted](/docs/api-reference/runs/submitToolOutputs) yet.
+                            nullable: true
+            required:
+                - index
+                - type
+
+        VectorStoreExpirationAfter:
+            type: object
+            title: Vector store expiration policy
+            description: The expiration policy for a vector store.
+            properties:
+                anchor:
+                    description: "Anchor timestamp after which the expiration policy applies. Supported anchors: `last_active_at`."
+                    type: string
+                    enum: ["last_active_at"]
+                days:
+                    description: The number of days after the anchor time that the vector store will expire.
+                    type: integer
+                    minimum: 1
+                    maximum: 365
+            required:
+                - anchor
+                - days
+
+        VectorStoreObject:
+            type: object
+            title: Vector store
+            description: A vector store is a collection of processed files can be used by the `file_search` tool.
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `vector_store`.
+                    type: string
+                    enum: ["vector_store"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the vector store was created.
+                    type: integer
+                name:
+                    description: The name of the vector store.
+                    type: string
+                usage_bytes:
+                    description: The total number of bytes used by the files in the vector store.
+                    type: integer
+                file_counts:
+                    type: object
+                    properties:
+                        in_progress:
+                            description: The number of files that are currently being processed.
+                            type: integer
+                        completed:
+                            description: The number of files that have been successfully processed.
+                            type: integer
+                        failed:
+                            description: The number of files that have failed to process.
+                            type: integer
+                        cancelled:
+                            description: The number of files that were cancelled.
+                            type: integer
+                        total:
+                            description: The total number of files.
+                            type: integer
+                    required:
+                        - in_progress
+                        - completed
+                        - failed
+                        - cancelled
+                        - total
+                status:
+                    description: The status of the vector store, which can be either `expired`, `in_progress`, or `completed`. A status of `completed` indicates that the vector store is ready for use.
+                    type: string
+                    enum: ["expired", "in_progress", "completed"]
+                expires_after:
+                    $ref: "#/components/schemas/VectorStoreExpirationAfter"
+                expires_at:
+                    description: The Unix timestamp (in seconds) for when the vector store will expire.
+                    type: integer
+                    nullable: true
+                last_active_at:
+                    description: The Unix timestamp (in seconds) for when the vector store was last active.
+                    type: integer
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+            required:
+                - id
+                - object
+                - usage_bytes
+                - created_at
+                - status
+                - last_active_at
+                - name
+                - file_counts
+                - metadata
+            x-oaiMeta:
+                name: The vector store object
+                beta: true
+                example: |
+                    {
+                      "id": "vs_123",
+                      "object": "vector_store",
+                      "created_at": 1698107661,
+                      "usage_bytes": 123456,
+                      "last_active_at": 1698107661,
+                      "name": "my_vector_store",
+                      "status": "completed",
+                      "file_counts": {
+                        "in_progress": 0,
+                        "completed": 100,
+                        "cancelled": 0,
+                        "failed": 0,
+                        "total": 100
+                      },
+                      "metadata": {},
+                      "last_used_at": 1698107661
+                    }
+
+        CreateVectorStoreRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file_ids:
+                    description: A list of [File](/docs/api-reference/files) IDs that the vector store should use. Useful for tools like `file_search` that can access files.
+                    type: array
+                    maxItems: 500
+                    items:
+                        type: string
+                name:
+                    description: The name of the vector store.
+                    type: string
+                expires_after:
+                    $ref: "#/components/schemas/VectorStoreExpirationAfter"
+                chunking_strategy:
+                    type: object
+                    description: The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy. Only applicable if `file_ids` is non-empty.
+                    oneOf:
+                        - $ref: "#/components/schemas/AutoChunkingStrategyRequestParam"
+                        - $ref: "#/components/schemas/StaticChunkingStrategyRequestParam"
+                    x-oaiExpandable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        UpdateVectorStoreRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                name:
+                    description: The name of the vector store.
+                    type: string
+                    nullable: true
+                expires_after:
+                    $ref: "#/components/schemas/VectorStoreExpirationAfter"
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        ListVectorStoresResponse:
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/VectorStoreObject"
+                first_id:
+                    type: string
+                    example: "vs_abc123"
+                last_id:
+                    type: string
+                    example: "vs_abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
+        DeleteVectorStoreResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [vector_store.deleted]
+            required:
+                - id
+                - object
+                - deleted
+
+        VectorStoreFileObject:
+            type: object
+            title: Vector store files
+            description: A list of files attached to a vector store.
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `vector_store.file`.
+                    type: string
+                    enum: ["vector_store.file"]
+                usage_bytes:
+                    description: The total vector store usage in bytes. Note that this may be different from the original file size.
+                    type: integer
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the vector store file was created.
+                    type: integer
+                vector_store_id:
+                    description: The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files) is attached to.
+                    type: string
+                status:
+                    description: The status of the vector store file, which can be either `in_progress`, `completed`, `cancelled`, or `failed`. The status `completed` indicates that the vector store file is ready for use.
+                    type: string
+                    enum: ["in_progress", "completed", "cancelled", "failed"]
+                last_error:
+                    type: object
+                    description: The last error associated with this vector store file. Will be `null` if there are no errors.
+                    nullable: true
+                    properties:
+                        code:
+                            type: string
+                            description: One of `server_error` or `rate_limit_exceeded`.
+                            enum:
+                                [
+                                    "internal_error",
+                                    "file_not_found",
+                                    "parsing_error",
+                                    "unhandled_mime_type",
+                                ]
+                        message:
+                            type: string
+                            description: A human-readable description of the error.
+                    required:
+                        - code
+                        - message
+                chunking_strategy:
+                    type: object
+                    description: The strategy used to chunk the file.
+                    oneOf:
+                        - $ref: "#/components/schemas/StaticChunkingStrategyResponseParam"
+                        - $ref: "#/components/schemas/OtherChunkingStrategyResponseParam"
+                    x-oaiExpandable: true
+            required:
+                - id
+                - object
+                - usage_bytes
+                - created_at
+                - vector_store_id
+                - status
+                - last_error
+            x-oaiMeta:
+                name: The vector store file object
+                beta: true
+                example: |
+                    {
+                      "id": "file-abc123",
+                      "object": "vector_store.file",
+                      "usage_bytes": 1234,
+                      "created_at": 1698107661,
+                      "vector_store_id": "vs_abc123",
+                      "status": "completed",
+                      "last_error": null,
+                      "chunking_strategy": {
+                        "type": "static",
+                        "static": {
+                          "max_chunk_size_tokens": 800,
+                          "chunk_overlap_tokens": 400
+                        }
+                      }
+                    }
+
+        OtherChunkingStrategyResponseParam:
+            type: object
+            title: Other Chunking Strategy
+            description: This is returned when the chunking strategy is unknown. Typically, this is because the file was indexed before the `chunking_strategy` concept was introduced in the API.
+            additionalProperties: false
+            properties:
+                type:
+                    type: string
+                    description: Always `other`.
+                    enum: ["other"]
+            required:
+                - type
+
+        StaticChunkingStrategyResponseParam:
+            type: object
+            title: Static Chunking Strategy
+            additionalProperties: false
+            properties:
+                type:
+                    type: string
+                    description: Always `static`.
+                    enum: ["static"]
+                static:
+                    $ref: "#/components/schemas/StaticChunkingStrategy"
+            required:
+                - type
+                - static
+
+        StaticChunkingStrategy:
+            type: object
+            additionalProperties: false
+            properties:
+                max_chunk_size_tokens:
+                    type: integer
+                    minimum: 100
+                    maximum: 4096
+                    description: The maximum number of tokens in each chunk. The default value is `800`. The minimum value is `100` and the maximum value is `4096`.
+                chunk_overlap_tokens:
+                    type: integer
+                    description: |
+                        The number of tokens that overlap between chunks. The default value is `400`.
+                        
+                        Note that the overlap must not exceed half of `max_chunk_size_tokens`.
+            required:
+                - max_chunk_size_tokens
+                - chunk_overlap_tokens
+
+        AutoChunkingStrategyRequestParam:
+            type: object
+            title: Auto Chunking Strategy
+            description: The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.
+            additionalProperties: false
+            properties:
+                type:
+                    type: string
+                    description: Always `auto`.
+                    enum: ["auto"]
+            required:
+                - type
+
+        StaticChunkingStrategyRequestParam:
+            type: object
+            title: Static Chunking Strategy
+            additionalProperties: false
+            properties:
+                type:
+                    type: string
+                    description: Always `static`.
+                    enum: ["static"]
+                static:
+                    $ref: "#/components/schemas/StaticChunkingStrategy"
+            required:
+                - type
+                - static
+
+        ChunkingStrategyRequestParam:
+            type: object
+            description: The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.
+            oneOf:
+                - $ref: "#/components/schemas/AutoChunkingStrategyRequestParam"
+                - $ref: "#/components/schemas/StaticChunkingStrategyRequestParam"
+            x-oaiExpandable: true
+
+        CreateVectorStoreFileRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file_id:
+                    description: A [File](/docs/api-reference/files) ID that the vector store should use. Useful for tools like `file_search` that can access files.
+                    type: string
+                chunking_strategy:
+                    $ref: "#/components/schemas/ChunkingStrategyRequestParam"
+            required:
+                - file_id
+
+        ListVectorStoreFilesResponse:
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/VectorStoreFileObject"
+                first_id:
+                    type: string
+                    example: "file-abc123"
+                last_id:
+                    type: string
+                    example: "file-abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
+        DeleteVectorStoreFileResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [vector_store.file.deleted]
+            required:
+                - id
+                - object
+                - deleted
+
+        VectorStoreFileBatchObject:
+            type: object
+            title: Vector store file batch
+            description: A batch of files attached to a vector store.
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `vector_store.file_batch`.
+                    type: string
+                    enum: ["vector_store.files_batch"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the vector store files batch was created.
+                    type: integer
+                vector_store_id:
+                    description: The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files) is attached to.
+                    type: string
+                status:
+                    description: The status of the vector store files batch, which can be either `in_progress`, `completed`, `cancelled` or `failed`.
+                    type: string
+                    enum: ["in_progress", "completed", "cancelled", "failed"]
+                file_counts:
+                    type: object
+                    properties:
+                        in_progress:
+                            description: The number of files that are currently being processed.
+                            type: integer
+                        completed:
+                            description: The number of files that have been processed.
+                            type: integer
+                        failed:
+                            description: The number of files that have failed to process.
+                            type: integer
+                        cancelled:
+                            description: The number of files that where cancelled.
+                            type: integer
+                        total:
+                            description: The total number of files.
+                            type: integer
+                    required:
+                        - in_progress
+                        - completed
+                        - cancelled
+                        - failed
+                        - total
+            required:
+                - id
+                - object
+                - created_at
+                - vector_store_id
+                - status
+                - file_counts
+            x-oaiMeta:
+                name: The vector store files batch object
+                beta: true
+                example: |
+                    {
+                      "id": "vsfb_123",
+                      "object": "vector_store.files_batch",
+                      "created_at": 1698107661,
+                      "vector_store_id": "vs_abc123",
+                      "status": "completed",
+                      "file_counts": {
+                        "in_progress": 0,
+                        "completed": 100,
+                        "failed": 0,
+                        "cancelled": 0,
+                        "total": 100
+                      }
+                    }
+
+        CreateVectorStoreFileBatchRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file_ids:
+                    description: A list of [File](/docs/api-reference/files) IDs that the vector store should use. Useful for tools like `file_search` that can access files.
+                    type: array
+                    minItems: 1
+                    maxItems: 500
+                    items:
+                        type: string
+                chunking_strategy:
+                    $ref: "#/components/schemas/ChunkingStrategyRequestParam"
+            required:
+                - file_ids
+
+        AssistantStreamEvent:
+            description: |
+                Represents an event emitted when streaming a Run.
+
+                Each event in a server-sent events stream has an `event` and `data` property:
+
+                ```
+                event: thread.created
+                data: {"id": "thread_123", "object": "thread", ...}
+                ```
+
+                We emit events whenever a new object is created, transitions to a new state, or is being
+                streamed in parts (deltas). For example, we emit `thread.run.created` when a new run
+                is created, `thread.run.completed` when a run completes, and so on. When an Assistant chooses
+                to create a message during a run, we emit a `thread.message.created event`, a
+                `thread.message.in_progress` event, many `thread.message.delta` events, and finally a
+                `thread.message.completed` event.
+
+                We may add additional events over time, so we recommend handling unknown events gracefully
+                in your code. See the [Assistants API quickstart](/docs/assistants/overview) to learn how to
+                integrate the Assistants API with streaming.
+            oneOf:
+                - $ref: "#/components/schemas/ThreadStreamEvent"
+                - $ref: "#/components/schemas/RunStreamEvent"
+                - $ref: "#/components/schemas/RunStepStreamEvent"
+                - $ref: "#/components/schemas/MessageStreamEvent"
+                - $ref: "#/components/schemas/ErrorEvent"
+                - $ref: "#/components/schemas/DoneEvent"
+            x-oaiMeta:
+                name: Assistant stream events
+                beta: true
+
+        ThreadStreamEvent:
+            oneOf:
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.created"]
+                      data:
+                          $ref: "#/components/schemas/ThreadObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a new [thread](/docs/api-reference/threads/object) is created.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [thread](/docs/api-reference/threads/object)"
+
+        RunStreamEvent:
+            oneOf:
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.created"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a new [run](/docs/api-reference/runs/object) is created.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.queued"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) moves to a `queued` status.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.in_progress"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) moves to an `in_progress` status.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.requires_action"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) moves to a `requires_action` status.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.completed"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) is completed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: [ "thread.run.incomplete" ]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) ends with status `incomplete`.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.failed"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) fails.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.cancelling"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) moves to a `cancelling` status.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.cancelled"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) is cancelled.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.expired"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) expires.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+
+        RunStepStreamEvent:
+            oneOf:
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.created"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) is created.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.in_progress"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) moves to an `in_progress` state.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.delta"]
+                      data:
+                          $ref: "#/components/schemas/RunStepDeltaObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when parts of a [run step](/docs/api-reference/runs/step-object) are being streamed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step delta](/docs/api-reference/assistants-streaming/run-step-delta-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.completed"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) is completed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.failed"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) fails.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.cancelled"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) is cancelled.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.expired"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) expires.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+
+        MessageStreamEvent:
+            oneOf:
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.message.created"]
+                      data:
+                          $ref: "#/components/schemas/MessageObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [message](/docs/api-reference/messages/object) is created.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.message.in_progress"]
+                      data:
+                          $ref: "#/components/schemas/MessageObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [message](/docs/api-reference/messages/object) moves to an `in_progress` state.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.message.delta"]
+                      data:
+                          $ref: "#/components/schemas/MessageDeltaObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when parts of a [Message](/docs/api-reference/messages/object) are being streamed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [message delta](/docs/api-reference/assistants-streaming/message-delta-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.message.completed"]
+                      data:
+                          $ref: "#/components/schemas/MessageObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [message](/docs/api-reference/messages/object) is completed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.message.incomplete"]
+                      data:
+                          $ref: "#/components/schemas/MessageObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [message](/docs/api-reference/messages/object) ends before it is completed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+
+        ErrorEvent:
+            type: object
+            properties:
+                event:
+                    type: string
+                    enum: ["error"]
+                data:
+                    $ref: "#/components/schemas/Error"
+            required:
+                - event
+                - data
+            description: Occurs when an [error](/docs/guides/error-codes/api-errors) occurs. This can happen due to an internal server error or a timeout.
+            x-oaiMeta:
+                dataDescription: "`data` is an [error](/docs/guides/error-codes/api-errors)"
+
+        DoneEvent:
+            type: object
+            properties:
+                event:
+                    type: string
+                    enum: ["done"]
+                data:
+                    type: string
+                    enum: ["[DONE]"]
+            required:
+                - event
+                - data
+            description: Occurs when a stream ends.
+            x-oaiMeta:
+                dataDescription: "`data` is `[DONE]`"
+
+        Batch:
+            type: object
+            properties:
+                id:
+                    type: string
+                object:
+                    type: string
+                    enum: [batch]
+                    description: The object type, which is always `batch`.
+                endpoint:
+                    type: string
+                    description: The OpenAI API endpoint used by the batch.
+
+                errors:
+                    type: object
+                    properties:
+                        object:
+                            type: string
+                            description: The object type, which is always `list`.
+                        data:
+                            type: array
+                            items:
+                                type: object
+                                properties:
+                                    code:
+                                        type: string
+                                        description: An error code identifying the error type.
+                                    message:
+                                        type: string
+                                        description: A human-readable message providing more details about the error.
+                                    param:
+                                        type: string
+                                        description: The name of the parameter that caused the error, if applicable.
+                                        nullable: true
+                                    line:
+                                        type: integer
+                                        description: The line number of the input file where the error occurred, if applicable.
+                                        nullable: true
+                input_file_id:
+                    type: string
+                    description: The ID of the input file for the batch.
+                completion_window:
+                    type: string
+                    description: The time frame within which the batch should be processed.
+                status:
+                    type: string
+                    description: The current status of the batch.
+                    enum:
+                        - validating
+                        - failed
+                        - in_progress
+                        - finalizing
+                        - completed
+                        - expired
+                        - cancelling
+                        - cancelled
+                output_file_id:
+                    type: string
+                    description: The ID of the file containing the outputs of successfully executed requests.
+                error_file_id:
+                    type: string
+                    description: The ID of the file containing the outputs of requests with errors.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch was created.
+                in_progress_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch started processing.
+                expires_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch will expire.
+                finalizing_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch started finalizing.
+                completed_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch was completed.
+                failed_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch failed.
+                expired_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch expired.
+                cancelling_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch started cancelling.
+                cancelled_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch was cancelled.
+                request_counts:
+                    type: object
+                    properties:
+                        total:
+                            type: integer
+                            description: Total number of requests in the batch.
+                        completed:
+                            type: integer
+                            description: Number of requests that have been completed successfully.
+                        failed:
+                            type: integer
+                            description: Number of requests that have failed.
+                    required:
+                        - total
+                        - completed
+                        - failed
+                    description: The request counts for different statuses within the batch.
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+            required:
+                - id
+                - object
+                - endpoint
+                - input_file_id
+                - completion_window
+                - status
+                - created_at
+            x-oaiMeta:
+                name: The batch object
+                example: *batch_object
+
+        BatchRequestInput:
+            type: object
+            description: The per-line object of the batch input file
+            properties:
+                custom_id:
+                    type: string
+                    description: A developer-provided per-request id that will be used to match outputs to inputs. Must be unique for each request in a batch.
+                method:
+                    type: string
+                    enum: ["POST"]
+                    description: The HTTP method to be used for the request. Currently only `POST` is supported.
+                url:
+                    type: string
+                    description: The OpenAI API relative URL to be used for the request. Currently `/v1/chat/completions`, `/v1/embeddings`, and `/v1/completions` are supported.
+            x-oaiMeta:
+                name: The request input object
+                example: |
+                    {"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "What is 2+2?"}]}}
+
+        BatchRequestOutput:
+            type: object
+            description: The per-line object of the batch output and error files
+            properties:
+                id:
+                    type: string
+                custom_id:
+                    type: string
+                    description: A developer-provided per-request id that will be used to match outputs to inputs.
+                response:
+                    type: object
+                    nullable: true
+                    properties:
+                        status_code:
+                            type: integer
+                            description: The HTTP status code of the response
+                        request_id:
+                            type: string
+                            description: An unique identifier for the OpenAI API request. Please include this request ID when contacting support.
+                        body:
+                            type: object
+                            x-oaiTypeLabel: map
+                            description: The JSON body of the response
+                error:
+                    type: object
+                    nullable: true
+                    description: For requests that failed with a non-HTTP error, this will contain more information on the cause of the failure.
+                    properties:
+                        code:
+                            type: string
+                            description: A machine-readable error code.
+                        message:
+                            type: string
+                            description: A human-readable error message.
+            x-oaiMeta:
+                name: The request output object
+                example: |
+                    {"id": "batch_req_wnaDys", "custom_id": "request-2", "response": {"status_code": 200, "request_id": "req_c187b3", "body": {"id": "chatcmpl-9758Iw", "object": "chat.completion", "created": 1711475054, "model": "gpt-3.5-turbo", "choices": [{"index": 0, "message": {"role": "assistant", "content": "2 + 2 equals 4."}, "finish_reason": "stop"}], "usage": {"prompt_tokens": 24, "completion_tokens": 15, "total_tokens": 39}, "system_fingerprint": null}}, "error": null}
+
+        ListBatchesResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/Batch"
+                first_id:
+                    type: string
+                    example: "batch_abc123"
+                last_id:
+                    type: string
+                    example: "batch_abc456"
+                has_more:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [list]
+            required:
+                - object
+                - data
+                - has_more
+
+security:
+    - ApiKeyAuth: []
+
+x-oaiMeta:
+    navigationGroups:
+        - id: endpoints
+          title: Endpoints
+        - id: assistants
+          title: Assistants
+        - id: legacy
+          title: Legacy
+    groups:
+        # > General Notes
+        # The `groups` section is used to generate the API reference pages and navigation, in the same
+        # order listed below. Additionally, each `group` can have a list of `sections`, each of which
+        # will become a navigation subroute and subsection under the group. Each section has:
+        #  - `type`: Currently, either an `endpoint` or `object`, depending on how the section needs to
+        #            be rendered
+        #  - `key`: The reference key that can be used to lookup the section definition
+        #  - `path`: The path (url) of the section, which is used to generate the navigation link.
+        #
+        # > The `object` sections maps to a schema component and the following fields are read for rendering
+        # - `x-oaiMeta.name`: The name of the object, which will become the section title
+        # - `x-oaiMeta.example`: The example object, which will be used to generate the example sample (always JSON)
+        # - `description`: The description of the object, which will be used to generate the section description
+        #
+        # > The `endpoint` section maps to an operation path and the following fields are read for rendering:
+        # - `x-oaiMeta.name`: The name of the endpoint, which will become the section title
+        # - `x-oaiMeta.examples`: The endpoint examples, which can be an object (meaning a single variation, most
+        #                         endpoints, or an array of objects, meaning multiple variations, e.g. the
+        #                         chat completion and completion endpoints, with streamed and non-streamed examples.
+        # - `x-oaiMeta.returns`: text describing what the endpoint returns.
+        # - `summary`: The summary of the endpoint, which will be used to generate the section description
+        - id: audio
+          title: Audio
+          description: |
+              Learn how to turn audio into text or text into audio.
+
+              Related guide: [Speech to text](/docs/guides/speech-to-text)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createSpeech
+                path: createSpeech
+              - type: endpoint
+                key: createTranscription
+                path: createTranscription
+              - type: endpoint
+                key: createTranslation
+                path: createTranslation
+              - type: object
+                key: CreateTranscriptionResponseJson
+                path: json-object
+              - type: object
+                key: CreateTranscriptionResponseVerboseJson
+                path: verbose-json-object
+        - id: chat
+          title: Chat
+          description: |
+              Given a list of messages comprising a conversation, the model will return a response.
+
+              Related guide: [Chat Completions](/docs/guides/text-generation)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createChatCompletion
+                path: create
+              - type: object
+                key: CreateChatCompletionResponse
+                path: object
+              - type: object
+                key: CreateChatCompletionStreamResponse
+                path: streaming
+        - id: embeddings
+          title: Embeddings
+          description: |
+              Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
+
+              Related guide: [Embeddings](/docs/guides/embeddings)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createEmbedding
+                path: create
+              - type: object
+                key: Embedding
+                path: object
+        - id: fine-tuning
+          title: Fine-tuning
+          description: |
+              Manage fine-tuning jobs to tailor a model to your specific training data.
+
+              Related guide: [Fine-tune models](/docs/guides/fine-tuning)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createFineTuningJob
+                path: create
+              - type: endpoint
+                key: listPaginatedFineTuningJobs
+                path: list
+              - type: endpoint
+                key: listFineTuningEvents
+                path: list-events
+              - type: endpoint
+                key: listFineTuningJobCheckpoints
+                path: list-checkpoints
+              - type: endpoint
+                key: retrieveFineTuningJob
+                path: retrieve
+              - type: endpoint
+                key: cancelFineTuningJob
+                path: cancel
+              - type: object
+                key: FinetuneChatRequestInput
+                path: chat-input
+              - type: object
+                key: FinetuneCompletionRequestInput
+                path: completions-input
+              - type: object
+                key: FineTuningJob
+                path: object
+              - type: object
+                key: FineTuningJobEvent
+                path: event-object
+              - type: object
+                key: FineTuningJobCheckpoint
+                path: checkpoint-object
+        - id: batch
+          title: Batch
+          description: |
+              Create large batches of API requests for asynchronous processing. The Batch API returns completions within 24 hours for a 50% discount.
+
+              Related guide: [Batch](/docs/guides/batch)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createBatch
+                path: create
+              - type: endpoint
+                key: retrieveBatch
+                path: retrieve
+              - type: endpoint
+                key: cancelBatch
+                path: cancel
+              - type: endpoint
+                key: listBatches
+                path: list
+              - type: object
+                key: Batch
+                path: object
+              - type: object
+                key: BatchRequestInput
+                path: request-input
+              - type: object
+                key: BatchRequestOutput
+                path: request-output
+        - id: files
+          title: Files
+          description: |
+              Files are used to upload documents that can be used with features like [Assistants](/docs/api-reference/assistants), [Fine-tuning](/docs/api-reference/fine-tuning), and [Batch API](/docs/guides/batch).
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createFile
+                path: create
+              - type: endpoint
+                key: listFiles
+                path: list
+              - type: endpoint
+                key: retrieveFile
+                path: retrieve
+              - type: endpoint
+                key: deleteFile
+                path: delete
+              - type: endpoint
+                key: downloadFile
+                path: retrieve-contents
+              - type: object
+                key: OpenAIFile
+                path: object
+        - id: uploads
+          title: Uploads
+          description: |
+              Allows you to upload large files in multiple parts.
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createUpload
+                path: create
+              - type: endpoint
+                key: addUploadPart
+                path: add-part
+              - type: endpoint
+                key: completeUpload
+                path: complete
+              - type: endpoint
+                key: cancelUpload
+                path: cancel
+              - type: object
+                key: Upload
+                path: object
+              - type: object
+                key: UploadPart
+                path: part-object
+        - id: images
+          title: Images
+          description: |
+              Given a prompt and/or an input image, the model will generate a new image.
+
+              Related guide: [Image generation](/docs/guides/images)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createImage
+                path: create
+              - type: endpoint
+                key: createImageEdit
+                path: createEdit
+              - type: endpoint
+                key: createImageVariation
+                path: createVariation
+              - type: object
+                key: Image
+                path: object
+        - id: models
+          title: Models
+          description: |
+              List and describe the various models available in the API. You can refer to the [Models](/docs/models) documentation to understand what models are available and the differences between them.
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: listModels
+                path: list
+              - type: endpoint
+                key: retrieveModel
+                path: retrieve
+              - type: endpoint
+                key: deleteModel
+                path: delete
+              - type: object
+                key: Model
+                path: object
+        - id: moderations
+          title: Moderations
+          description: |
+              Given some input text, outputs if the model classifies it as potentially harmful across several categories.
+
+              Related guide: [Moderations](/docs/guides/moderation)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createModeration
+                path: create
+              - type: object
+                key: CreateModerationResponse
+                path: object
+        - id: assistants
+          title: Assistants
+          beta: true
+          description: |
+              Build assistants that can call models and use tools to perform tasks.
+
+              [Get started with the Assistants API](/docs/assistants)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createAssistant
+                path: createAssistant
+              - type: endpoint
+                key: listAssistants
+                path: listAssistants
+              - type: endpoint
+                key: getAssistant
+                path: getAssistant
+              - type: endpoint
+                key: modifyAssistant
+                path: modifyAssistant
+              - type: endpoint
+                key: deleteAssistant
+                path: deleteAssistant
+              - type: object
+                key: AssistantObject
+                path: object
+        - id: threads
+          title: Threads
+          beta: true
+          description: |
+              Create threads that assistants can interact with.
+
+              Related guide: [Assistants](/docs/assistants/overview)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createThread
+                path: createThread
+              - type: endpoint
+                key: getThread
+                path: getThread
+              - type: endpoint
+                key: modifyThread
+                path: modifyThread
+              - type: endpoint
+                key: deleteThread
+                path: deleteThread
+              - type: object
+                key: ThreadObject
+                path: object
+        - id: messages
+          title: Messages
+          beta: true
+          description: |
+              Create messages within threads
+
+              Related guide: [Assistants](/docs/assistants/overview)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createMessage
+                path: createMessage
+              - type: endpoint
+                key: listMessages
+                path: listMessages
+              - type: endpoint
+                key: getMessage
+                path: getMessage
+              - type: endpoint
+                key: modifyMessage
+                path: modifyMessage
+              - type: endpoint
+                key: deleteMessage
+                path: deleteMessage
+              - type: object
+                key: MessageObject
+                path: object
+        - id: runs
+          title: Runs
+          beta: true
+          description: |
+              Represents an execution run on a thread.
+
+              Related guide: [Assistants](/docs/assistants/overview)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createRun
+                path: createRun
+              - type: endpoint
+                key: createThreadAndRun
+                path: createThreadAndRun
+              - type: endpoint
+                key: listRuns
+                path: listRuns
+              - type: endpoint
+                key: getRun
+                path: getRun
+              - type: endpoint
+                key: modifyRun
+                path: modifyRun
+              - type: endpoint
+                key: submitToolOuputsToRun
+                path: submitToolOutputs
+              - type: endpoint
+                key: cancelRun
+                path: cancelRun
+              - type: object
+                key: RunObject
+                path: object
+        - id: run-steps
+          title: Run Steps
+          beta: true
+          description: |
+              Represents the steps (model and tool calls) taken during the run.
+
+              Related guide: [Assistants](/docs/assistants/overview)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: listRunSteps
+                path: listRunSteps
+              - type: endpoint
+                key: getRunStep
+                path: getRunStep
+              - type: object
+                key: RunStepObject
+                path: step-object
+        - id: vector-stores
+          title: Vector Stores
+          beta: true
+          description: |
+              Vector stores are used to store files for use by the `file_search` tool.
+
+              Related guide: [File Search](/docs/assistants/tools/file-search)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createVectorStore
+                path: create
+              - type: endpoint
+                key: listVectorStores
+                path: list
+              - type: endpoint
+                key: getVectorStore
+                path: retrieve
+              - type: endpoint
+                key: modifyVectorStore
+                path: modify
+              - type: endpoint
+                key: deleteVectorStore
+                path: delete
+              - type: object
+                key: VectorStoreObject
+                path: object
+        - id: vector-stores-files
+          title: Vector Store Files
+          beta: true
+          description: |
+              Vector store files represent files inside a vector store.
+
+              Related guide: [File Search](/docs/assistants/tools/file-search)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createVectorStoreFile
+                path: createFile
+              - type: endpoint
+                key: listVectorStoreFiles
+                path: listFiles
+              - type: endpoint
+                key: getVectorStoreFile
+                path: getFile
+              - type: endpoint
+                key: deleteVectorStoreFile
+                path: deleteFile
+              - type: object
+                key: VectorStoreFileObject
+                path: file-object
+        - id: vector-stores-file-batches
+          title: Vector Store File Batches
+          beta: true
+          description: |
+              Vector store file batches represent operations to add multiple files to a vector store.
+
+              Related guide: [File Search](/docs/assistants/tools/file-search)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createVectorStoreFileBatch
+                path: createBatch
+              - type: endpoint
+                key: getVectorStoreFileBatch
+                path: getBatch
+              - type: endpoint
+                key: cancelVectorStoreFileBatch
+                path: cancelBatch
+              - type: endpoint
+                key: listFilesInVectorStoreBatch
+                path: listBatchFiles
+              - type: object
+                key: VectorStoreFileBatchObject
+                path: batch-object
+        - id: assistants-streaming
+          title: Streaming
+          beta: true
+          description: |
+              Stream the result of executing a Run or resuming a Run after submitting tool outputs.
+
+              You can stream events from the [Create Thread and Run](/docs/api-reference/runs/createThreadAndRun),
+              [Create Run](/docs/api-reference/runs/createRun), and [Submit Tool Outputs](/docs/api-reference/runs/submitToolOutputs)
+              endpoints by passing `"stream": true`. The response will be a [Server-Sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) stream.
+
+              Our Node and Python SDKs provide helpful utilities to make streaming easy. Reference the
+              [Assistants API quickstart](/docs/assistants/overview) to learn more.
+          navigationGroup: assistants
+          sections:
+              - type: object
+                key: MessageDeltaObject
+                path: message-delta-object
+              - type: object
+                key: RunStepDeltaObject
+                path: run-step-delta-object
+              - type: object
+                key: AssistantStreamEvent
+                path: events
+        - id: completions
+          title: Completions
+          legacy: true
+          navigationGroup: legacy
+          description: |
+              Given a prompt, the model will return one or more predicted completions along with the probabilities of alternative tokens at each position. Most developer should use our [Chat Completions API](/docs/guides/text-generation/text-generation-models) to leverage our best and newest models.
+          sections:
+              - type: endpoint
+                key: createCompletion
+                path: create
+              - type: object
+                key: CreateCompletionResponse
+                path: object

--- a/Sources/SpeziLLMOpenAI/openapi.yaml
+++ b/Sources/SpeziLLMOpenAI/openapi.yaml
@@ -59,6 +59,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/CreateChatCompletionResponse"
+                        text/event-stream:
+                            schema:
+                                $ref: "#/components/schemas/CreateChatCompletionStreamResponse"
 
             x-oaiMeta:
                 name: Create chat completion

--- a/Tests/UITests/TestApp/LLMOpenAI/Functions/LLMOpenAIFunctionHealthData.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/Functions/LLMOpenAIFunctionHealthData.swift
@@ -15,7 +15,11 @@ struct LLMOpenAIFunctionHealthData: LLMFunction {
     
     
     // swiftlint:disable attributes
-    @Parameter(description: "The types of health data that are requested", enum: ["allergies", "medications", "preconditions"])
+    // FIXME: should be @Parameter
+    @_LLMFunctionParameterWrapper(
+        description: "The types of health data that are requested",
+        enum: ["allergies", "medications", "preconditions"]
+    )
     var healthDataTypes: [String]
     // swiftlint:enable attributes
     

--- a/Tests/UITests/TestApp/LLMOpenAI/Functions/LLMOpenAIFunctionPerson.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/Functions/LLMOpenAIFunctionPerson.swift
@@ -29,7 +29,7 @@ struct LLMOpenAIFunctionPerson: LLMFunction {
     
     
     // swiftlint:disable attributes
-    @Parameter(description: "Persons which age is to be determined.")
+    @_LLMFunctionParameterWrapper(description: "Persons which age is to be determined.")
     var persons: [CustomArrayItemType]
     // swiftlint:enable attributes
     

--- a/Tests/UITests/TestApp/LLMOpenAI/Functions/LLMOpenAIFunctionWeather.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/Functions/LLMOpenAIFunctionWeather.swift
@@ -21,9 +21,12 @@ struct LLMOpenAIFunctionWeather: LLMFunction {
     
     
     // swiftlint:disable attributes
-    @Parameter(description: "The city and state of the to be determined weather, e.g. San Francisco, CA")
+    // FIXME: should be @Parameter
+    @_LLMFunctionParameterWrapper(
+        description: "The city and state of the to be determined weather, e.g. San Francisco, CA"
+    )
     var location: String
-    @Parameter(description: "The unit of the temperature")
+    @_LLMFunctionParameterWrapper(description: "The unit of the temperature")
     var unit: TemperatureUnit
     // swiftlint:enable attributes
     

--- a/Tests/UITests/TestApp/LLMOpenAI/LLMOpenAIChatTestView.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/LLMOpenAIChatTestView.swift
@@ -15,7 +15,7 @@ import SwiftUI
 struct LLMOpenAIChatTestView: View {
     static let schema = LLMOpenAISchema(
         parameters: .init(
-            modelType: .gpt4_turbo,
+            modelType: .init(value1: "gpt-4-turbo", value2: .gpt_hyphen_4_hyphen_turbo),
             systemPrompt: "You're a helpful assistant that answers questions from users."
         )
     ) {

--- a/Tests/UITests/TestApp/LLMOpenAI/Onboarding/LLMOpenAIModelOnboarding.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/Onboarding/LLMOpenAIModelOnboarding.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+import OpenAPIRuntime
+import OpenAPIURLSession
 import SpeziLLMOpenAI
 import SpeziOnboarding
 import SwiftUI
@@ -19,8 +21,8 @@ struct LLMOpenAIModelOnboarding: View {
     var body: some View {
         Group {
             LLMOpenAIModelOnboardingStep { model in
-                modelSelection = model
-                self.showingAlert.toggle()
+                modelSelection = model.value1 ?? "No model available"
+                showingAlert.toggle()
             }
         }
         .alert(isPresented: $showingAlert) {

--- a/Tests/UITests/TestApp/openapi-generator-config.yaml
+++ b/Tests/UITests/TestApp/openapi-generator-config.yaml
@@ -1,0 +1,3 @@
+generate:
+  - types
+  - client

--- a/Tests/UITests/TestApp/openapi-generator-config.yaml
+++ b/Tests/UITests/TestApp/openapi-generator-config.yaml
@@ -1,3 +1,4 @@
 generate:
   - types
   - client
+accessModifier: public

--- a/Tests/UITests/TestApp/openapi.yaml
+++ b/Tests/UITests/TestApp/openapi.yaml
@@ -1,0 +1,14280 @@
+openapi: 3.0.0
+info:
+    title: OpenAI API
+    description: The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details.
+    version: "2.1.0"
+    termsOfService: https://openai.com/policies/terms-of-use
+    contact:
+        name: OpenAI Support
+        url: https://help.openai.com/
+    license:
+        name: MIT
+        url: https://github.com/openai/openai-openapi/blob/master/LICENSE
+servers:
+    - url: https://api.openai.com/v1
+tags:
+    - name: Assistants
+      description: Build Assistants that can call models and use tools.
+    - name: Audio
+      description: Turn audio into text or text into audio.
+    - name: Chat
+      description: Given a list of messages comprising a conversation, the model will return a response.
+    - name: Completions
+      description: Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position.
+    - name: Embeddings
+      description: Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
+    - name: Fine-tuning
+      description: Manage fine-tuning jobs to tailor a model to your specific training data.
+    - name: Batch
+      description: Create large batches of API requests to run asynchronously.
+    - name: Files
+      description: Files are used to upload documents that can be used with features like Assistants and Fine-tuning.
+    - name: Uploads
+      description: Use Uploads to upload large files in multiple parts.
+    - name: Images
+      description: Given a prompt and/or an input image, the model will generate a new image.
+    - name: Models
+      description: List and describe the various models available in the API.
+    - name: Moderations
+      description: Given a input text, outputs if the model classifies it as potentially harmful.
+paths:
+    # Note: When adding an endpoint, make sure you also add it in the `groups` section, in the end of this file,
+    # under the appropriate group
+    /chat/completions:
+        post:
+            operationId: createChatCompletion
+            tags:
+                - Chat
+            summary: Creates a model response for the given chat conversation.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateChatCompletionRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CreateChatCompletionResponse"
+
+            x-oaiMeta:
+                name: Create chat completion
+                group: chat
+                returns: |
+                    Returns a [chat completion](/docs/api-reference/chat/object) object, or a streamed sequence of [chat completion chunk](/docs/api-reference/chat/streaming) objects if the request is streamed.
+                path: create
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/chat/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "VAR_model_id",
+                                  "messages": [
+                                    {
+                                      "role": "system",
+                                      "content": "You are a helpful assistant."
+                                    },
+                                    {
+                                      "role": "user",
+                                      "content": "Hello!"
+                                    }
+                                  ]
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              completion = client.chat.completions.create(
+                                model="VAR_model_id",
+                                messages=[
+                                  {"role": "system", "content": "You are a helpful assistant."},
+                                  {"role": "user", "content": "Hello!"}
+                                ]
+                              )
+
+                              print(completion.choices[0].message)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const completion = await openai.chat.completions.create({
+                                  messages: [{ role: "system", content: "You are a helpful assistant." }],
+                                  model: "VAR_model_id",
+                                });
+
+                                console.log(completion.choices[0]);
+                              }
+
+                              main();
+                      response: &chat_completion_example |
+                          {
+                            "id": "chatcmpl-123",
+                            "object": "chat.completion",
+                            "created": 1677652288,
+                            "model": "gpt-4o-mini",
+                            "system_fingerprint": "fp_44709d6fcb",
+                            "choices": [{
+                              "index": 0,
+                              "message": {
+                                "role": "assistant",
+                                "content": "\n\nHello there, how may I assist you today?",
+                              },
+                              "logprobs": null,
+                              "finish_reason": "stop"
+                            }],
+                            "usage": {
+                              "prompt_tokens": 9,
+                              "completion_tokens": 12,
+                              "total_tokens": 21
+                            }
+                          }
+                    - title: Image input
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/chat/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "gpt-4-turbo",
+                                  "messages": [
+                                    {
+                                      "role": "user",
+                                      "content": [
+                                        {
+                                          "type": "text",
+                                          "text": "What'\''s in this image?"
+                                        },
+                                        {
+                                          "type": "image_url",
+                                          "image_url": {
+                                            "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "max_tokens": 300
+                                }'
+                          python: |
+                              from openai import OpenAI
+
+                              client = OpenAI()
+
+                              response = client.chat.completions.create(
+                                  model="gpt-4-turbo",
+                                  messages=[
+                                      {
+                                          "role": "user",
+                                          "content": [
+                                              {"type": "text", "text": "What's in this image?"},
+                                              {
+                                                  "type": "image_url",
+                                                  "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                                              },
+                                          ],
+                                      }
+                                  ],
+                                  max_tokens=300,
+                              )
+
+                              print(response.choices[0])
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const response = await openai.chat.completions.create({
+                                  model: "gpt-4-turbo",
+                                  messages: [
+                                    {
+                                      role: "user",
+                                      content: [
+                                        { type: "text", text: "What's in this image?" },
+                                        {
+                                          type: "image_url",
+                                          image_url:
+                                            "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                });
+                                console.log(response.choices[0]);
+                              }
+                              main();
+                      response: &chat_completion_image_example |
+                          {
+                            "id": "chatcmpl-123",
+                            "object": "chat.completion",
+                            "created": 1677652288,
+                            "model": "gpt-4o-mini",
+                            "system_fingerprint": "fp_44709d6fcb",
+                            "choices": [{
+                              "index": 0,
+                              "message": {
+                                "role": "assistant",
+                                "content": "\n\nThis image shows a wooden boardwalk extending through a lush green marshland.",
+                              },
+                              "logprobs": null,
+                              "finish_reason": "stop"
+                            }],
+                            "usage": {
+                              "prompt_tokens": 9,
+                              "completion_tokens": 12,
+                              "total_tokens": 21
+                            }
+                          }
+                    - title: Streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/chat/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "VAR_model_id",
+                                  "messages": [
+                                    {
+                                      "role": "system",
+                                      "content": "You are a helpful assistant."
+                                    },
+                                    {
+                                      "role": "user",
+                                      "content": "Hello!"
+                                    }
+                                  ],
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              completion = client.chat.completions.create(
+                                model="VAR_model_id",
+                                messages=[
+                                  {"role": "system", "content": "You are a helpful assistant."},
+                                  {"role": "user", "content": "Hello!"}
+                                ],
+                                stream=True
+                              )
+
+                              for chunk in completion:
+                                print(chunk.choices[0].delta)
+
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const completion = await openai.chat.completions.create({
+                                  model: "VAR_model_id",
+                                  messages: [
+                                    {"role": "system", "content": "You are a helpful assistant."},
+                                    {"role": "user", "content": "Hello!"}
+                                  ],
+                                  stream: true,
+                                });
+
+                                for await (const chunk of completion) {
+                                  console.log(chunk.choices[0].delta.content);
+                                }
+                              }
+
+                              main();
+                      response: &chat_completion_chunk_example |
+                          {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+                          {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}
+
+                          ....
+
+                          {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+                    - title: Functions
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/chat/completions \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -d '{
+                                "model": "gpt-4-turbo",
+                                "messages": [
+                                  {
+                                    "role": "user",
+                                    "content": "What'\''s the weather like in Boston today?"
+                                  }
+                                ],
+                                "tools": [
+                                  {
+                                    "type": "function",
+                                    "function": {
+                                      "name": "get_current_weather",
+                                      "description": "Get the current weather in a given location",
+                                      "parameters": {
+                                        "type": "object",
+                                        "properties": {
+                                          "location": {
+                                            "type": "string",
+                                            "description": "The city and state, e.g. San Francisco, CA"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": ["celsius", "fahrenheit"]
+                                          }
+                                        },
+                                        "required": ["location"]
+                                      }
+                                    }
+                                  }
+                                ],
+                                "tool_choice": "auto"
+                              }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              tools = [
+                                {
+                                  "type": "function",
+                                  "function": {
+                                    "name": "get_current_weather",
+                                    "description": "Get the current weather in a given location",
+                                    "parameters": {
+                                      "type": "object",
+                                      "properties": {
+                                        "location": {
+                                          "type": "string",
+                                          "description": "The city and state, e.g. San Francisco, CA",
+                                        },
+                                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                      },
+                                      "required": ["location"],
+                                    },
+                                  }
+                                }
+                              ]
+                              messages = [{"role": "user", "content": "What's the weather like in Boston today?"}]
+                              completion = client.chat.completions.create(
+                                model="VAR_model_id",
+                                messages=messages,
+                                tools=tools,
+                                tool_choice="auto"
+                              )
+
+                              print(completion)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const messages = [{"role": "user", "content": "What's the weather like in Boston today?"}];
+                                const tools = [
+                                    {
+                                      "type": "function",
+                                      "function": {
+                                        "name": "get_current_weather",
+                                        "description": "Get the current weather in a given location",
+                                        "parameters": {
+                                          "type": "object",
+                                          "properties": {
+                                            "location": {
+                                              "type": "string",
+                                              "description": "The city and state, e.g. San Francisco, CA",
+                                            },
+                                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                          },
+                                          "required": ["location"],
+                                        },
+                                      }
+                                    }
+                                ];
+
+                                const response = await openai.chat.completions.create({
+                                  model: "gpt-4-turbo",
+                                  messages: messages,
+                                  tools: tools,
+                                  tool_choice: "auto",
+                                });
+
+                                console.log(response);
+                              }
+
+                              main();
+                      response: &chat_completion_function_example |
+                          {
+                            "id": "chatcmpl-abc123",
+                            "object": "chat.completion",
+                            "created": 1699896916,
+                            "model": "gpt-4o-mini",
+                            "choices": [
+                              {
+                                "index": 0,
+                                "message": {
+                                  "role": "assistant",
+                                  "content": null,
+                                  "tool_calls": [
+                                    {
+                                      "id": "call_abc123",
+                                      "type": "function",
+                                      "function": {
+                                        "name": "get_current_weather",
+                                        "arguments": "{\n\"location\": \"Boston, MA\"\n}"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "logprobs": null,
+                                "finish_reason": "tool_calls"
+                              }
+                            ],
+                            "usage": {
+                              "prompt_tokens": 82,
+                              "completion_tokens": 17,
+                              "total_tokens": 99
+                            }
+                          }
+                    - title: Logprobs
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/chat/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "VAR_model_id",
+                                  "messages": [
+                                    {
+                                      "role": "user",
+                                      "content": "Hello!"
+                                    }
+                                  ],
+                                  "logprobs": true,
+                                  "top_logprobs": 2
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              completion = client.chat.completions.create(
+                                model="VAR_model_id",
+                                messages=[
+                                  {"role": "user", "content": "Hello!"}
+                                ],
+                                logprobs=True,
+                                top_logprobs=2
+                              )
+
+                              print(completion.choices[0].message)
+                              print(completion.choices[0].logprobs)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const completion = await openai.chat.completions.create({
+                                  messages: [{ role: "user", content: "Hello!" }],
+                                  model: "VAR_model_id",
+                                  logprobs: true,
+                                  top_logprobs: 2,
+                                });
+
+                                console.log(completion.choices[0]);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "chatcmpl-123",
+                            "object": "chat.completion",
+                            "created": 1702685778,
+                            "model": "gpt-4o-mini",
+                            "choices": [
+                              {
+                                "index": 0,
+                                "message": {
+                                  "role": "assistant",
+                                  "content": "Hello! How can I assist you today?"
+                                },
+                                "logprobs": {
+                                  "content": [
+                                    {
+                                      "token": "Hello",
+                                      "logprob": -0.31725305,
+                                      "bytes": [72, 101, 108, 108, 111],
+                                      "top_logprobs": [
+                                        {
+                                          "token": "Hello",
+                                          "logprob": -0.31725305,
+                                          "bytes": [72, 101, 108, 108, 111]
+                                        },
+                                        {
+                                          "token": "Hi",
+                                          "logprob": -1.3190403,
+                                          "bytes": [72, 105]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": "!",
+                                      "logprob": -0.02380986,
+                                      "bytes": [
+                                        33
+                                      ],
+                                      "top_logprobs": [
+                                        {
+                                          "token": "!",
+                                          "logprob": -0.02380986,
+                                          "bytes": [33]
+                                        },
+                                        {
+                                          "token": " there",
+                                          "logprob": -3.787621,
+                                          "bytes": [32, 116, 104, 101, 114, 101]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " How",
+                                      "logprob": -0.000054669687,
+                                      "bytes": [32, 72, 111, 119],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " How",
+                                          "logprob": -0.000054669687,
+                                          "bytes": [32, 72, 111, 119]
+                                        },
+                                        {
+                                          "token": "<|end|>",
+                                          "logprob": -10.953937,
+                                          "bytes": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " can",
+                                      "logprob": -0.015801601,
+                                      "bytes": [32, 99, 97, 110],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " can",
+                                          "logprob": -0.015801601,
+                                          "bytes": [32, 99, 97, 110]
+                                        },
+                                        {
+                                          "token": " may",
+                                          "logprob": -4.161023,
+                                          "bytes": [32, 109, 97, 121]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " I",
+                                      "logprob": -3.7697225e-6,
+                                      "bytes": [
+                                        32,
+                                        73
+                                      ],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " I",
+                                          "logprob": -3.7697225e-6,
+                                          "bytes": [32, 73]
+                                        },
+                                        {
+                                          "token": " assist",
+                                          "logprob": -13.596657,
+                                          "bytes": [32, 97, 115, 115, 105, 115, 116]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " assist",
+                                      "logprob": -0.04571125,
+                                      "bytes": [32, 97, 115, 115, 105, 115, 116],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " assist",
+                                          "logprob": -0.04571125,
+                                          "bytes": [32, 97, 115, 115, 105, 115, 116]
+                                        },
+                                        {
+                                          "token": " help",
+                                          "logprob": -3.1089056,
+                                          "bytes": [32, 104, 101, 108, 112]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " you",
+                                      "logprob": -5.4385737e-6,
+                                      "bytes": [32, 121, 111, 117],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " you",
+                                          "logprob": -5.4385737e-6,
+                                          "bytes": [32, 121, 111, 117]
+                                        },
+                                        {
+                                          "token": " today",
+                                          "logprob": -12.807695,
+                                          "bytes": [32, 116, 111, 100, 97, 121]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": " today",
+                                      "logprob": -0.0040071653,
+                                      "bytes": [32, 116, 111, 100, 97, 121],
+                                      "top_logprobs": [
+                                        {
+                                          "token": " today",
+                                          "logprob": -0.0040071653,
+                                          "bytes": [32, 116, 111, 100, 97, 121]
+                                        },
+                                        {
+                                          "token": "?",
+                                          "logprob": -5.5247097,
+                                          "bytes": [63]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "token": "?",
+                                      "logprob": -0.0008108172,
+                                      "bytes": [63],
+                                      "top_logprobs": [
+                                        {
+                                          "token": "?",
+                                          "logprob": -0.0008108172,
+                                          "bytes": [63]
+                                        },
+                                        {
+                                          "token": "?\n",
+                                          "logprob": -7.184561,
+                                          "bytes": [63, 10]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "finish_reason": "stop"
+                              }
+                            ],
+                            "usage": {
+                              "prompt_tokens": 9,
+                              "completion_tokens": 9,
+                              "total_tokens": 18
+                            },
+                            "system_fingerprint": null
+                          }
+
+    /completions:
+        post:
+            operationId: createCompletion
+            tags:
+                - Completions
+            summary: Creates a completion for the provided prompt and parameters.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateCompletionRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CreateCompletionResponse"
+            x-oaiMeta:
+                name: Create completion
+                group: completions
+                returns: |
+                    Returns a [completion](/docs/api-reference/completions/object) object, or a sequence of completion objects if the request is streamed.
+                legacy: true
+                examples:
+                    - title: No streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "VAR_model_id",
+                                  "prompt": "Say this is a test",
+                                  "max_tokens": 7,
+                                  "temperature": 0
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              client.completions.create(
+                                model="VAR_model_id",
+                                prompt="Say this is a test",
+                                max_tokens=7,
+                                temperature=0
+                              )
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const completion = await openai.completions.create({
+                                  model: "VAR_model_id",
+                                  prompt: "Say this is a test.",
+                                  max_tokens: 7,
+                                  temperature: 0,
+                                });
+
+                                console.log(completion);
+                              }
+                              main();
+                      response: |
+                          {
+                            "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+                            "object": "text_completion",
+                            "created": 1589478378,
+                            "model": "VAR_model_id",
+                            "system_fingerprint": "fp_44709d6fcb",
+                            "choices": [
+                              {
+                                "text": "\n\nThis is indeed a test",
+                                "index": 0,
+                                "logprobs": null,
+                                "finish_reason": "length"
+                              }
+                            ],
+                            "usage": {
+                              "prompt_tokens": 5,
+                              "completion_tokens": 7,
+                              "total_tokens": 12
+                            }
+                          }
+                    - title: Streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/completions \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "model": "VAR_model_id",
+                                  "prompt": "Say this is a test",
+                                  "max_tokens": 7,
+                                  "temperature": 0,
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              for chunk in client.completions.create(
+                                model="VAR_model_id",
+                                prompt="Say this is a test",
+                                max_tokens=7,
+                                temperature=0,
+                                stream=True
+                              ):
+                                print(chunk.choices[0].text)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const stream = await openai.completions.create({
+                                  model: "VAR_model_id",
+                                  prompt: "Say this is a test.",
+                                  stream: true,
+                                });
+
+                                for await (const chunk of stream) {
+                                  console.log(chunk.choices[0].text)
+                                }
+                              }
+                              main();
+                      response: |
+                          {
+                            "id": "cmpl-7iA7iJjj8V2zOkCGvWF2hAkDWBQZe",
+                            "object": "text_completion",
+                            "created": 1690759702,
+                            "choices": [
+                              {
+                                "text": "This",
+                                "index": 0,
+                                "logprobs": null,
+                                "finish_reason": null
+                              }
+                            ],
+                            "model": "gpt-3.5-turbo-instruct"
+                            "system_fingerprint": "fp_44709d6fcb",
+                          }
+
+    /images/generations:
+        post:
+            operationId: createImage
+            tags:
+                - Images
+            summary: Creates an image given a prompt.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateImageRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ImagesResponse"
+            x-oaiMeta:
+                name: Create image
+                group: images
+                returns: Returns a list of [image](/docs/api-reference/images/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/images/generations \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -d '{
+                                "model": "dall-e-3",
+                                "prompt": "A cute baby sea otter",
+                                "n": 1,
+                                "size": "1024x1024"
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.images.generate(
+                              model="dall-e-3",
+                              prompt="A cute baby sea otter",
+                              n=1,
+                              size="1024x1024"
+                            )
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const image = await openai.images.generate({ model: "dall-e-3", prompt: "A cute baby sea otter" });
+
+                              console.log(image.data);
+                            }
+                            main();
+                    response: |
+                        {
+                          "created": 1589478378,
+                          "data": [
+                            {
+                              "url": "https://..."
+                            },
+                            {
+                              "url": "https://..."
+                            }
+                          ]
+                        }
+    /images/edits:
+        post:
+            operationId: createImageEdit
+            tags:
+                - Images
+            summary: Creates an edited or extended image given an original image and a prompt.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/CreateImageEditRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ImagesResponse"
+            x-oaiMeta:
+                name: Create image edit
+                group: images
+                returns: Returns a list of [image](/docs/api-reference/images/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/images/edits \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -F image="@otter.png" \
+                              -F mask="@mask.png" \
+                              -F prompt="A cute baby sea otter wearing a beret" \
+                              -F n=2 \
+                              -F size="1024x1024"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.images.edit(
+                              image=open("otter.png", "rb"),
+                              mask=open("mask.png", "rb"),
+                              prompt="A cute baby sea otter wearing a beret",
+                              n=2,
+                              size="1024x1024"
+                            )
+                        node.js: |-
+                            import fs from "fs";
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const image = await openai.images.edit({
+                                image: fs.createReadStream("otter.png"),
+                                mask: fs.createReadStream("mask.png"),
+                                prompt: "A cute baby sea otter wearing a beret",
+                              });
+
+                              console.log(image.data);
+                            }
+                            main();
+                    response: |
+                        {
+                          "created": 1589478378,
+                          "data": [
+                            {
+                              "url": "https://..."
+                            },
+                            {
+                              "url": "https://..."
+                            }
+                          ]
+                        }
+    /images/variations:
+        post:
+            operationId: createImageVariation
+            tags:
+                - Images
+            summary: Creates a variation of a given image.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/CreateImageVariationRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ImagesResponse"
+            x-oaiMeta:
+                name: Create image variation
+                group: images
+                returns: Returns a list of [image](/docs/api-reference/images/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/images/variations \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -F image="@otter.png" \
+                              -F n=2 \
+                              -F size="1024x1024"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            response = client.images.create_variation(
+                              image=open("image_edit_original.png", "rb"),
+                              n=2,
+                              size="1024x1024"
+                            )
+                        node.js: |-
+                            import fs from "fs";
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const image = await openai.images.createVariation({
+                                image: fs.createReadStream("otter.png"),
+                              });
+
+                              console.log(image.data);
+                            }
+                            main();
+                    response: |
+                        {
+                          "created": 1589478378,
+                          "data": [
+                            {
+                              "url": "https://..."
+                            },
+                            {
+                              "url": "https://..."
+                            }
+                          ]
+                        }
+
+    /embeddings:
+        post:
+            operationId: createEmbedding
+            tags:
+                - Embeddings
+            summary: Creates an embedding vector representing the input text.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateEmbeddingRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CreateEmbeddingResponse"
+            x-oaiMeta:
+                name: Create embeddings
+                group: embeddings
+                returns: A list of [embedding](/docs/api-reference/embeddings/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/embeddings \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -d '{
+                                "input": "The food was delicious and the waiter...",
+                                "model": "text-embedding-ada-002",
+                                "encoding_format": "float"
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.embeddings.create(
+                              model="text-embedding-ada-002",
+                              input="The food was delicious and the waiter...",
+                              encoding_format="float"
+                            )
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const embedding = await openai.embeddings.create({
+                                model: "text-embedding-ada-002",
+                                input: "The quick brown fox jumped over the lazy dog",
+                                encoding_format: "float",
+                              });
+
+                              console.log(embedding);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "object": "embedding",
+                              "embedding": [
+                                0.0023064255,
+                                -0.009327292,
+                                .... (1536 floats total for ada-002)
+                                -0.0028842222,
+                              ],
+                              "index": 0
+                            }
+                          ],
+                          "model": "text-embedding-ada-002",
+                          "usage": {
+                            "prompt_tokens": 8,
+                            "total_tokens": 8
+                          }
+                        }
+
+    /audio/speech:
+        post:
+            operationId: createSpeech
+            tags:
+                - Audio
+            summary: Generates audio from the input text.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateSpeechRequest"
+            responses:
+                "200":
+                    description: OK
+                    headers:
+                        Transfer-Encoding:
+                            schema:
+                                type: string
+                            description: chunked
+                    content:
+                        application/octet-stream:
+                            schema:
+                                type: string
+                                format: binary
+            x-oaiMeta:
+                name: Create speech
+                group: audio
+                returns: The audio file content.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/audio/speech \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -d '{
+                                "model": "tts-1",
+                                "input": "The quick brown fox jumped over the lazy dog.",
+                                "voice": "alloy"
+                              }' \
+                              --output speech.mp3
+                        python: |
+                            from pathlib import Path
+                            import openai
+
+                            speech_file_path = Path(__file__).parent / "speech.mp3"
+                            response = openai.audio.speech.create(
+                              model="tts-1",
+                              voice="alloy",
+                              input="The quick brown fox jumped over the lazy dog."
+                            )
+                            response.stream_to_file(speech_file_path)
+                        node: |
+                            import fs from "fs";
+                            import path from "path";
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            const speechFile = path.resolve("./speech.mp3");
+
+                            async function main() {
+                              const mp3 = await openai.audio.speech.create({
+                                model: "tts-1",
+                                voice: "alloy",
+                                input: "Today is a wonderful day to build something people love!",
+                              });
+                              console.log(speechFile);
+                              const buffer = Buffer.from(await mp3.arrayBuffer());
+                              await fs.promises.writeFile(speechFile, buffer);
+                            }
+                            main();
+    /audio/transcriptions:
+        post:
+            operationId: createTranscription
+            tags:
+                - Audio
+            summary: Transcribes audio into the input language.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/CreateTranscriptionRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                oneOf:
+                                    - $ref: "#/components/schemas/CreateTranscriptionResponseJson"
+                                    - $ref: "#/components/schemas/CreateTranscriptionResponseVerboseJson"
+            x-oaiMeta:
+                name: Create transcription
+                group: audio
+                returns: The [transcription object](/docs/api-reference/audio/json-object) or a [verbose transcription object](/docs/api-reference/audio/verbose-json-object).
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/audio/transcriptions \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: multipart/form-data" \
+                                -F file="@/path/to/file/audio.mp3" \
+                                -F model="whisper-1"
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              audio_file = open("speech.mp3", "rb")
+                              transcript = client.audio.transcriptions.create(
+                                model="whisper-1",
+                                file=audio_file
+                              )
+                          node: |
+                              import fs from "fs";
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const transcription = await openai.audio.transcriptions.create({
+                                  file: fs.createReadStream("audio.mp3"),
+                                  model: "whisper-1",
+                                });
+
+                                console.log(transcription.text);
+                              }
+                              main();
+                      response: &basic_transcription_response_example |
+                          {
+                            "text": "Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that."
+                          }
+                    - title: Word timestamps
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/audio/transcriptions \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: multipart/form-data" \
+                                -F file="@/path/to/file/audio.mp3" \
+                                -F "timestamp_granularities[]=word" \
+                                -F model="whisper-1" \
+                                -F response_format="verbose_json"
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              audio_file = open("speech.mp3", "rb")
+                              transcript = client.audio.transcriptions.create(
+                                file=audio_file,
+                                model="whisper-1",
+                                response_format="verbose_json",
+                                timestamp_granularities=["word"]
+                              )
+
+                              print(transcript.words)
+                          node: |
+                              import fs from "fs";
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const transcription = await openai.audio.transcriptions.create({
+                                  file: fs.createReadStream("audio.mp3"),
+                                  model: "whisper-1",
+                                  response_format: "verbose_json",
+                                  timestamp_granularities: ["word"]
+                                });
+
+                                console.log(transcription.text);
+                              }
+                              main();
+                      response: |
+                          {
+                            "task": "transcribe",
+                            "language": "english",
+                            "duration": 8.470000267028809,
+                            "text": "The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.",
+                            "words": [
+                              {
+                                "word": "The",
+                                "start": 0.0,
+                                "end": 0.23999999463558197
+                              },
+                              ...
+                              {
+                                "word": "volleyball",
+                                "start": 7.400000095367432,
+                                "end": 7.900000095367432
+                              }
+                            ]
+                          }
+                    - title: Segment timestamps
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/audio/transcriptions \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: multipart/form-data" \
+                                -F file="@/path/to/file/audio.mp3" \
+                                -F "timestamp_granularities[]=segment" \
+                                -F model="whisper-1" \
+                                -F response_format="verbose_json"
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              audio_file = open("speech.mp3", "rb")
+                              transcript = client.audio.transcriptions.create(
+                                file=audio_file,
+                                model="whisper-1",
+                                response_format="verbose_json",
+                                timestamp_granularities=["segment"]
+                              )
+
+                              print(transcript.words)
+                          node: |
+                              import fs from "fs";
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const transcription = await openai.audio.transcriptions.create({
+                                  file: fs.createReadStream("audio.mp3"),
+                                  model: "whisper-1",
+                                  response_format: "verbose_json",
+                                  timestamp_granularities: ["segment"]
+                                });
+
+                                console.log(transcription.text);
+                              }
+                              main();
+                      response: &verbose_transcription_response_example |
+                          {
+                            "task": "transcribe",
+                            "language": "english",
+                            "duration": 8.470000267028809,
+                            "text": "The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.",
+                            "segments": [
+                              {
+                                "id": 0,
+                                "seek": 0,
+                                "start": 0.0,
+                                "end": 3.319999933242798,
+                                "text": " The beach was a popular spot on a hot summer day.",
+                                "tokens": [
+                                  50364, 440, 7534, 390, 257, 3743, 4008, 322, 257, 2368, 4266, 786, 13, 50530
+                                ],
+                                "temperature": 0.0,
+                                "avg_logprob": -0.2860786020755768,
+                                "compression_ratio": 1.2363636493682861,
+                                "no_speech_prob": 0.00985979475080967
+                              },
+                              ...
+                            ]
+                          }
+    /audio/translations:
+        post:
+            operationId: createTranslation
+            tags:
+                - Audio
+            summary: Translates audio into English.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/CreateTranslationRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                oneOf:
+                                    - $ref: "#/components/schemas/CreateTranslationResponseJson"
+                                    - $ref: "#/components/schemas/CreateTranslationResponseVerboseJson"
+            x-oaiMeta:
+                name: Create translation
+                group: audio
+                returns: The translated text.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/audio/translations \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: multipart/form-data" \
+                              -F file="@/path/to/file/german.m4a" \
+                              -F model="whisper-1"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            audio_file = open("speech.mp3", "rb")
+                            transcript = client.audio.translations.create(
+                              model="whisper-1",
+                              file=audio_file
+                            )
+                        node: |
+                            import fs from "fs";
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                                const translation = await openai.audio.translations.create({
+                                    file: fs.createReadStream("speech.mp3"),
+                                    model: "whisper-1",
+                                });
+
+                                console.log(translation.text);
+                            }
+                            main();
+                    response: |
+                        {
+                          "text": "Hello, my name is Wolfgang and I come from Germany. Where are you heading today?"
+                        }
+
+    /files:
+        get:
+            operationId: listFiles
+            tags:
+                - Files
+            summary: Returns a list of files that belong to the user's organization.
+            parameters:
+                - in: query
+                  name: purpose
+                  required: false
+                  schema:
+                      type: string
+                  description: Only return files with the given purpose.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListFilesResponse"
+            x-oaiMeta:
+                name: List files
+                group: files
+                returns: A list of [File](/docs/api-reference/files/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/files \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.files.list()
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const list = await openai.files.list();
+
+                              for await (const file of list) {
+                                console.log(file);
+                              }
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "data": [
+                            {
+                              "id": "file-abc123",
+                              "object": "file",
+                              "bytes": 175,
+                              "created_at": 1613677385,
+                              "filename": "salesOverview.pdf",
+                              "purpose": "assistants",
+                            },
+                            {
+                              "id": "file-abc123",
+                              "object": "file",
+                              "bytes": 140,
+                              "created_at": 1613779121,
+                              "filename": "puppy.jsonl",
+                              "purpose": "fine-tune",
+                            }
+                          ],
+                          "object": "list"
+                        }
+        post:
+            operationId: createFile
+            tags:
+                - Files
+            summary: |
+                Upload a file that can be used across various endpoints. Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB.
+
+                The Assistants API supports files up to 2 million tokens and of specific file types. See the [Assistants Tools guide](/docs/assistants/tools) for details.
+
+                The Fine-tuning API only supports `.jsonl` files. The input also has certain required formats for fine-tuning [chat](/docs/api-reference/fine-tuning/chat-input) or [completions](/docs/api-reference/fine-tuning/completions-input) models.
+
+                The Batch API only supports `.jsonl` files up to 100 MB in size. The input also has a specific required [format](/docs/api-reference/batch/request-input).
+
+                Please [contact us](https://help.openai.com/) if you need to increase these storage limits.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/CreateFileRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/OpenAIFile"
+            x-oaiMeta:
+                name: Upload file
+                group: files
+                returns: The uploaded [File](/docs/api-reference/files/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/files \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -F purpose="fine-tune" \
+                              -F file="@mydata.jsonl"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.files.create(
+                              file=open("mydata.jsonl", "rb"),
+                              purpose="fine-tune"
+                            )
+                        node.js: |-
+                            import fs from "fs";
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const file = await openai.files.create({
+                                file: fs.createReadStream("mydata.jsonl"),
+                                purpose: "fine-tune",
+                              });
+
+                              console.log(file);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "file-abc123",
+                          "object": "file",
+                          "bytes": 120000,
+                          "created_at": 1677610602,
+                          "filename": "mydata.jsonl",
+                          "purpose": "fine-tune",
+                        }
+    /files/{file_id}:
+        delete:
+            operationId: deleteFile
+            tags:
+                - Files
+            summary: Delete a file.
+            parameters:
+                - in: path
+                  name: file_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the file to use for this request.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteFileResponse"
+            x-oaiMeta:
+                name: Delete file
+                group: files
+                returns: Deletion status.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/files/file-abc123 \
+                              -X DELETE \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.files.delete("file-abc123")
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const file = await openai.files.del("file-abc123");
+
+                              console.log(file);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "file-abc123",
+                          "object": "file",
+                          "deleted": true
+                        }
+        get:
+            operationId: retrieveFile
+            tags:
+                - Files
+            summary: Returns information about a specific file.
+            parameters:
+                - in: path
+                  name: file_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the file to use for this request.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/OpenAIFile"
+            x-oaiMeta:
+                name: Retrieve file
+                group: files
+                returns: The [File](/docs/api-reference/files/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/files/file-abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.files.retrieve("file-abc123")
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const file = await openai.files.retrieve("file-abc123");
+
+                              console.log(file);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "file-abc123",
+                          "object": "file",
+                          "bytes": 120000,
+                          "created_at": 1677610602,
+                          "filename": "mydata.jsonl",
+                          "purpose": "fine-tune",
+                        }
+    /files/{file_id}/content:
+        get:
+            operationId: downloadFile
+            tags:
+                - Files
+            summary: Returns the contents of the specified file.
+            parameters:
+                - in: path
+                  name: file_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the file to use for this request.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+            x-oaiMeta:
+                name: Retrieve file content
+                group: files
+                returns: The file content.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/files/file-abc123/content \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" > file.jsonl
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            content = client.files.content("file-abc123")
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const file = await openai.files.content("file-abc123");
+
+                              console.log(file);
+                            }
+
+                            main();
+    /uploads:
+        post:
+            operationId: createUpload
+            tags:
+                - Uploads
+            summary: |
+                Creates an intermediate [Upload](/docs/api-reference/uploads/object) object that you can add [Parts](/docs/api-reference/uploads/part-object) to. Currently, an Upload can accept at most 8 GB in total and expires after an hour after you create it.
+                
+                Once you complete the Upload, we will create a [File](/docs/api-reference/files/object) object that contains all the parts you uploaded. This File is usable in the rest of our platform as a regular File object.
+                
+                For certain `purpose`s, the correct `mime_type` must be specified. Please refer to documentation for the supported MIME types for your use case:
+                - [Assistants](/docs/assistants/tools/file-search/supported-files)
+                
+                For guidance on the proper filename extensions for each purpose, please follow the documentation on [creating a File](/docs/api-reference/files/create).
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateUploadRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Upload"
+            x-oaiMeta:
+                name: Create upload
+                group: uploads
+                returns: The [Upload](/docs/api-reference/uploads/object) object with status `pending`.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/uploads \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -d '{
+                                "purpose": "fine-tune",
+                                "filename": "training_examples.jsonl",
+                                "bytes": 2147483648,
+                                "mime_type": "text/jsonl"
+                              }'
+                    response: |
+                        {
+                          "id": "upload_abc123",
+                          "object": "upload",
+                          "bytes": 2147483648,
+                          "created_at": 1719184911,
+                          "filename": "training_examples.jsonl",
+                          "purpose": "fine-tune",
+                          "status": "pending",
+                          "expires_at": 1719127296
+                        }
+
+    /uploads/{upload_id}/parts:
+        post:
+            operationId: addUploadPart
+            tags:
+                - Uploads
+            summary: |
+                Adds a [Part](/docs/api-reference/uploads/part-object) to an [Upload](/docs/api-reference/uploads/object) object. A Part represents a chunk of bytes from the file you are trying to upload. 
+
+                Each Part can be at most 64 MB, and you can add Parts until you hit the Upload maximum of 8 GB.
+
+                It is possible to add multiple Parts in parallel. You can decide the intended order of the Parts when you [complete the Upload](/docs/api-reference/uploads/complete).
+            parameters:
+                - in: path
+                  name: upload_id
+                  required: true
+                  schema:
+                      type: string
+                      example: upload_abc123
+                  description: |
+                      The ID of the Upload.
+            requestBody:
+                required: true
+                content:
+                    multipart/form-data:
+                        schema:
+                            $ref: "#/components/schemas/AddUploadPartRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/UploadPart"
+            x-oaiMeta:
+                name: Add upload part
+                group: uploads
+                returns: The upload [Part](/docs/api-reference/uploads/part-object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/uploads/upload_abc123/parts
+                              -F data="aHR0cHM6Ly9hcGkub3BlbmFpLmNvbS92MS91cGxvYWRz..."
+                    response: |
+                        {
+                          "id": "part_def456",
+                          "object": "upload.part",
+                          "created_at": 1719185911,
+                          "upload_id": "upload_abc123"
+                        }
+
+    /uploads/{upload_id}/complete:
+        post:
+            operationId: completeUpload
+            tags:
+                - Uploads
+            summary: |
+                Completes the [Upload](/docs/api-reference/uploads/object). 
+                
+                Within the returned Upload object, there is a nested [File](/docs/api-reference/files/object) object that is ready to use in the rest of the platform.
+
+                You can specify the order of the Parts by passing in an ordered list of the Part IDs.
+
+                The number of bytes uploaded upon completion must match the number of bytes initially specified when creating the Upload object. No Parts may be added after an Upload is completed.
+            parameters:
+                - in: path
+                  name: upload_id
+                  required: true
+                  schema:
+                      type: string
+                      example: upload_abc123
+                  description: |
+                      The ID of the Upload.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CompleteUploadRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Upload"
+            x-oaiMeta:
+                name: Complete upload
+                group: uploads
+                returns: The [Upload](/docs/api-reference/uploads/object) object with status `completed` with an additional `file` property containing the created usable File object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/uploads/upload_abc123/complete
+                              -d '{
+                                "part_ids": ["part_def456", "part_ghi789"]
+                              }'
+                    response: |
+                        {
+                          "id": "upload_abc123",
+                          "object": "upload",
+                          "bytes": 2147483648,
+                          "created_at": 1719184911,
+                          "filename": "training_examples.jsonl",
+                          "purpose": "fine-tune",
+                          "status": "completed",
+                          "expires_at": 1719127296,
+                          "file": {
+                            "id": "file-xyz321",
+                            "object": "file",
+                            "bytes": 2147483648,
+                            "created_at": 1719186911,
+                            "filename": "training_examples.jsonl",
+                            "purpose": "fine-tune",
+                          }
+                        }
+
+    /uploads/{upload_id}/cancel:
+        post:
+            operationId: cancelUpload
+            tags:
+                - Uploads
+            summary: |
+                Cancels the Upload. No Parts may be added after an Upload is cancelled.
+            parameters:
+                - in: path
+                  name: upload_id
+                  required: true
+                  schema:
+                      type: string
+                      example: upload_abc123
+                  description: |
+                      The ID of the Upload.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Upload"
+            x-oaiMeta:
+                name: Cancel upload
+                group: uploads
+                returns: The [Upload](/docs/api-reference/uploads/object) object with status `cancelled`.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/uploads/upload_abc123/cancel
+                    response: |
+                        {
+                          "id": "upload_abc123",
+                          "object": "upload",
+                          "bytes": 2147483648,
+                          "created_at": 1719184911,
+                          "filename": "training_examples.jsonl",
+                          "purpose": "fine-tune",
+                          "status": "cancelled",
+                          "expires_at": 1719127296
+                        }
+  
+    /fine_tuning/jobs:
+        post:
+            operationId: createFineTuningJob
+            tags:
+                - Fine-tuning
+            summary: |
+                Creates a fine-tuning job which begins the process of creating a new model from a given dataset.
+
+                Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
+
+                [Learn more about fine-tuning](/docs/guides/fine-tuning)
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateFineTuningJobRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FineTuningJob"
+            x-oaiMeta:
+                name: Create fine-tuning job
+                group: fine-tuning
+                returns: A [fine-tuning.job](/docs/api-reference/fine-tuning/object) object.
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/fine_tuning/jobs \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "training_file": "file-BK7bzQj3FfZFXr7DbL6xJwfo",
+                                  "model": "gpt-3.5-turbo"
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              client.fine_tuning.jobs.create(
+                                training_file="file-abc123",
+                                model="gpt-3.5-turbo"
+                              )
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const fineTune = await openai.fineTuning.jobs.create({
+                                  training_file: "file-abc123"
+                                });
+
+                                console.log(fineTune);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "object": "fine_tuning.job",
+                            "id": "ftjob-abc123",
+                            "model": "gpt-3.5-turbo-0125",
+                            "created_at": 1614807352,
+                            "fine_tuned_model": null,
+                            "organization_id": "org-123",
+                            "result_files": [],
+                            "status": "queued",
+                            "validation_file": null,
+                            "training_file": "file-abc123",
+                          }
+                    - title: Epochs
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/fine_tuning/jobs \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "training_file": "file-abc123",
+                                  "model": "gpt-3.5-turbo",
+                                  "hyperparameters": {
+                                    "n_epochs": 2
+                                  }
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              client.fine_tuning.jobs.create(
+                                training_file="file-abc123",
+                                model="gpt-3.5-turbo",
+                                hyperparameters={
+                                  "n_epochs":2
+                                }
+                              )
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const fineTune = await openai.fineTuning.jobs.create({
+                                  training_file: "file-abc123",
+                                  model: "gpt-3.5-turbo",
+                                  hyperparameters: { n_epochs: 2 }
+                                });
+
+                                console.log(fineTune);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "object": "fine_tuning.job",
+                            "id": "ftjob-abc123",
+                            "model": "gpt-3.5-turbo-0125",
+                            "created_at": 1614807352,
+                            "fine_tuned_model": null,
+                            "organization_id": "org-123",
+                            "result_files": [],
+                            "status": "queued",
+                            "validation_file": null,
+                            "training_file": "file-abc123",
+                            "hyperparameters": {"n_epochs": 2},
+                          }
+                    - title: Validation file
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/fine_tuning/jobs \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "training_file": "file-abc123",
+                                  "validation_file": "file-abc123",
+                                  "model": "gpt-3.5-turbo"
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              client.fine_tuning.jobs.create(
+                                training_file="file-abc123",
+                                validation_file="file-def456",
+                                model="gpt-3.5-turbo"
+                              )
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const fineTune = await openai.fineTuning.jobs.create({
+                                  training_file: "file-abc123",
+                                  validation_file: "file-abc123"
+                                });
+
+                                console.log(fineTune);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "object": "fine_tuning.job",
+                            "id": "ftjob-abc123",
+                            "model": "gpt-3.5-turbo-0125",
+                            "created_at": 1614807352,
+                            "fine_tuned_model": null,
+                            "organization_id": "org-123",
+                            "result_files": [],
+                            "status": "queued",
+                            "validation_file": "file-abc123",
+                            "training_file": "file-abc123",
+                          }
+                    - title: W&B Integration
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/fine_tuning/jobs \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -d '{
+                                  "training_file": "file-abc123",
+                                  "validation_file": "file-abc123",
+                                  "model": "gpt-3.5-turbo",
+                                  "integrations": [
+                                    {
+                                      "type": "wandb",
+                                      "wandb": {
+                                        "project": "my-wandb-project",
+                                        "name": "ft-run-display-name"
+                                        "tags": [
+                                          "first-experiment", "v2"
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }'
+                      response: |
+                          {
+                            "object": "fine_tuning.job",
+                            "id": "ftjob-abc123",
+                            "model": "gpt-3.5-turbo-0125",
+                            "created_at": 1614807352,
+                            "fine_tuned_model": null,
+                            "organization_id": "org-123",
+                            "result_files": [],
+                            "status": "queued",
+                            "validation_file": "file-abc123",
+                            "training_file": "file-abc123",
+                            "integrations": [
+                              {
+                                "type": "wandb",
+                                "wandb": {
+                                  "project": "my-wandb-project",
+                                  "entity": None,
+                                  "run_id": "ftjob-abc123"
+                                }
+                              }
+                            ]
+                          }
+        get:
+            operationId: listPaginatedFineTuningJobs
+            tags:
+                - Fine-tuning
+            summary: |
+                List your organization's fine-tuning jobs
+            parameters:
+                - name: after
+                  in: query
+                  description: Identifier for the last job from the previous pagination request.
+                  required: false
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: Number of fine-tuning jobs to retrieve.
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListPaginatedFineTuningJobsResponse"
+            x-oaiMeta:
+                name: List fine-tuning jobs
+                group: fine-tuning
+                returns: A list of paginated [fine-tuning job](/docs/api-reference/fine-tuning/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/fine_tuning/jobs?limit=2 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.fine_tuning.jobs.list()
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const list = await openai.fineTuning.jobs.list();
+
+                              for await (const fineTune of list) {
+                                console.log(fineTune);
+                              }
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "object": "fine_tuning.job.event",
+                              "id": "ft-event-TjX0lMfOniCZX64t9PUQT5hn",
+                              "created_at": 1689813489,
+                              "level": "warn",
+                              "message": "Fine tuning process stopping due to job cancellation",
+                              "data": null,
+                              "type": "message"
+                            },
+                            { ... },
+                            { ... }
+                          ], "has_more": true
+                        }
+    /fine_tuning/jobs/{fine_tuning_job_id}:
+        get:
+            operationId: retrieveFineTuningJob
+            tags:
+                - Fine-tuning
+            summary: |
+                Get info about a fine-tuning job.
+
+                [Learn more about fine-tuning](/docs/guides/fine-tuning)
+            parameters:
+                - in: path
+                  name: fine_tuning_job_id
+                  required: true
+                  schema:
+                      type: string
+                      example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+                  description: |
+                      The ID of the fine-tuning job.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FineTuningJob"
+            x-oaiMeta:
+                name: Retrieve fine-tuning job
+                group: fine-tuning
+                returns: The [fine-tuning](/docs/api-reference/fine-tuning/object) object with the given ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.fine_tuning.jobs.retrieve("ftjob-abc123")
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const fineTune = await openai.fineTuning.jobs.retrieve("ftjob-abc123");
+
+                              console.log(fineTune);
+                            }
+
+                            main();
+                    response: &fine_tuning_example |
+                        {
+                          "object": "fine_tuning.job",
+                          "id": "ftjob-abc123",
+                          "model": "davinci-002",
+                          "created_at": 1692661014,
+                          "finished_at": 1692661190,
+                          "fine_tuned_model": "ft:davinci-002:my-org:custom_suffix:7q8mpxmy",
+                          "organization_id": "org-123",
+                          "result_files": [
+                              "file-abc123"
+                          ],
+                          "status": "succeeded",
+                          "validation_file": null,
+                          "training_file": "file-abc123",
+                          "hyperparameters": {
+                              "n_epochs": 4,
+                              "batch_size": 1,
+                              "learning_rate_multiplier": 1.0
+                          },
+                          "trained_tokens": 5768,
+                          "integrations": [],
+                          "seed": 0,
+                          "estimated_finish": 0
+                        }
+    /fine_tuning/jobs/{fine_tuning_job_id}/events:
+        get:
+            operationId: listFineTuningEvents
+            tags:
+                - Fine-tuning
+            summary: |
+                Get status updates for a fine-tuning job.
+            parameters:
+                - in: path
+                  name: fine_tuning_job_id
+                  required: true
+                  schema:
+                      type: string
+                      example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+                  description: |
+                      The ID of the fine-tuning job to get events for.
+                - name: after
+                  in: query
+                  description: Identifier for the last event from the previous pagination request.
+                  required: false
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: Number of events to retrieve.
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListFineTuningJobEventsResponse"
+            x-oaiMeta:
+                name: List fine-tuning events
+                group: fine-tuning
+                returns: A list of fine-tuning event objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/events \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.fine_tuning.jobs.list_events(
+                              fine_tuning_job_id="ftjob-abc123",
+                              limit=2
+                            )
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const list = await openai.fineTuning.list_events(id="ftjob-abc123", limit=2);
+
+                              for await (const fineTune of list) {
+                                console.log(fineTune);
+                              }
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "object": "fine_tuning.job.event",
+                              "id": "ft-event-ddTJfwuMVpfLXseO0Am0Gqjm",
+                              "created_at": 1692407401,
+                              "level": "info",
+                              "message": "Fine tuning job successfully completed",
+                              "data": null,
+                              "type": "message"
+                            },
+                            {
+                              "object": "fine_tuning.job.event",
+                              "id": "ft-event-tyiGuB72evQncpH87xe505Sv",
+                              "created_at": 1692407400,
+                              "level": "info",
+                              "message": "New fine-tuned model created: ft:gpt-3.5-turbo:openai::7p4lURel",
+                              "data": null,
+                              "type": "message"
+                            }
+                          ],
+                          "has_more": true
+                        }
+    /fine_tuning/jobs/{fine_tuning_job_id}/cancel:
+        post:
+            operationId: cancelFineTuningJob
+            tags:
+                - Fine-tuning
+            summary: |
+                Immediately cancel a fine-tune job.
+            parameters:
+                - in: path
+                  name: fine_tuning_job_id
+                  required: true
+                  schema:
+                      type: string
+                      example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+                  description: |
+                      The ID of the fine-tuning job to cancel.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FineTuningJob"
+            x-oaiMeta:
+                name: Cancel fine-tuning
+                group: fine-tuning
+                returns: The cancelled [fine-tuning](/docs/api-reference/fine-tuning/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl -X POST https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/cancel \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.fine_tuning.jobs.cancel("ftjob-abc123")
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const fineTune = await openai.fineTuning.jobs.cancel("ftjob-abc123");
+
+                              console.log(fineTune);
+                            }
+                            main();
+                    response: |
+                        {
+                          "object": "fine_tuning.job",
+                          "id": "ftjob-abc123",
+                          "model": "gpt-3.5-turbo-0125",
+                          "created_at": 1689376978,
+                          "fine_tuned_model": null,
+                          "organization_id": "org-123",
+                          "result_files": [],
+                          "hyperparameters": {
+                            "n_epochs":  "auto"
+                          },
+                          "status": "cancelled",
+                          "validation_file": "file-abc123",
+                          "training_file": "file-abc123"
+                        }
+    /fine_tuning/jobs/{fine_tuning_job_id}/checkpoints:
+        get:
+            operationId: listFineTuningJobCheckpoints
+            tags:
+                - Fine-tuning
+            summary: |
+                List checkpoints for a fine-tuning job.
+            parameters:
+                - in: path
+                  name: fine_tuning_job_id
+                  required: true
+                  schema:
+                      type: string
+                      example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+                  description: |
+                      The ID of the fine-tuning job to get checkpoints for.
+                - name: after
+                  in: query
+                  description: Identifier for the last checkpoint ID from the previous pagination request.
+                  required: false
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: Number of checkpoints to retrieve.
+                  required: false
+                  schema:
+                      type: integer
+                      default: 10
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListFineTuningJobCheckpointsResponse"
+            x-oaiMeta:
+                name: List fine-tuning checkpoints
+                group: fine-tuning
+                returns: A list of fine-tuning [checkpoint objects](/docs/api-reference/fine-tuning/checkpoint-object) for a fine-tuning job.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/checkpoints \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                    response: |
+                        {
+                          "object": "list"
+                          "data": [
+                            {
+                              "object": "fine_tuning.job.checkpoint",
+                              "id": "ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB",
+                              "created_at": 1519129973,
+                              "fine_tuned_model_checkpoint": "ft:gpt-3.5-turbo-0125:my-org:custom-suffix:96olL566:ckpt-step-2000",
+                              "metrics": {
+                                "full_valid_loss": 0.134,
+                                "full_valid_mean_token_accuracy": 0.874
+                              },
+                              "fine_tuning_job_id": "ftjob-abc123",
+                              "step_number": 2000,
+                            },
+                            {
+                              "object": "fine_tuning.job.checkpoint",
+                              "id": "ftckpt_enQCFmOTGj3syEpYVhBRLTSy",
+                              "created_at": 1519129833,
+                              "fine_tuned_model_checkpoint": "ft:gpt-3.5-turbo-0125:my-org:custom-suffix:7q8mpxmy:ckpt-step-1000",
+                              "metrics": {
+                                "full_valid_loss": 0.167,
+                                "full_valid_mean_token_accuracy": 0.781
+                              },
+                              "fine_tuning_job_id": "ftjob-abc123",
+                              "step_number": 1000,
+                            },
+                          ],
+                          "first_id": "ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB",
+                          "last_id": "ftckpt_enQCFmOTGj3syEpYVhBRLTSy",
+                          "has_more": true
+                        }
+
+    /models:
+        get:
+            operationId: listModels
+            tags:
+                - Models
+            summary: Lists the currently available models, and provides basic information about each one such as the owner and availability.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListModelsResponse"
+            x-oaiMeta:
+                name: List models
+                group: models
+                returns: A list of [model](/docs/api-reference/models/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/models \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.models.list()
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const list = await openai.models.list();
+
+                              for await (const model of list) {
+                                console.log(model);
+                              }
+                            }
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "model-id-0",
+                              "object": "model",
+                              "created": 1686935002,
+                              "owned_by": "organization-owner"
+                            },
+                            {
+                              "id": "model-id-1",
+                              "object": "model",
+                              "created": 1686935002,
+                              "owned_by": "organization-owner",
+                            },
+                            {
+                              "id": "model-id-2",
+                              "object": "model",
+                              "created": 1686935002,
+                              "owned_by": "openai"
+                            },
+                          ],
+                          "object": "list"
+                        }
+    /models/{model}:
+        get:
+            operationId: retrieveModel
+            tags:
+                - Models
+            summary: Retrieves a model instance, providing basic information about the model such as the owner and permissioning.
+            parameters:
+                - in: path
+                  name: model
+                  required: true
+                  schema:
+                      type: string
+                      # ideally this will be an actual ID, so this will always work from browser
+                      example: gpt-3.5-turbo
+                  description: The ID of the model to use for this request
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Model"
+            x-oaiMeta:
+                name: Retrieve model
+                group: models
+                returns: The [model](/docs/api-reference/models/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/models/VAR_model_id \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.models.retrieve("VAR_model_id")
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const model = await openai.models.retrieve("VAR_model_id");
+
+                              console.log(model);
+                            }
+
+                            main();
+                    response: &retrieve_model_response |
+                        {
+                          "id": "VAR_model_id",
+                          "object": "model",
+                          "created": 1686935002,
+                          "owned_by": "openai"
+                        }
+        delete:
+            operationId: deleteModel
+            tags:
+                - Models
+            summary: Delete a fine-tuned model. You must have the Owner role in your organization to delete a model.
+            parameters:
+                - in: path
+                  name: model
+                  required: true
+                  schema:
+                      type: string
+                      example: ft:gpt-3.5-turbo:acemeco:suffix:abc123
+                  description: The model to delete
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteModelResponse"
+            x-oaiMeta:
+                name: Delete a fine-tuned model
+                group: models
+                returns: Deletion status.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/models/ft:gpt-3.5-turbo:acemeco:suffix:abc123 \
+                              -X DELETE \
+                              -H "Authorization: Bearer $OPENAI_API_KEY"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.models.delete("ft:gpt-3.5-turbo:acemeco:suffix:abc123")
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const model = await openai.models.del("ft:gpt-3.5-turbo:acemeco:suffix:abc123");
+
+                              console.log(model);
+                            }
+                            main();
+                    response: |
+                        {
+                          "id": "ft:gpt-3.5-turbo:acemeco:suffix:abc123",
+                          "object": "model",
+                          "deleted": true
+                        }
+
+    /moderations:
+        post:
+            operationId: createModeration
+            tags:
+                - Moderations
+            summary: Classifies if text is potentially harmful.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateModerationRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/CreateModerationResponse"
+            x-oaiMeta:
+                name: Create moderation
+                group: moderations
+                returns: A [moderation](/docs/api-reference/moderations/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/moderations \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -d '{
+                                "input": "I want to kill them."
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            moderation = client.moderations.create(input="I want to kill them.")
+                            print(moderation)
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const moderation = await openai.moderations.create({ input: "I want to kill them." });
+
+                              console.log(moderation);
+                            }
+                            main();
+                    response: &moderation_example |
+                        {
+                          "id": "modr-XXXXX",
+                          "model": "text-moderation-005",
+                          "results": [
+                            {
+                              "flagged": true,
+                              "categories": {
+                                "sexual": false,
+                                "hate": false,
+                                "harassment": false,
+                                "self-harm": false,
+                                "sexual/minors": false,
+                                "hate/threatening": false,
+                                "violence/graphic": false,
+                                "self-harm/intent": false,
+                                "self-harm/instructions": false,
+                                "harassment/threatening": true,
+                                "violence": true,
+                              },
+                              "category_scores": {
+                                "sexual": 1.2282071e-06,
+                                "hate": 0.010696256,
+                                "harassment": 0.29842457,
+                                "self-harm": 1.5236925e-08,
+                                "sexual/minors": 5.7246268e-08,
+                                "hate/threatening": 0.0060676364,
+                                "violence/graphic": 4.435014e-06,
+                                "self-harm/intent": 8.098441e-10,
+                                "self-harm/instructions": 2.8498655e-11,
+                                "harassment/threatening": 0.63055265,
+                                "violence": 0.99011886,
+                              }
+                            }
+                          ]
+                        }
+
+    /assistants:
+        get:
+            operationId: listAssistants
+            tags:
+                - Assistants
+            summary: Returns a list of assistants.
+            parameters:
+                - name: limit
+                  in: query
+                  description: &pagination_limit_param_description |
+                      A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: &pagination_order_param_description |
+                      Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: &pagination_after_param_description |
+                      A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: &pagination_before_param_description |
+                      A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListAssistantsResponse"
+            x-oaiMeta:
+                name: List assistants
+                group: assistants
+                beta: true
+                returns: A list of [assistant](/docs/api-reference/assistants/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl "https://api.openai.com/v1/assistants?order=desc&limit=20" \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            my_assistants = client.beta.assistants.list(
+                                order="desc",
+                                limit="20",
+                            )
+                            print(my_assistants.data)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myAssistants = await openai.beta.assistants.list({
+                                order: "desc",
+                                limit: "20",
+                              });
+
+                              console.log(myAssistants.data);
+                            }
+
+                            main();
+                    response: &list_assistants_example |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "asst_abc123",
+                              "object": "assistant",
+                              "created_at": 1698982736,
+                              "name": "Coding Tutor",
+                              "description": null,
+                              "model": "gpt-4-turbo",
+                              "instructions": "You are a helpful assistant designed to make me better at coding!",
+                              "tools": [],
+                              "tool_resources": {},
+                              "metadata": {},
+                              "top_p": 1.0,
+                              "temperature": 1.0,
+                              "response_format": "auto"
+                            },
+                            {
+                              "id": "asst_abc456",
+                              "object": "assistant",
+                              "created_at": 1698982718,
+                              "name": "My Assistant",
+                              "description": null,
+                              "model": "gpt-4-turbo",
+                              "instructions": "You are a helpful assistant designed to make me better at coding!",
+                              "tools": [],
+                              "tool_resources": {},
+                              "metadata": {},
+                              "top_p": 1.0,
+                              "temperature": 1.0,
+                              "response_format": "auto"
+                            },
+                            {
+                              "id": "asst_abc789",
+                              "object": "assistant",
+                              "created_at": 1698982643,
+                              "name": null,
+                              "description": null,
+                              "model": "gpt-4-turbo",
+                              "instructions": null,
+                              "tools": [],
+                              "tool_resources": {},
+                              "metadata": {},
+                              "top_p": 1.0,
+                              "temperature": 1.0,
+                              "response_format": "auto"
+                            }
+                          ],
+                          "first_id": "asst_abc123",
+                          "last_id": "asst_abc789",
+                          "has_more": false
+                        }
+        post:
+            operationId: createAssistant
+            tags:
+                - Assistants
+            summary: Create an assistant with a model and instructions.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateAssistantRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AssistantObject"
+            x-oaiMeta:
+                name: Create assistant
+                group: assistants
+                beta: true
+                returns: An [assistant](/docs/api-reference/assistants/object) object.
+                examples:
+                    - title: Code Interpreter
+                      request:
+                          curl: |
+                              curl "https://api.openai.com/v1/assistants" \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "instructions": "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                                  "name": "Math Tutor",
+                                  "tools": [{"type": "code_interpreter"}],
+                                  "model": "gpt-4-turbo"
+                                }'
+
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              my_assistant = client.beta.assistants.create(
+                                  instructions="You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                                  name="Math Tutor",
+                                  tools=[{"type": "code_interpreter"}],
+                                  model="gpt-4-turbo",
+                              )
+                              print(my_assistant)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const myAssistant = await openai.beta.assistants.create({
+                                  instructions:
+                                    "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                                  name: "Math Tutor",
+                                  tools: [{ type: "code_interpreter" }],
+                                  model: "gpt-4-turbo",
+                                });
+
+                                console.log(myAssistant);
+                              }
+
+                              main();
+                      response: &create_assistants_example |
+                          {
+                            "id": "asst_abc123",
+                            "object": "assistant",
+                            "created_at": 1698984975,
+                            "name": "Math Tutor",
+                            "description": null,
+                            "model": "gpt-4-turbo",
+                            "instructions": "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                            "tools": [
+                              {
+                                "type": "code_interpreter"
+                              }
+                            ],
+                            "metadata": {},
+                            "top_p": 1.0,
+                            "temperature": 1.0,
+                            "response_format": "auto"
+                          }
+                    - title: Files
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/assistants \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                                  "tools": [{"type": "file_search"}],
+                                  "tool_resources": {"file_search": {"vector_store_ids": ["vs_123"]}},
+                                  "model": "gpt-4-turbo"
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              my_assistant = client.beta.assistants.create(
+                                  instructions="You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                                  name="HR Helper",
+                                  tools=[{"type": "file_search"}],
+                                  tool_resources={"file_search": {"vector_store_ids": ["vs_123"]}},
+                                  model="gpt-4-turbo"
+                              )
+                              print(my_assistant)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const myAssistant = await openai.beta.assistants.create({
+                                  instructions:
+                                    "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                                  name: "HR Helper",
+                                  tools: [{ type: "file_search" }],
+                                  tool_resources: {
+                                    file_search: {
+                                      vector_store_ids: ["vs_123"]
+                                    }
+                                  },
+                                  model: "gpt-4-turbo"
+                                });
+
+                                console.log(myAssistant);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "asst_abc123",
+                            "object": "assistant",
+                            "created_at": 1699009403,
+                            "name": "HR Helper",
+                            "description": null,
+                            "model": "gpt-4-turbo",
+                            "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                            "tools": [
+                              {
+                                "type": "file_search"
+                              }
+                            ],
+                            "tool_resources": {
+                              "file_search": {
+                                "vector_store_ids": ["vs_123"]
+                              }
+                            },
+                            "metadata": {},
+                            "top_p": 1.0,
+                            "temperature": 1.0,
+                            "response_format": "auto"
+                          }
+
+    /assistants/{assistant_id}:
+        get:
+            operationId: getAssistant
+            tags:
+                - Assistants
+            summary: Retrieves an assistant.
+            parameters:
+                - in: path
+                  name: assistant_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the assistant to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AssistantObject"
+            x-oaiMeta:
+                name: Retrieve assistant
+                group: assistants
+                beta: true
+                returns: The [assistant](/docs/api-reference/assistants/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/assistants/asst_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            my_assistant = client.beta.assistants.retrieve("asst_abc123")
+                            print(my_assistant)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myAssistant = await openai.beta.assistants.retrieve(
+                                "asst_abc123"
+                              );
+
+                              console.log(myAssistant);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "asst_abc123",
+                          "object": "assistant",
+                          "created_at": 1699009709,
+                          "name": "HR Helper",
+                          "description": null,
+                          "model": "gpt-4-turbo",
+                          "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                          "tools": [
+                            {
+                              "type": "file_search"
+                            }
+                          ],
+                          "metadata": {},
+                          "top_p": 1.0,
+                          "temperature": 1.0,
+                          "response_format": "auto"
+                        }
+        post:
+            operationId: modifyAssistant
+            tags:
+                - Assistants
+            summary: Modifies an assistant.
+            parameters:
+                - in: path
+                  name: assistant_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the assistant to modify.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ModifyAssistantRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AssistantObject"
+            x-oaiMeta:
+                name: Modify assistant
+                group: assistants
+                beta: true
+                returns: The modified [assistant](/docs/api-reference/assistants/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/assistants/asst_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                  "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                                  "tools": [{"type": "file_search"}],
+                                  "model": "gpt-4-turbo"
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            my_updated_assistant = client.beta.assistants.update(
+                              "asst_abc123",
+                              instructions="You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                              name="HR Helper",
+                              tools=[{"type": "file_search"}],
+                              model="gpt-4-turbo"
+                            )
+
+                            print(my_updated_assistant)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myUpdatedAssistant = await openai.beta.assistants.update(
+                                "asst_abc123",
+                                {
+                                  instructions:
+                                    "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                                  name: "HR Helper",
+                                  tools: [{ type: "file_search" }],
+                                  model: "gpt-4-turbo"
+                                }
+                              );
+
+                              console.log(myUpdatedAssistant);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "asst_123",
+                          "object": "assistant",
+                          "created_at": 1699009709,
+                          "name": "HR Helper",
+                          "description": null,
+                          "model": "gpt-4-turbo",
+                          "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                          "tools": [
+                            {
+                              "type": "file_search"
+                            }
+                          ],
+                          "tool_resources": {
+                            "file_search": {
+                              "vector_store_ids": []
+                            }
+                          },
+                          "metadata": {},
+                          "top_p": 1.0,
+                          "temperature": 1.0,
+                          "response_format": "auto"
+                        }
+        delete:
+            operationId: deleteAssistant
+            tags:
+                - Assistants
+            summary: Delete an assistant.
+            parameters:
+                - in: path
+                  name: assistant_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the assistant to delete.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteAssistantResponse"
+            x-oaiMeta:
+                name: Delete assistant
+                group: assistants
+                beta: true
+                returns: Deletion status
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/assistants/asst_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X DELETE
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            response = client.beta.assistants.delete("asst_abc123")
+                            print(response)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const response = await openai.beta.assistants.del("asst_abc123");
+
+                              console.log(response);
+                            }
+                            main();
+                    response: |
+                        {
+                          "id": "asst_abc123",
+                          "object": "assistant.deleted",
+                          "deleted": true
+                        }
+
+    /threads:
+        post:
+            operationId: createThread
+            tags:
+                - Assistants
+            summary: Create a thread.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateThreadRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ThreadObject"
+            x-oaiMeta:
+                name: Create thread
+                group: threads
+                beta: true
+                returns: A [thread](/docs/api-reference/threads) object.
+                examples:
+                    - title: Empty
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads \
+                                -H "Content-Type: application/json" \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d ''
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              empty_thread = client.beta.threads.create()
+                              print(empty_thread)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const emptyThread = await openai.beta.threads.create();
+
+                                console.log(emptyThread);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "thread_abc123",
+                            "object": "thread",
+                            "created_at": 1699012949,
+                            "metadata": {},
+                            "tool_resources": {}
+                          }
+                    - title: Messages
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                  "messages": [{
+                                    "role": "user",
+                                    "content": "Hello, what is AI?"
+                                  }, {
+                                    "role": "user",
+                                    "content": "How does AI work? Explain it in simple terms."
+                                  }]
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              message_thread = client.beta.threads.create(
+                                messages=[
+                                  {
+                                    "role": "user",
+                                    "content": "Hello, what is AI?"
+                                  },
+                                  {
+                                    "role": "user",
+                                    "content": "How does AI work? Explain it in simple terms."
+                                  },
+                                ]
+                              )
+
+                              print(message_thread)
+                          node.js: |-
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const messageThread = await openai.beta.threads.create({
+                                  messages: [
+                                    {
+                                      role: "user",
+                                      content: "Hello, what is AI?"
+                                    },
+                                    {
+                                      role: "user",
+                                      content: "How does AI work? Explain it in simple terms.",
+                                    },
+                                  ],
+                                });
+
+                                console.log(messageThread);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "thread_abc123",
+                            "object": "thread",
+                            "created_at": 1699014083,
+                            "metadata": {},
+                            "tool_resources": {}
+                          }
+
+    /threads/{thread_id}:
+        get:
+            operationId: getThread
+            tags:
+                - Assistants
+            summary: Retrieves a thread.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ThreadObject"
+            x-oaiMeta:
+                name: Retrieve thread
+                group: threads
+                beta: true
+                returns: The [thread](/docs/api-reference/threads/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            my_thread = client.beta.threads.retrieve("thread_abc123")
+                            print(my_thread)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myThread = await openai.beta.threads.retrieve(
+                                "thread_abc123"
+                              );
+
+                              console.log(myThread);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "thread_abc123",
+                          "object": "thread",
+                          "created_at": 1699014083,
+                          "metadata": {},
+                          "tool_resources": {
+                            "code_interpreter": {
+                              "file_ids": []
+                            }
+                          }
+                        }
+        post:
+            operationId: modifyThread
+            tags:
+                - Assistants
+            summary: Modifies a thread.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to modify. Only the `metadata` can be modified.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ModifyThreadRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ThreadObject"
+            x-oaiMeta:
+                name: Modify thread
+                group: threads
+                beta: true
+                returns: The modified [thread](/docs/api-reference/threads/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                  "metadata": {
+                                    "modified": "true",
+                                    "user": "abc123"
+                                  }
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            my_updated_thread = client.beta.threads.update(
+                              "thread_abc123",
+                              metadata={
+                                "modified": "true",
+                                "user": "abc123"
+                              }
+                            )
+                            print(my_updated_thread)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const updatedThread = await openai.beta.threads.update(
+                                "thread_abc123",
+                                {
+                                  metadata: { modified: "true", user: "abc123" },
+                                }
+                              );
+
+                              console.log(updatedThread);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "thread_abc123",
+                          "object": "thread",
+                          "created_at": 1699014083,
+                          "metadata": {
+                            "modified": "true",
+                            "user": "abc123"
+                          },
+                          "tool_resources": {}
+                        }
+        delete:
+            operationId: deleteThread
+            tags:
+                - Assistants
+            summary: Delete a thread.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to delete.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteThreadResponse"
+            x-oaiMeta:
+                name: Delete thread
+                group: threads
+                beta: true
+                returns: Deletion status
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X DELETE
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            response = client.beta.threads.delete("thread_abc123")
+                            print(response)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const response = await openai.beta.threads.del("thread_abc123");
+
+                              console.log(response);
+                            }
+                            main();
+                    response: |
+                        {
+                          "id": "thread_abc123",
+                          "object": "thread.deleted",
+                          "deleted": true
+                        }
+
+    /threads/{thread_id}/messages:
+        get:
+            operationId: listMessages
+            tags:
+                - Assistants
+            summary: Returns a list of messages for a given thread.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) the messages belong to.
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+                - name: run_id
+                  in: query
+                  description: |
+                      Filter messages by the run ID that generated them.
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListMessagesResponse"
+            x-oaiMeta:
+                name: List messages
+                group: threads
+                beta: true
+                returns: A list of [message](/docs/api-reference/messages) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/messages \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            thread_messages = client.beta.threads.messages.list("thread_abc123")
+                            print(thread_messages.data)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const threadMessages = await openai.beta.threads.messages.list(
+                                "thread_abc123"
+                              );
+
+                              console.log(threadMessages.data);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "msg_abc123",
+                              "object": "thread.message",
+                              "created_at": 1699016383,
+                              "assistant_id": null,
+                              "thread_id": "thread_abc123",
+                              "run_id": null,
+                              "role": "user",
+                              "content": [
+                                {
+                                  "type": "text",
+                                  "text": {
+                                    "value": "How does AI work? Explain it in simple terms.",
+                                    "annotations": []
+                                  }
+                                }
+                              ],
+                              "attachments": [],
+                              "metadata": {}
+                            },
+                            {
+                              "id": "msg_abc456",
+                              "object": "thread.message",
+                              "created_at": 1699016383,
+                              "assistant_id": null,
+                              "thread_id": "thread_abc123",
+                              "run_id": null,
+                              "role": "user",
+                              "content": [
+                                {
+                                  "type": "text",
+                                  "text": {
+                                    "value": "Hello, what is AI?",
+                                    "annotations": []
+                                  }
+                                }
+                              ],
+                              "attachments": [],
+                              "metadata": {}
+                            }
+                          ],
+                          "first_id": "msg_abc123",
+                          "last_id": "msg_abc456",
+                          "has_more": false
+                        }
+        post:
+            operationId: createMessage
+            tags:
+                - Assistants
+            summary: Create a message.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) to create a message for.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateMessageRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/MessageObject"
+            x-oaiMeta:
+                name: Create message
+                group: threads
+                beta: true
+                returns: A [message](/docs/api-reference/messages/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/messages \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                  "role": "user",
+                                  "content": "How does AI work? Explain it in simple terms."
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            thread_message = client.beta.threads.messages.create(
+                              "thread_abc123",
+                              role="user",
+                              content="How does AI work? Explain it in simple terms.",
+                            )
+                            print(thread_message)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const threadMessages = await openai.beta.threads.messages.create(
+                                "thread_abc123",
+                                { role: "user", content: "How does AI work? Explain it in simple terms." }
+                              );
+
+                              console.log(threadMessages);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "msg_abc123",
+                          "object": "thread.message",
+                          "created_at": 1713226573,
+                          "assistant_id": null,
+                          "thread_id": "thread_abc123",
+                          "run_id": null,
+                          "role": "user",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": {
+                                "value": "How does AI work? Explain it in simple terms.",
+                                "annotations": []
+                              }
+                            }
+                          ],
+                          "attachments": [],
+                          "metadata": {}
+                        }
+
+    /threads/{thread_id}/messages/{message_id}:
+        get:
+            operationId: getMessage
+            tags:
+                - Assistants
+            summary: Retrieve a message.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) to which this message belongs.
+                - in: path
+                  name: message_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the message to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/MessageObject"
+            x-oaiMeta:
+                name: Retrieve message
+                group: threads
+                beta: true
+                returns: The [message](/docs/api-reference/messages/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            message = client.beta.threads.messages.retrieve(
+                              message_id="msg_abc123",
+                              thread_id="thread_abc123",
+                            )
+                            print(message)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const message = await openai.beta.threads.messages.retrieve(
+                                "thread_abc123",
+                                "msg_abc123"
+                              );
+
+                              console.log(message);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "msg_abc123",
+                          "object": "thread.message",
+                          "created_at": 1699017614,
+                          "assistant_id": null,
+                          "thread_id": "thread_abc123",
+                          "run_id": null,
+                          "role": "user",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": {
+                                "value": "How does AI work? Explain it in simple terms.",
+                                "annotations": []
+                              }
+                            }
+                          ],
+                          "attachments": [],
+                          "metadata": {}
+                        }
+        post:
+            operationId: modifyMessage
+            tags:
+                - Assistants
+            summary: Modifies a message.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to which this message belongs.
+                - in: path
+                  name: message_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the message to modify.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ModifyMessageRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/MessageObject"
+            x-oaiMeta:
+                name: Modify message
+                group: threads
+                beta: true
+                returns: The modified [message](/docs/api-reference/messages/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                  "metadata": {
+                                    "modified": "true",
+                                    "user": "abc123"
+                                  }
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            message = client.beta.threads.messages.update(
+                              message_id="msg_abc12",
+                              thread_id="thread_abc123",
+                              metadata={
+                                "modified": "true",
+                                "user": "abc123",
+                              },
+                            )
+                            print(message)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const message = await openai.beta.threads.messages.update(
+                                "thread_abc123",
+                                "msg_abc123",
+                                {
+                                  metadata: {
+                                    modified: "true",
+                                    user: "abc123",
+                                  },
+                                }
+                              }'
+                    response: |
+                        {
+                          "id": "msg_abc123",
+                          "object": "thread.message",
+                          "created_at": 1699017614,
+                          "assistant_id": null,
+                          "thread_id": "thread_abc123",
+                          "run_id": null,
+                          "role": "user",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": {
+                                "value": "How does AI work? Explain it in simple terms.",
+                                "annotations": []
+                              }
+                            }
+                          ],
+                          "file_ids": [],
+                          "metadata": {
+                            "modified": "true",
+                            "user": "abc123"
+                          }
+                        }
+        delete:
+            operationId: deleteMessage
+            tags:
+                - Assistants
+            summary: Deletes a message.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to which this message belongs.
+                - in: path
+                  name: message_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the message to delete.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteMessageResponse"
+            x-oaiMeta:
+                name: Delete message
+                group: threads
+                beta: true
+                returns: Deletion status
+                examples:
+                    request:
+                        curl: |
+                            curl -X DELETE https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \
+                              -H "Content-Type: application/json" \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            deleted_message = client.beta.threads.messages.delete(
+                              message_id="msg_abc12",
+                              thread_id="thread_abc123",
+                            )
+                            print(deleted_message)
+                        node.js: |-
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const deletedMessage = await openai.beta.threads.messages.del(
+                                "thread_abc123",
+                                "msg_abc123"
+                              );
+
+                              console.log(deletedMessage);
+                            }
+                    response: |
+                        {
+                          "id": "msg_abc123",
+                          "object": "thread.message.deleted",
+                          "deleted": true
+                        }
+
+    /threads/runs:
+        post:
+            operationId: createThreadAndRun
+            tags:
+                - Assistants
+            summary: Create a thread and run it in one request.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateThreadAndRunRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Create thread and run
+                group: threads
+                beta: true
+                returns: A [run](/docs/api-reference/runs/object) object.
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                    "assistant_id": "asst_abc123",
+                                    "thread": {
+                                      "messages": [
+                                        {"role": "user", "content": "Explain deep learning to a 5 year old."}
+                                      ]
+                                    }
+                                  }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              run = client.beta.threads.create_and_run(
+                                assistant_id="asst_abc123",
+                                thread={
+                                  "messages": [
+                                    {"role": "user", "content": "Explain deep learning to a 5 year old."}
+                                  ]
+                                }
+                              )
+
+                              print(run)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const run = await openai.beta.threads.createAndRun({
+                                  assistant_id: "asst_abc123",
+                                  thread: {
+                                    messages: [
+                                      { role: "user", content: "Explain deep learning to a 5 year old." },
+                                    ],
+                                  },
+                                });
+
+                                console.log(run);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "run_abc123",
+                            "object": "thread.run",
+                            "created_at": 1699076792,
+                            "assistant_id": "asst_abc123",
+                            "thread_id": "thread_abc123",
+                            "status": "queued",
+                            "started_at": null,
+                            "expires_at": 1699077392,
+                            "cancelled_at": null,
+                            "failed_at": null,
+                            "completed_at": null,
+                            "required_action": null,
+                            "last_error": null,
+                            "model": "gpt-4-turbo",
+                            "instructions": "You are a helpful assistant.",
+                            "tools": [],
+                            "tool_resources": {},
+                            "metadata": {},
+                            "temperature": 1.0,
+                            "top_p": 1.0,
+                            "max_completion_tokens": null,
+                            "max_prompt_tokens": null,
+                            "truncation_strategy": {
+                              "type": "auto",
+                              "last_messages": null
+                            },
+                            "incomplete_details": null,
+                            "usage": null,
+                            "response_format": "auto",
+                            "tool_choice": "auto",
+                            "parallel_tool_calls": true
+                          }
+
+                    - title: Streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "assistant_id": "asst_123",
+                                  "thread": {
+                                    "messages": [
+                                      {"role": "user", "content": "Hello"}
+                                    ]
+                                  },
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              stream = client.beta.threads.create_and_run(
+                                assistant_id="asst_123",
+                                thread={
+                                  "messages": [
+                                    {"role": "user", "content": "Hello"}
+                                  ]
+                                },
+                                stream=True
+                              )
+
+                              for event in stream:
+                                print(event)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const stream = await openai.beta.threads.createAndRun({
+                                    assistant_id: "asst_123",
+                                    thread: {
+                                      messages: [
+                                        { role: "user", content: "Hello" },
+                                      ],
+                                    },
+                                    stream: true
+                                });
+
+                                for await (const event of stream) {
+                                  console.log(event);
+                                }
+                              }
+
+                              main();
+                      response: |
+                          event: thread.created
+                          data: {"id":"thread_123","object":"thread","created_at":1710348075,"metadata":{}}
+
+                          event: thread.run.created
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+                          event: thread.run.queued
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+                          event: thread.run.in_progress
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+                          event: thread.run.step.created
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.run.step.in_progress
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.message.created
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[], "metadata":{}}
+
+                          event: thread.message.in_progress
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[], "metadata":{}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+                          ...
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" today"}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+                          event: thread.message.completed
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710348077,"role":"assistant","content":[{"type":"text","text":{"value":"Hello! How can I assist you today?","annotations":[]}}], "metadata":{}}
+
+                          event: thread.run.step.completed
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710348077,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+                          event: thread.run.completed
+                          {"id":"run_123","object":"thread.run","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1713226836,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1713226837,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":345,"completion_tokens":11,"total_tokens":356},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+                          event: done
+                          data: [DONE]
+
+                    - title: Streaming with Functions
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "assistant_id": "asst_abc123",
+                                  "thread": {
+                                    "messages": [
+                                      {"role": "user", "content": "What is the weather like in San Francisco?"}
+                                    ]
+                                  },
+                                  "tools": [
+                                    {
+                                      "type": "function",
+                                      "function": {
+                                        "name": "get_current_weather",
+                                        "description": "Get the current weather in a given location",
+                                        "parameters": {
+                                          "type": "object",
+                                          "properties": {
+                                            "location": {
+                                              "type": "string",
+                                              "description": "The city and state, e.g. San Francisco, CA"
+                                            },
+                                            "unit": {
+                                              "type": "string",
+                                              "enum": ["celsius", "fahrenheit"]
+                                            }
+                                          },
+                                          "required": ["location"]
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              tools = [
+                                {
+                                  "type": "function",
+                                  "function": {
+                                    "name": "get_current_weather",
+                                    "description": "Get the current weather in a given location",
+                                    "parameters": {
+                                      "type": "object",
+                                      "properties": {
+                                        "location": {
+                                          "type": "string",
+                                          "description": "The city and state, e.g. San Francisco, CA",
+                                        },
+                                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                      },
+                                      "required": ["location"],
+                                    },
+                                  }
+                                }
+                              ]
+
+                              stream = client.beta.threads.create_and_run(
+                                thread={
+                                    "messages": [
+                                      {"role": "user", "content": "What is the weather like in San Francisco?"}
+                                    ]
+                                },
+                                assistant_id="asst_abc123",
+                                tools=tools,
+                                stream=True
+                              )
+
+                              for event in stream:
+                                print(event)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              const tools = [
+                                  {
+                                    "type": "function",
+                                    "function": {
+                                      "name": "get_current_weather",
+                                      "description": "Get the current weather in a given location",
+                                      "parameters": {
+                                        "type": "object",
+                                        "properties": {
+                                          "location": {
+                                            "type": "string",
+                                            "description": "The city and state, e.g. San Francisco, CA",
+                                          },
+                                          "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                        },
+                                        "required": ["location"],
+                                      },
+                                    }
+                                  }
+                              ];
+
+                              async function main() {
+                                const stream = await openai.beta.threads.createAndRun({
+                                  assistant_id: "asst_123",
+                                  thread: {
+                                    messages: [
+                                      { role: "user", content: "What is the weather like in San Francisco?" },
+                                    ],
+                                  },
+                                  tools: tools,
+                                  stream: true
+                                });
+
+                                for await (const event of stream) {
+                                  console.log(event);
+                                }
+                              }
+
+                              main();
+                      response: |
+                          event: thread.created
+                          data: {"id":"thread_123","object":"thread","created_at":1710351818,"metadata":{}}
+
+                          event: thread.run.created
+                          data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.queued
+                          data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.in_progress
+                          data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710351818,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.step.created
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710351819,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710352418,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[]},"usage":null}
+
+                          event: thread.run.step.in_progress
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710351819,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710352418,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[]},"usage":null}
+
+                          event: thread.run.step.delta
+                          data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"id":"call_XXNp8YGaFrjrSjgqxtC8JJ1B","type":"function","function":{"name":"get_current_weather","arguments":"","output":null}}]}}}
+
+                          event: thread.run.step.delta
+                          data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"{\""}}]}}}
+
+                          event: thread.run.step.delta
+                          data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"location"}}]}}}
+
+                          ...
+
+                          event: thread.run.step.delta
+                          data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"ahrenheit"}}]}}}
+
+                          event: thread.run.step.delta
+                          data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"\"}"}}]}}}
+
+                          event: thread.run.requires_action
+                          data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"requires_action","started_at":1710351818,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":{"type":"submit_tool_outputs","submit_tool_outputs":{"tool_calls":[{"id":"call_XXNp8YGaFrjrSjgqxtC8JJ1B","type":"function","function":{"name":"get_current_weather","arguments":"{\"location\":\"San Francisco, CA\",\"unit\":\"fahrenheit\"}"}}]}},"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":345,"completion_tokens":11,"total_tokens":356},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: done
+                          data: [DONE]
+
+    /threads/{thread_id}/runs:
+        get:
+            operationId: listRuns
+            tags:
+                - Assistants
+            summary: Returns a list of runs belonging to a thread.
+            parameters:
+                - name: thread_id
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread the run belongs to.
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListRunsResponse"
+            x-oaiMeta:
+                name: List runs
+                group: threads
+                beta: true
+                returns: A list of [run](/docs/api-reference/runs/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            runs = client.beta.threads.runs.list(
+                              "thread_abc123"
+                            )
+
+                            print(runs)
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const runs = await openai.beta.threads.runs.list(
+                                "thread_abc123"
+                              );
+
+                              console.log(runs);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "run_abc123",
+                              "object": "thread.run",
+                              "created_at": 1699075072,
+                              "assistant_id": "asst_abc123",
+                              "thread_id": "thread_abc123",
+                              "status": "completed",
+                              "started_at": 1699075072,
+                              "expires_at": null,
+                              "cancelled_at": null,
+                              "failed_at": null,
+                              "completed_at": 1699075073,
+                              "last_error": null,
+                              "model": "gpt-4-turbo",
+                              "instructions": null,
+                              "incomplete_details": null,
+                              "tools": [
+                                {
+                                  "type": "code_interpreter"
+                                }
+                              ],
+                              "tool_resources": {
+                                "code_interpreter": {
+                                  "file_ids": [
+                                    "file-abc123",
+                                    "file-abc456"
+                                  ]
+                                }
+                              },
+                              "metadata": {},
+                              "usage": {
+                                "prompt_tokens": 123,
+                                "completion_tokens": 456,
+                                "total_tokens": 579
+                              },
+                              "temperature": 1.0,
+                              "top_p": 1.0,
+                              "max_prompt_tokens": 1000,
+                              "max_completion_tokens": 1000,
+                              "truncation_strategy": {
+                                "type": "auto",
+                                "last_messages": null
+                              },
+                              "response_format": "auto",
+                              "tool_choice": "auto",
+                              "parallel_tool_calls": true
+                            },
+                            {
+                              "id": "run_abc456",
+                              "object": "thread.run",
+                              "created_at": 1699063290,
+                              "assistant_id": "asst_abc123",
+                              "thread_id": "thread_abc123",
+                              "status": "completed",
+                              "started_at": 1699063290,
+                              "expires_at": null,
+                              "cancelled_at": null,
+                              "failed_at": null,
+                              "completed_at": 1699063291,
+                              "last_error": null,
+                              "model": "gpt-4-turbo",
+                              "instructions": null,
+                              "incomplete_details": null,
+                              "tools": [
+                                {
+                                  "type": "code_interpreter"
+                                }
+                              ],
+                              "tool_resources": {
+                                "code_interpreter": {
+                                  "file_ids": [
+                                    "file-abc123",
+                                    "file-abc456"
+                                  ]
+                                }
+                              },
+                              "metadata": {},
+                              "usage": {
+                                "prompt_tokens": 123,
+                                "completion_tokens": 456,
+                                "total_tokens": 579
+                              },
+                              "temperature": 1.0,
+                              "top_p": 1.0,
+                              "max_prompt_tokens": 1000,
+                              "max_completion_tokens": 1000,
+                              "truncation_strategy": {
+                                "type": "auto",
+                                "last_messages": null
+                              },
+                              "response_format": "auto",
+                              "tool_choice": "auto",
+                              "parallel_tool_calls": true
+                            }
+                          ],
+                          "first_id": "run_abc123",
+                          "last_id": "run_abc456",
+                          "has_more": false
+                        }
+        post:
+            operationId: createRun
+            tags:
+                - Assistants
+            summary: Create a run.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to run.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateRunRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Create run
+                group: threads
+                beta: true
+                returns: A [run](/docs/api-reference/runs/object) object.
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "assistant_id": "asst_abc123"
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              run = client.beta.threads.runs.create(
+                                thread_id="thread_abc123",
+                                assistant_id="asst_abc123"
+                              )
+
+                              print(run)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const run = await openai.beta.threads.runs.create(
+                                  "thread_abc123",
+                                  { assistant_id: "asst_abc123" }
+                                );
+
+                                console.log(run);
+                              }
+
+                              main();
+                      response: &run_object_example |
+                          {
+                            "id": "run_abc123",
+                            "object": "thread.run",
+                            "created_at": 1699063290,
+                            "assistant_id": "asst_abc123",
+                            "thread_id": "thread_abc123",
+                            "status": "queued",
+                            "started_at": 1699063290,
+                            "expires_at": null,
+                            "cancelled_at": null,
+                            "failed_at": null,
+                            "completed_at": 1699063291,
+                            "last_error": null,
+                            "model": "gpt-4-turbo",
+                            "instructions": null,
+                            "incomplete_details": null,
+                            "tools": [
+                              {
+                                "type": "code_interpreter"
+                              }
+                            ],
+                            "metadata": {},
+                            "usage": null,
+                            "temperature": 1.0,
+                            "top_p": 1.0,
+                            "max_prompt_tokens": 1000,
+                            "max_completion_tokens": 1000,
+                            "truncation_strategy": {
+                              "type": "auto",
+                              "last_messages": null
+                            },
+                            "response_format": "auto",
+                            "tool_choice": "auto",
+                            "parallel_tool_calls": true
+                          }
+                    - title: Streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/thread_123/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "assistant_id": "asst_123",
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              stream = client.beta.threads.runs.create(
+                                thread_id="thread_123",
+                                assistant_id="asst_123",
+                                stream=True
+                              )
+
+                              for event in stream:
+                                print(event)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const stream = await openai.beta.threads.runs.create(
+                                  "thread_123",
+                                  { assistant_id: "asst_123", stream: true }
+                                );
+
+                                for await (const event of stream) {
+                                  console.log(event);
+                                }
+                              }
+
+                              main();
+                      response: |
+                          event: thread.run.created
+                          data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.queued
+                          data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.in_progress
+                          data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710330641,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.step.created
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.run.step.in_progress
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.message.created
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.in_progress
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+                          ...
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" today"}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+                          event: thread.message.completed
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710330642,"role":"assistant","content":[{"type":"text","text":{"value":"Hello! How can I assist you today?","annotations":[]}}],"metadata":{}}
+
+                          event: thread.run.step.completed
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710330642,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+                          event: thread.run.completed
+                          data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710330641,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710330642,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: done
+                          data: [DONE]
+
+                    - title: Streaming with Functions
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "assistant_id": "asst_abc123",
+                                  "tools": [
+                                    {
+                                      "type": "function",
+                                      "function": {
+                                        "name": "get_current_weather",
+                                        "description": "Get the current weather in a given location",
+                                        "parameters": {
+                                          "type": "object",
+                                          "properties": {
+                                            "location": {
+                                              "type": "string",
+                                              "description": "The city and state, e.g. San Francisco, CA"
+                                            },
+                                            "unit": {
+                                              "type": "string",
+                                              "enum": ["celsius", "fahrenheit"]
+                                            }
+                                          },
+                                          "required": ["location"]
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              tools = [
+                                {
+                                  "type": "function",
+                                  "function": {
+                                    "name": "get_current_weather",
+                                    "description": "Get the current weather in a given location",
+                                    "parameters": {
+                                      "type": "object",
+                                      "properties": {
+                                        "location": {
+                                          "type": "string",
+                                          "description": "The city and state, e.g. San Francisco, CA",
+                                        },
+                                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                      },
+                                      "required": ["location"],
+                                    },
+                                  }
+                                }
+                              ]
+
+                              stream = client.beta.threads.runs.create(
+                                thread_id="thread_abc123",
+                                assistant_id="asst_abc123",
+                                tools=tools,
+                                stream=True
+                              )
+
+                              for event in stream:
+                                print(event)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              const tools = [
+                                  {
+                                    "type": "function",
+                                    "function": {
+                                      "name": "get_current_weather",
+                                      "description": "Get the current weather in a given location",
+                                      "parameters": {
+                                        "type": "object",
+                                        "properties": {
+                                          "location": {
+                                            "type": "string",
+                                            "description": "The city and state, e.g. San Francisco, CA",
+                                          },
+                                          "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                        },
+                                        "required": ["location"],
+                                      },
+                                    }
+                                  }
+                              ];
+
+                              async function main() {
+                                const stream = await openai.beta.threads.runs.create(
+                                  "thread_abc123",
+                                  {
+                                    assistant_id: "asst_abc123",
+                                    tools: tools,
+                                    stream: true
+                                  }
+                                );
+
+                                for await (const event of stream) {
+                                  console.log(event);
+                                }
+                              }
+
+                              main();
+                      response: |
+                          event: thread.run.created
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.queued
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.in_progress
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710348075,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.step.created
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.run.step.in_progress
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+                          event: thread.message.created
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.in_progress
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+                          ...
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" today"}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+                          event: thread.message.completed
+                          data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710348077,"role":"assistant","content":[{"type":"text","text":{"value":"Hello! How can I assist you today?","annotations":[]}}],"metadata":{}}
+
+                          event: thread.run.step.completed
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710348077,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+                          event: thread.run.completed
+                          data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710348075,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710348077,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: done
+                          data: [DONE]
+
+    /threads/{thread_id}/runs/{run_id}:
+        get:
+            operationId: getRun
+            tags:
+                - Assistants
+            summary: Retrieves a run.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) that was run.
+                - in: path
+                  name: run_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Retrieve run
+                group: threads
+                beta: true
+                returns: The [run](/docs/api-reference/runs/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            run = client.beta.threads.runs.retrieve(
+                              thread_id="thread_abc123",
+                              run_id="run_abc123"
+                            )
+
+                            print(run)
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const run = await openai.beta.threads.runs.retrieve(
+                                "thread_abc123",
+                                "run_abc123"
+                              );
+
+                              console.log(run);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "run_abc123",
+                          "object": "thread.run",
+                          "created_at": 1699075072,
+                          "assistant_id": "asst_abc123",
+                          "thread_id": "thread_abc123",
+                          "status": "completed",
+                          "started_at": 1699075072,
+                          "expires_at": null,
+                          "cancelled_at": null,
+                          "failed_at": null,
+                          "completed_at": 1699075073,
+                          "last_error": null,
+                          "model": "gpt-4-turbo",
+                          "instructions": null,
+                          "incomplete_details": null,
+                          "tools": [
+                            {
+                              "type": "code_interpreter"
+                            }
+                          ],
+                          "metadata": {},
+                          "usage": {
+                            "prompt_tokens": 123,
+                            "completion_tokens": 456,
+                            "total_tokens": 579
+                          },
+                          "temperature": 1.0,
+                          "top_p": 1.0,
+                          "max_prompt_tokens": 1000,
+                          "max_completion_tokens": 1000,
+                          "truncation_strategy": {
+                            "type": "auto",
+                            "last_messages": null
+                          },
+                          "response_format": "auto",
+                          "tool_choice": "auto",
+                          "parallel_tool_calls": true
+                        }
+        post:
+            operationId: modifyRun
+            tags:
+                - Assistants
+            summary: Modifies a run.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) that was run.
+                - in: path
+                  name: run_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run to modify.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ModifyRunRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Modify run
+                group: threads
+                beta: true
+                returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -d '{
+                                "metadata": {
+                                  "user_id": "user_abc123"
+                                }
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            run = client.beta.threads.runs.update(
+                              thread_id="thread_abc123",
+                              run_id="run_abc123",
+                              metadata={"user_id": "user_abc123"},
+                            )
+
+                            print(run)
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const run = await openai.beta.threads.runs.update(
+                                "thread_abc123",
+                                "run_abc123",
+                                {
+                                  metadata: {
+                                    user_id: "user_abc123",
+                                  },
+                                }
+                              );
+
+                              console.log(run);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "run_abc123",
+                          "object": "thread.run",
+                          "created_at": 1699075072,
+                          "assistant_id": "asst_abc123",
+                          "thread_id": "thread_abc123",
+                          "status": "completed",
+                          "started_at": 1699075072,
+                          "expires_at": null,
+                          "cancelled_at": null,
+                          "failed_at": null,
+                          "completed_at": 1699075073,
+                          "last_error": null,
+                          "model": "gpt-4-turbo",
+                          "instructions": null,
+                          "incomplete_details": null,
+                          "tools": [
+                            {
+                              "type": "code_interpreter"
+                            }
+                          ],
+                          "tool_resources": {
+                            "code_interpreter": {
+                              "file_ids": [
+                                "file-abc123",
+                                "file-abc456"
+                              ]
+                            }
+                          },
+                          "metadata": {
+                            "user_id": "user_abc123"
+                          },
+                          "usage": {
+                            "prompt_tokens": 123,
+                            "completion_tokens": 456,
+                            "total_tokens": 579
+                          },
+                          "temperature": 1.0,
+                          "top_p": 1.0,
+                          "max_prompt_tokens": 1000,
+                          "max_completion_tokens": 1000,
+                          "truncation_strategy": {
+                            "type": "auto",
+                            "last_messages": null
+                          },
+                          "response_format": "auto",
+                          "tool_choice": "auto",
+                          "parallel_tool_calls": true
+                        }
+
+    /threads/{thread_id}/runs/{run_id}/submit_tool_outputs:
+        post:
+            operationId: submitToolOuputsToRun
+            tags:
+                - Assistants
+            summary: |
+                When a run has the `status: "requires_action"` and `required_action.type` is `submit_tool_outputs`, this endpoint can be used to submit the outputs from the tool calls once they're all completed. All outputs must be submitted in a single request.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the [thread](/docs/api-reference/threads) to which this run belongs.
+                - in: path
+                  name: run_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run that requires the tool output submission.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/SubmitToolOutputsRunRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Submit tool outputs to run
+                group: threads
+                beta: true
+                returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
+                examples:
+                    - title: Default
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/thread_123/runs/run_123/submit_tool_outputs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "tool_outputs": [
+                                    {
+                                      "tool_call_id": "call_001",
+                                      "output": "70 degrees and sunny."
+                                    }
+                                  ]
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              run = client.beta.threads.runs.submit_tool_outputs(
+                                thread_id="thread_123",
+                                run_id="run_123",
+                                tool_outputs=[
+                                  {
+                                    "tool_call_id": "call_001",
+                                    "output": "70 degrees and sunny."
+                                  }
+                                ]
+                              )
+
+                              print(run)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const run = await openai.beta.threads.runs.submitToolOutputs(
+                                  "thread_123",
+                                  "run_123",
+                                  {
+                                    tool_outputs: [
+                                      {
+                                        tool_call_id: "call_001",
+                                        output: "70 degrees and sunny.",
+                                      },
+                                    ],
+                                  }
+                                );
+
+                                console.log(run);
+                              }
+
+                              main();
+                      response: |
+                          {
+                            "id": "run_123",
+                            "object": "thread.run",
+                            "created_at": 1699075592,
+                            "assistant_id": "asst_123",
+                            "thread_id": "thread_123",
+                            "status": "queued",
+                            "started_at": 1699075592,
+                            "expires_at": 1699076192,
+                            "cancelled_at": null,
+                            "failed_at": null,
+                            "completed_at": null,
+                            "last_error": null,
+                            "model": "gpt-4-turbo",
+                            "instructions": null,
+                            "tools": [
+                              {
+                                "type": "function",
+                                "function": {
+                                  "name": "get_current_weather",
+                                  "description": "Get the current weather in a given location",
+                                  "parameters": {
+                                    "type": "object",
+                                    "properties": {
+                                      "location": {
+                                        "type": "string",
+                                        "description": "The city and state, e.g. San Francisco, CA"
+                                      },
+                                      "unit": {
+                                        "type": "string",
+                                        "enum": ["celsius", "fahrenheit"]
+                                      }
+                                    },
+                                    "required": ["location"]
+                                  }
+                                }
+                              }
+                            ],
+                            "metadata": {},
+                            "usage": null,
+                            "temperature": 1.0,
+                            "top_p": 1.0,
+                            "max_prompt_tokens": 1000,
+                            "max_completion_tokens": 1000,
+                            "truncation_strategy": {
+                              "type": "auto",
+                              "last_messages": null
+                            },
+                            "response_format": "auto",
+                            "tool_choice": "auto",
+                            "parallel_tool_calls": true
+                          }
+
+                    - title: Streaming
+                      request:
+                          curl: |
+                              curl https://api.openai.com/v1/threads/thread_123/runs/run_123/submit_tool_outputs \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "tool_outputs": [
+                                    {
+                                      "tool_call_id": "call_001",
+                                      "output": "70 degrees and sunny."
+                                    }
+                                  ],
+                                  "stream": true
+                                }'
+                          python: |
+                              from openai import OpenAI
+                              client = OpenAI()
+
+                              stream = client.beta.threads.runs.submit_tool_outputs(
+                                thread_id="thread_123",
+                                run_id="run_123",
+                                tool_outputs=[
+                                  {
+                                    "tool_call_id": "call_001",
+                                    "output": "70 degrees and sunny."
+                                  }
+                                ],
+                                stream=True
+                              )
+
+                              for event in stream:
+                                print(event)
+                          node.js: |
+                              import OpenAI from "openai";
+
+                              const openai = new OpenAI();
+
+                              async function main() {
+                                const stream = await openai.beta.threads.runs.submitToolOutputs(
+                                  "thread_123",
+                                  "run_123",
+                                  {
+                                    tool_outputs: [
+                                      {
+                                        tool_call_id: "call_001",
+                                        output: "70 degrees and sunny.",
+                                      },
+                                    ],
+                                  }
+                                );
+
+                                for await (const event of stream) {
+                                  console.log(event);
+                                }
+                              }
+
+                              main();
+                      response: |
+                          event: thread.run.step.completed
+                          data: {"id":"step_001","object":"thread.run.step","created_at":1710352449,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"completed","cancelled_at":null,"completed_at":1710352475,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[{"id":"call_iWr0kQ2EaYMaxNdl0v3KYkx7","type":"function","function":{"name":"get_current_weather","arguments":"{\"location\":\"San Francisco, CA\",\"unit\":\"fahrenheit\"}","output":"70 degrees and sunny."}}]},"usage":{"prompt_tokens":291,"completion_tokens":24,"total_tokens":315}}
+
+                          event: thread.run.queued
+                          data: {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":1710352448,"expires_at":1710353047,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.in_progress
+                          data: {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710352475,"expires_at":1710353047,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: thread.run.step.created
+                          data: {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":null}
+
+                          event: thread.run.step.in_progress
+                          data: {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":null}
+
+                          event: thread.message.created
+                          data: {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.in_progress
+                          data: {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"The","annotations":[]}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" current"}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" weather"}}]}}
+
+                          ...
+
+                          event: thread.message.delta
+                          data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" sunny"}}]}}
+
+                          event: thread.message.delta
+                          data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"."}}]}}
+
+                          event: thread.message.completed
+                          data: {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710352477,"role":"assistant","content":[{"type":"text","text":{"value":"The current weather in San Francisco, CA is 70 degrees Fahrenheit and sunny.","annotations":[]}}],"metadata":{}}
+
+                          event: thread.run.step.completed
+                          data: {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710352477,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":{"prompt_tokens":329,"completion_tokens":18,"total_tokens":347}}
+
+                          event: thread.run.completed
+                          data: {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710352475,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710352477,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+                          event: done
+                          data: [DONE]
+
+    /threads/{thread_id}/runs/{run_id}/cancel:
+        post:
+            operationId: cancelRun
+            tags:
+                - Assistants
+            summary: Cancels a run that is `in_progress`.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to which this run belongs.
+                - in: path
+                  name: run_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run to cancel.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunObject"
+            x-oaiMeta:
+                name: Cancel a run
+                group: threads
+                beta: true
+                returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/cancel \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X POST
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            run = client.beta.threads.runs.cancel(
+                              thread_id="thread_abc123",
+                              run_id="run_abc123"
+                            )
+
+                            print(run)
+                        node.js: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const run = await openai.beta.threads.runs.cancel(
+                                "thread_abc123",
+                                "run_abc123"
+                              );
+
+                              console.log(run);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "run_abc123",
+                          "object": "thread.run",
+                          "created_at": 1699076126,
+                          "assistant_id": "asst_abc123",
+                          "thread_id": "thread_abc123",
+                          "status": "cancelling",
+                          "started_at": 1699076126,
+                          "expires_at": 1699076726,
+                          "cancelled_at": null,
+                          "failed_at": null,
+                          "completed_at": null,
+                          "last_error": null,
+                          "model": "gpt-4-turbo",
+                          "instructions": "You summarize books.",
+                          "tools": [
+                            {
+                              "type": "file_search"
+                            }
+                          ],
+                          "tool_resources": {
+                            "file_search": {
+                              "vector_store_ids": ["vs_123"]
+                            }
+                          },
+                          "metadata": {},
+                          "usage": null,
+                          "temperature": 1.0,
+                          "top_p": 1.0,
+                          "response_format": "auto",
+                          "tool_choice": "auto",
+                          "parallel_tool_calls": true
+                        }
+
+    /threads/{thread_id}/runs/{run_id}/steps:
+        get:
+            operationId: listRunSteps
+            tags:
+                - Assistants
+            summary: Returns a list of run steps belonging to a run.
+            parameters:
+                - name: thread_id
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread the run and run steps belong to.
+                - name: run_id
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run the run steps belong to.
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListRunStepsResponse"
+            x-oaiMeta:
+                name: List run steps
+                group: threads
+                beta: true
+                returns: A list of [run step](/docs/api-reference/runs/step-object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/steps \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            run_steps = client.beta.threads.runs.steps.list(
+                                thread_id="thread_abc123",
+                                run_id="run_abc123"
+                            )
+
+                            print(run_steps)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const runStep = await openai.beta.threads.runs.steps.list(
+                                "thread_abc123",
+                                "run_abc123"
+                              );
+                              console.log(runStep);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "step_abc123",
+                              "object": "thread.run.step",
+                              "created_at": 1699063291,
+                              "run_id": "run_abc123",
+                              "assistant_id": "asst_abc123",
+                              "thread_id": "thread_abc123",
+                              "type": "message_creation",
+                              "status": "completed",
+                              "cancelled_at": null,
+                              "completed_at": 1699063291,
+                              "expired_at": null,
+                              "failed_at": null,
+                              "last_error": null,
+                              "step_details": {
+                                "type": "message_creation",
+                                "message_creation": {
+                                  "message_id": "msg_abc123"
+                                }
+                              },
+                              "usage": {
+                                "prompt_tokens": 123,
+                                "completion_tokens": 456,
+                                "total_tokens": 579
+                              }
+                            }
+                          ],
+                          "first_id": "step_abc123",
+                          "last_id": "step_abc456",
+                          "has_more": false
+                        }
+
+    /threads/{thread_id}/runs/{run_id}/steps/{step_id}:
+        get:
+            operationId: getRunStep
+            tags:
+                - Assistants
+            summary: Retrieves a run step.
+            parameters:
+                - in: path
+                  name: thread_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the thread to which the run and run step belongs.
+                - in: path
+                  name: run_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run to which the run step belongs.
+                - in: path
+                  name: step_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the run step to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/RunStepObject"
+            x-oaiMeta:
+                name: Retrieve run step
+                group: threads
+                beta: true
+                returns: The [run step](/docs/api-reference/runs/step-object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            run_step = client.beta.threads.runs.steps.retrieve(
+                                thread_id="thread_abc123",
+                                run_id="run_abc123",
+                                step_id="step_abc123"
+                            )
+
+                            print(run_step)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const runStep = await openai.beta.threads.runs.steps.retrieve(
+                                "thread_abc123",
+                                "run_abc123",
+                                "step_abc123"
+                              );
+                              console.log(runStep);
+                            }
+
+                            main();
+                    response: &run_step_object_example |
+                        {
+                          "id": "step_abc123",
+                          "object": "thread.run.step",
+                          "created_at": 1699063291,
+                          "run_id": "run_abc123",
+                          "assistant_id": "asst_abc123",
+                          "thread_id": "thread_abc123",
+                          "type": "message_creation",
+                          "status": "completed",
+                          "cancelled_at": null,
+                          "completed_at": 1699063291,
+                          "expired_at": null,
+                          "failed_at": null,
+                          "last_error": null,
+                          "step_details": {
+                            "type": "message_creation",
+                            "message_creation": {
+                              "message_id": "msg_abc123"
+                            }
+                          },
+                          "usage": {
+                            "prompt_tokens": 123,
+                            "completion_tokens": 456,
+                            "total_tokens": 579
+                          }
+                        }
+
+    /vector_stores:
+        get:
+            operationId: listVectorStores
+            tags:
+                - Vector Stores
+            summary: Returns a list of vector stores.
+            parameters:
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListVectorStoresResponse"
+            x-oaiMeta:
+                name: List vector stores
+                group: vector_stores
+                beta: true
+                returns: A list of [vector store](/docs/api-reference/vector-stores/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_stores = client.beta.vector_stores.list()
+                            print(vector_stores)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStores = await openai.beta.vectorStores.list();
+                              console.log(vectorStores);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "vs_abc123",
+                              "object": "vector_store",
+                              "created_at": 1699061776,
+                              "name": "Support FAQ",
+                              "bytes": 139920,
+                              "file_counts": {
+                                "in_progress": 0,
+                                "completed": 3,
+                                "failed": 0,
+                                "cancelled": 0,
+                                "total": 3
+                              }
+                            },
+                            {
+                              "id": "vs_abc456",
+                              "object": "vector_store",
+                              "created_at": 1699061776,
+                              "name": "Support FAQ v2",
+                              "bytes": 139920,
+                              "file_counts": {
+                                "in_progress": 0,
+                                "completed": 3,
+                                "failed": 0,
+                                "cancelled": 0,
+                                "total": 3
+                              }
+                            }
+                          ],
+                          "first_id": "vs_abc123",
+                          "last_id": "vs_abc456",
+                          "has_more": false
+                        }
+        post:
+            operationId: createVectorStore
+            tags:
+                - Vector Stores
+            summary: Create a vector store.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateVectorStoreRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreObject"
+            x-oaiMeta:
+                name: Create vector store
+                group: vector_stores
+                beta: true
+                returns: A [vector store](/docs/api-reference/vector-stores/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                              -d '{
+                                "name": "Support FAQ"
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store = client.beta.vector_stores.create(
+                              name="Support FAQ"
+                            )
+                            print(vector_store)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStore = await openai.beta.vectorStores.create({
+                                name: "Support FAQ"
+                              });
+                              console.log(vectorStore);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vs_abc123",
+                          "object": "vector_store",
+                          "created_at": 1699061776,
+                          "name": "Support FAQ",
+                          "bytes": 139920,
+                          "file_counts": {
+                            "in_progress": 0,
+                            "completed": 3,
+                            "failed": 0,
+                            "cancelled": 0,
+                            "total": 3
+                          }
+                        }
+
+    /vector_stores/{vector_store_id}:
+        get:
+            operationId: getVectorStore
+            tags:
+                - Vector Stores
+            summary: Retrieves a vector store.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the vector store to retrieve.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreObject"
+            x-oaiMeta:
+                name: Retrieve vector store
+                group: vector_stores
+                beta: true
+                returns: The [vector store](/docs/api-reference/vector-stores/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store = client.beta.vector_stores.retrieve(
+                              vector_store_id="vs_abc123"
+                            )
+                            print(vector_store)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStore = await openai.beta.vectorStores.retrieve(
+                                "vs_abc123"
+                              );
+                              console.log(vectorStore);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vs_abc123",
+                          "object": "vector_store",
+                          "created_at": 1699061776
+                        }
+        post:
+            operationId: modifyVectorStore
+            tags:
+                - Vector Stores
+            summary: Modifies a vector store.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the vector store to modify.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/UpdateVectorStoreRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreObject"
+            x-oaiMeta:
+                name: Modify vector store
+                group: vector_stores
+                beta: true
+                returns: The modified [vector store](/docs/api-reference/vector-stores/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                              -d '{
+                                "name": "Support FAQ"
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store = client.beta.vector_stores.update(
+                              vector_store_id="vs_abc123",
+                              name="Support FAQ"
+                            )
+                            print(vector_store)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStore = await openai.beta.vectorStores.update(
+                                "vs_abc123",
+                                {
+                                  name: "Support FAQ"
+                                }
+                              );
+                              console.log(vectorStore);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vs_abc123",
+                          "object": "vector_store",
+                          "created_at": 1699061776,
+                          "name": "Support FAQ",
+                          "bytes": 139920,
+                          "file_counts": {
+                            "in_progress": 0,
+                            "completed": 3,
+                            "failed": 0,
+                            "cancelled": 0,
+                            "total": 3
+                          }
+                        }
+
+        delete:
+            operationId: deleteVectorStore
+            tags:
+                - Vector Stores
+            summary: Delete a vector store.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the vector store to delete.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteVectorStoreResponse"
+            x-oaiMeta:
+                name: Delete vector store
+                group: vector_stores
+                beta: true
+                returns: Deletion status
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X DELETE
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            deleted_vector_store = client.beta.vector_stores.delete(
+                              vector_store_id="vs_abc123"
+                            )
+                            print(deleted_vector_store)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const deletedVectorStore = await openai.beta.vectorStores.del(
+                                "vs_abc123"
+                              );
+                              console.log(deletedVectorStore);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          id: "vs_abc123",
+                          object: "vector_store.deleted",
+                          deleted: true
+                        }
+
+    /vector_stores/{vector_store_id}/files:
+        get:
+            operationId: listVectorStoreFiles
+            tags:
+                - Vector Stores
+            summary: Returns a list of vector store files.
+            parameters:
+                - name: vector_store_id
+                  in: path
+                  description: The ID of the vector store that the files belong to.
+                  required: true
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+                - name: filter
+                  in: query
+                  description: "Filter by file status. One of `in_progress`, `completed`, `failed`, `cancelled`."
+                  schema:
+                      type: string
+                      enum: ["in_progress", "completed", "failed", "cancelled"]
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+            x-oaiMeta:
+                name: List vector store files
+                group: vector_stores
+                beta: true
+                returns: A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_files = client.beta.vector_stores.files.list(
+                              vector_store_id="vs_abc123"
+                            )
+                            print(vector_store_files)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStoreFiles = await openai.beta.vectorStores.files.list(
+                                "vs_abc123"
+                              );
+                              console.log(vectorStoreFiles);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "file-abc123",
+                              "object": "vector_store.file",
+                              "created_at": 1699061776,
+                              "vector_store_id": "vs_abc123"
+                            },
+                            {
+                              "id": "file-abc456",
+                              "object": "vector_store.file",
+                              "created_at": 1699061776,
+                              "vector_store_id": "vs_abc123"
+                            }
+                          ],
+                          "first_id": "file-abc123",
+                          "last_id": "file-abc456",
+                          "has_more": false
+                        }
+        post:
+            operationId: createVectorStoreFile
+            tags:
+                - Vector Stores
+            summary: Create a vector store file by attaching a [File](/docs/api-reference/files) to a [vector store](/docs/api-reference/vector-stores/object).
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                      example: vs_abc123
+                  description: |
+                      The ID of the vector store for which to create a File.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateVectorStoreFileRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreFileObject"
+            x-oaiMeta:
+                name: Create vector store file
+                group: vector_stores
+                beta: true
+                returns: A [vector store file](/docs/api-reference/vector-stores-files/file-object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "file_id": "file-abc123"
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_file = client.beta.vector_stores.files.create(
+                              vector_store_id="vs_abc123",
+                              file_id="file-abc123"
+                            )
+                            print(vector_store_file)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myVectorStoreFile = await openai.beta.vectorStores.files.create(
+                                "vs_abc123",
+                                {
+                                  file_id: "file-abc123"
+                                }
+                              );
+                              console.log(myVectorStoreFile);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "file-abc123",
+                          "object": "vector_store.file",
+                          "created_at": 1699061776,
+                          "usage_bytes": 1234,
+                          "vector_store_id": "vs_abcd",
+                          "status": "completed",
+                          "last_error": null
+                        }
+
+    /vector_stores/{vector_store_id}/files/{file_id}:
+        get:
+            operationId: getVectorStoreFile
+            tags:
+                - Vector Stores
+            summary: Retrieves a vector store file.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                      example: vs_abc123
+                  description: The ID of the vector store that the file belongs to.
+                - in: path
+                  name: file_id
+                  required: true
+                  schema:
+                      type: string
+                      example: file-abc123
+                  description: The ID of the file being retrieved.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreFileObject"
+            x-oaiMeta:
+                name: Retrieve vector store file
+                group: vector_stores
+                beta: true
+                returns: The [vector store file](/docs/api-reference/vector-stores-files/file-object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files/file-abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_file = client.beta.vector_stores.files.retrieve(
+                              vector_store_id="vs_abc123",
+                              file_id="file-abc123"
+                            )
+                            print(vector_store_file)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStoreFile = await openai.beta.vectorStores.files.retrieve(
+                                "vs_abc123",
+                                "file-abc123"
+                              );
+                              console.log(vectorStoreFile);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "file-abc123",
+                          "object": "vector_store.file",
+                          "created_at": 1699061776,
+                          "vector_store_id": "vs_abcd",
+                          "status": "completed",
+                          "last_error": null
+                        }
+        delete:
+            operationId: deleteVectorStoreFile
+            tags:
+                - Vector Stores
+            summary: Delete a vector store file. This will remove the file from the vector store but the file itself will not be deleted. To delete the file, use the [delete file](/docs/api-reference/files/delete) endpoint.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the vector store that the file belongs to.
+                - in: path
+                  name: file_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the file to delete.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DeleteVectorStoreFileResponse"
+            x-oaiMeta:
+                name: Delete vector store file
+                group: vector_stores
+                beta: true
+                returns: Deletion status
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files/file-abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X DELETE
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            deleted_vector_store_file = client.beta.vector_stores.files.delete(
+                                vector_store_id="vs_abc123",
+                                file_id="file-abc123"
+                            )
+                            print(deleted_vector_store_file)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const deletedVectorStoreFile = await openai.beta.vectorStores.files.del(
+                                "vs_abc123",
+                                "file-abc123"
+                              );
+                              console.log(deletedVectorStoreFile);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          id: "file-abc123",
+                          object: "vector_store.file.deleted",
+                          deleted: true
+                        }
+
+    /vector_stores/{vector_store_id}/file_batches:
+        post:
+            operationId: createVectorStoreFileBatch
+            tags:
+                - Vector Stores
+            summary: Create a vector store file batch.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                      example: vs_abc123
+                  description: |
+                      The ID of the vector store for which to create a File Batch.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreateVectorStoreFileBatchRequest"
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            x-oaiMeta:
+                name: Create vector store file batch
+                group: vector_stores
+                beta: true
+                returns: A [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/file_batches \
+                                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                                -H "Content-Type: application/json \
+                                -H "OpenAI-Beta: assistants=v2" \
+                                -d '{
+                                  "file_ids": ["file-abc123", "file-abc456"]
+                                }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_file_batch = client.beta.vector_stores.file_batches.create(
+                              vector_store_id="vs_abc123",
+                              file_ids=["file-abc123", "file-abc456"]
+                            )
+                            print(vector_store_file_batch)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const myVectorStoreFileBatch = await openai.beta.vectorStores.fileBatches.create(
+                                "vs_abc123",
+                                {
+                                  file_ids: ["file-abc123", "file-abc456"]
+                                }
+                              );
+                              console.log(myVectorStoreFileBatch);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vsfb_abc123",
+                          "object": "vector_store.file_batch",
+                          "created_at": 1699061776,
+                          "vector_store_id": "vs_abc123",
+                          "status": "in_progress",
+                          "file_counts": {
+                            "in_progress": 1,
+                            "completed": 1,
+                            "failed": 0,
+                            "cancelled": 0,
+                            "total": 0,
+                          }
+                        }
+
+    /vector_stores/{vector_store_id}/file_batches/{batch_id}:
+        get:
+            operationId: getVectorStoreFileBatch
+            tags:
+                - Vector Stores
+            summary: Retrieves a vector store file batch.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                      example: vs_abc123
+                  description: The ID of the vector store that the file batch belongs to.
+                - in: path
+                  name: batch_id
+                  required: true
+                  schema:
+                      type: string
+                      example: vsfb_abc123
+                  description: The ID of the file batch being retrieved.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            x-oaiMeta:
+                name: Retrieve vector store file batch
+                group: vector_stores
+                beta: true
+                returns: The [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_file_batch = client.beta.vector_stores.file_batches.retrieve(
+                              vector_store_id="vs_abc123",
+                              batch_id="vsfb_abc123"
+                            )
+                            print(vector_store_file_batch)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStoreFileBatch = await openai.beta.vectorStores.fileBatches.retrieve(
+                                "vs_abc123",
+                                "vsfb_abc123"
+                              );
+                              console.log(vectorStoreFileBatch);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vsfb_abc123",
+                          "object": "vector_store.file_batch",
+                          "created_at": 1699061776,
+                          "vector_store_id": "vs_abc123",
+                          "status": "in_progress",
+                          "file_counts": {
+                            "in_progress": 1,
+                            "completed": 1,
+                            "failed": 0,
+                            "cancelled": 0,
+                            "total": 0,
+                          }
+                        }
+
+    /vector_stores/{vector_store_id}/file_batches/{batch_id}/cancel:
+        post:
+            operationId: cancelVectorStoreFileBatch
+            tags:
+                - Vector Stores
+            summary: Cancel a vector store file batch. This attempts to cancel the processing of files in this batch as soon as possible.
+            parameters:
+                - in: path
+                  name: vector_store_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the vector store that the file batch belongs to.
+                - in: path
+                  name: batch_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the file batch to cancel.
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            x-oaiMeta:
+                name: Cancel vector store file batch
+                group: vector_stores
+                beta: true
+                returns: The modified vector store file batch object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123/cancel \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2" \
+                              -X POST
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            deleted_vector_store_file_batch = client.beta.vector_stores.file_batches.cancel(
+                                vector_store_id="vs_abc123",
+                                file_batch_id="vsfb_abc123"
+                            )
+                            print(deleted_vector_store_file_batch)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const deletedVectorStoreFileBatch = await openai.vector_stores.fileBatches.cancel(
+                                "vs_abc123",
+                                "vsfb_abc123"
+                              );
+                              console.log(deletedVectorStoreFileBatch);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "vsfb_abc123",
+                          "object": "vector_store.file_batch",
+                          "created_at": 1699061776,
+                          "vector_store_id": "vs_abc123",
+                          "status": "cancelling",
+                          "file_counts": {
+                            "in_progress": 12,
+                            "completed": 3,
+                            "failed": 0,
+                            "cancelled": 0,
+                            "total": 15,
+                          }
+                        }
+
+    /vector_stores/{vector_store_id}/file_batches/{batch_id}/files:
+        get:
+            operationId: listFilesInVectorStoreBatch
+            tags:
+                - Vector Stores
+            summary: Returns a list of vector store files in a batch.
+            parameters:
+                - name: vector_store_id
+                  in: path
+                  description: The ID of the vector store that the files belong to.
+                  required: true
+                  schema:
+                      type: string
+                - name: batch_id
+                  in: path
+                  description: The ID of the file batch that the files belong to.
+                  required: true
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: order
+                  in: query
+                  description: *pagination_order_param_description
+                  schema:
+                      type: string
+                      default: desc
+                      enum: ["asc", "desc"]
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+                - name: filter
+                  in: query
+                  description: "Filter by file status. One of `in_progress`, `completed`, `failed`, `cancelled`."
+                  schema:
+                      type: string
+                      enum: ["in_progress", "completed", "failed", "cancelled"]
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+            x-oaiMeta:
+                name: List vector store files in a batch
+                group: vector_stores
+                beta: true
+                returns: A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123/files \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -H "OpenAI-Beta: assistants=v2"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            vector_store_files = client.beta.vector_stores.file_batches.list_files(
+                              vector_store_id="vs_abc123",
+                              batch_id="vsfb_abc123"
+                            )
+                            print(vector_store_files)
+                        node.js: |
+                            import OpenAI from "openai";
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const vectorStoreFiles = await openai.beta.vectorStores.fileBatches.listFiles(
+                                "vs_abc123",
+                                "vsfb_abc123"
+                              );
+                              console.log(vectorStoreFiles);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "file-abc123",
+                              "object": "vector_store.file",
+                              "created_at": 1699061776,
+                              "vector_store_id": "vs_abc123"
+                            },
+                            {
+                              "id": "file-abc456",
+                              "object": "vector_store.file",
+                              "created_at": 1699061776,
+                              "vector_store_id": "vs_abc123"
+                            }
+                          ],
+                          "first_id": "file-abc123",
+                          "last_id": "file-abc456",
+                          "has_more": false
+                        }
+
+    /batches:
+        post:
+            summary: Creates and executes a batch from an uploaded file of requests
+            operationId: createBatch
+            tags:
+                - Batch
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - input_file_id
+                                - endpoint
+                                - completion_window
+                            properties:
+                                input_file_id:
+                                    type: string
+                                    description: |
+                                        The ID of an uploaded file that contains requests for the new batch.
+
+                                        See [upload file](/docs/api-reference/files/create) for how to upload a file.
+
+                                        Your input file must be formatted as a [JSONL file](/docs/api-reference/batch/request-input), and must be uploaded with the purpose `batch`. The file can contain up to 50,000 requests, and can be up to 100 MB in size.
+                                endpoint:
+                                    type: string
+                                    enum:
+                                        [
+                                            "/v1/chat/completions",
+                                            "/v1/embeddings",
+                                            "/v1/completions",
+                                        ]
+                                    description: The endpoint to be used for all requests in the batch. Currently `/v1/chat/completions`, `/v1/embeddings`, and `/v1/completions` are supported. Note that `/v1/embeddings` batches are also restricted to a maximum of 50,000 embedding inputs across all requests in the batch.
+                                completion_window:
+                                    type: string
+                                    enum: ["24h"]
+                                    description: The time frame within which the batch should be processed. Currently only `24h` is supported.
+                                metadata:
+                                    type: object
+                                    additionalProperties:
+                                        type: string
+                                    description: Optional custom metadata for the batch.
+                                    nullable: true
+            responses:
+                "200":
+                    description: Batch created successfully.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Batch"
+            x-oaiMeta:
+                name: Create batch
+                group: batch
+                returns: The created [Batch](/docs/api-reference/batch/object) object.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/batches \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -d '{
+                                "input_file_id": "file-abc123",
+                                "endpoint": "/v1/chat/completions",
+                                "completion_window": "24h"
+                              }'
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.batches.create(
+                              input_file_id="file-abc123",
+                              endpoint="/v1/chat/completions",
+                              completion_window="24h"
+                            )
+                        node: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const batch = await openai.batches.create({
+                                input_file_id: "file-abc123",
+                                endpoint: "/v1/chat/completions",
+                                completion_window: "24h"
+                              });
+
+                              console.log(batch);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "batch_abc123",
+                          "object": "batch",
+                          "endpoint": "/v1/chat/completions",
+                          "errors": null,
+                          "input_file_id": "file-abc123",
+                          "completion_window": "24h",
+                          "status": "validating",
+                          "output_file_id": null,
+                          "error_file_id": null,
+                          "created_at": 1711471533,
+                          "in_progress_at": null,
+                          "expires_at": null,
+                          "finalizing_at": null,
+                          "completed_at": null,
+                          "failed_at": null,
+                          "expired_at": null,
+                          "cancelling_at": null,
+                          "cancelled_at": null,
+                          "request_counts": {
+                            "total": 0,
+                            "completed": 0,
+                            "failed": 0
+                          },
+                          "metadata": {
+                            "customer_id": "user_123456789",
+                            "batch_description": "Nightly eval job",
+                          }
+                        }
+        get:
+            operationId: listBatches
+            tags:
+                - Batch
+            summary: List your organization's batches.
+            parameters:
+                - in: query
+                  name: after
+                  required: false
+                  schema:
+                      type: string
+                  description: *pagination_after_param_description
+                - name: limit
+                  in: query
+                  description: *pagination_limit_param_description
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+            responses:
+                "200":
+                    description: Batch listed successfully.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListBatchesResponse"
+            x-oaiMeta:
+                name: List batch
+                group: batch
+                returns: A list of paginated [Batch](/docs/api-reference/batch/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/batches?limit=2 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json"
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.batches.list()
+                        node: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const list = await openai.batches.list();
+
+                              for await (const batch of list) {
+                                console.log(batch);
+                              }
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "batch_abc123",
+                              "object": "batch",
+                              "endpoint": "/v1/chat/completions",
+                              "errors": null,
+                              "input_file_id": "file-abc123",
+                              "completion_window": "24h",
+                              "status": "completed",
+                              "output_file_id": "file-cvaTdG",
+                              "error_file_id": "file-HOWS94",
+                              "created_at": 1711471533,
+                              "in_progress_at": 1711471538,
+                              "expires_at": 1711557933,
+                              "finalizing_at": 1711493133,
+                              "completed_at": 1711493163,
+                              "failed_at": null,
+                              "expired_at": null,
+                              "cancelling_at": null,
+                              "cancelled_at": null,
+                              "request_counts": {
+                                "total": 100,
+                                "completed": 95,
+                                "failed": 5
+                              },
+                              "metadata": {
+                                "customer_id": "user_123456789",
+                                "batch_description": "Nightly job",
+                              }
+                            },
+                            { ... },
+                          ],
+                          "first_id": "batch_abc123",
+                          "last_id": "batch_abc456",
+                          "has_more": true
+                        }
+
+    /batches/{batch_id}:
+        get:
+            operationId: retrieveBatch
+            tags:
+                - Batch
+            summary: Retrieves a batch.
+            parameters:
+                - in: path
+                  name: batch_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the batch to retrieve.
+            responses:
+                "200":
+                    description: Batch retrieved successfully.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Batch"
+            x-oaiMeta:
+                name: Retrieve batch
+                group: batch
+                returns: The [Batch](/docs/api-reference/batch/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/batches/batch_abc123 \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.batches.retrieve("batch_abc123")
+                        node: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const batch = await openai.batches.retrieve("batch_abc123");
+
+                              console.log(batch);
+                            }
+
+                            main();
+                    response: &batch_object |
+                        {
+                          "id": "batch_abc123",
+                          "object": "batch",
+                          "endpoint": "/v1/completions",
+                          "errors": null,
+                          "input_file_id": "file-abc123",
+                          "completion_window": "24h",
+                          "status": "completed",
+                          "output_file_id": "file-cvaTdG",
+                          "error_file_id": "file-HOWS94",
+                          "created_at": 1711471533,
+                          "in_progress_at": 1711471538,
+                          "expires_at": 1711557933,
+                          "finalizing_at": 1711493133,
+                          "completed_at": 1711493163,
+                          "failed_at": null,
+                          "expired_at": null,
+                          "cancelling_at": null,
+                          "cancelled_at": null,
+                          "request_counts": {
+                            "total": 100,
+                            "completed": 95,
+                            "failed": 5
+                          },
+                          "metadata": {
+                            "customer_id": "user_123456789",
+                            "batch_description": "Nightly eval job",
+                          }
+                        }
+
+    /batches/{batch_id}/cancel:
+        post:
+            operationId: cancelBatch
+            tags:
+                - Batch
+            summary: Cancels an in-progress batch. The batch will be in status `cancelling` for up to 10 minutes, before changing to `cancelled`, where it will have partial results (if any) available in the output file.
+            parameters:
+                - in: path
+                  name: batch_id
+                  required: true
+                  schema:
+                      type: string
+                  description: The ID of the batch to cancel.
+            responses:
+                "200":
+                    description: Batch is cancelling. Returns the cancelling batch's details.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Batch"
+            x-oaiMeta:
+                name: Cancel batch
+                group: batch
+                returns: The [Batch](/docs/api-reference/batch/object) object matching the specified ID.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/batches/batch_abc123/cancel \
+                              -H "Authorization: Bearer $OPENAI_API_KEY" \
+                              -H "Content-Type: application/json" \
+                              -X POST
+                        python: |
+                            from openai import OpenAI
+                            client = OpenAI()
+
+                            client.batches.cancel("batch_abc123")
+                        node: |
+                            import OpenAI from "openai";
+
+                            const openai = new OpenAI();
+
+                            async function main() {
+                              const batch = await openai.batches.cancel("batch_abc123");
+
+                              console.log(batch);
+                            }
+
+                            main();
+                    response: |
+                        {
+                          "id": "batch_abc123",
+                          "object": "batch",
+                          "endpoint": "/v1/chat/completions",
+                          "errors": null,
+                          "input_file_id": "file-abc123",
+                          "completion_window": "24h",
+                          "status": "cancelling",
+                          "output_file_id": null,
+                          "error_file_id": null,
+                          "created_at": 1711471533,
+                          "in_progress_at": 1711471538,
+                          "expires_at": 1711557933,
+                          "finalizing_at": null,
+                          "completed_at": null,
+                          "failed_at": null,
+                          "expired_at": null,
+                          "cancelling_at": 1711475133,
+                          "cancelled_at": null,
+                          "request_counts": {
+                            "total": 100,
+                            "completed": 23,
+                            "failed": 1
+                          },
+                          "metadata": {
+                            "customer_id": "user_123456789",
+                            "batch_description": "Nightly eval job",
+                          }
+                        }
+
+components:
+    securitySchemes:
+        ApiKeyAuth:
+            type: http
+            scheme: "bearer"
+
+    schemas:
+        Error:
+            type: object
+            properties:
+                code:
+                    type: string
+                    nullable: true
+                message:
+                    type: string
+                    nullable: false
+                param:
+                    type: string
+                    nullable: true
+                type:
+                    type: string
+                    nullable: false
+            required:
+                - type
+                - message
+                - param
+                - code
+        ErrorResponse:
+            type: object
+            properties:
+                error:
+                    $ref: "#/components/schemas/Error"
+            required:
+                - error
+
+        ListModelsResponse:
+            type: object
+            properties:
+                object:
+                    type: string
+                    enum: [list]
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/Model"
+            required:
+                - object
+                - data
+        DeleteModelResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+            required:
+                - id
+                - object
+                - deleted
+
+        CreateCompletionRequest:
+            type: object
+            properties:
+                model:
+                    description: &model_description |
+                        ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["gpt-3.5-turbo-instruct", "davinci-002", "babbage-002"]
+                    x-oaiTypeLabel: string
+                prompt:
+                    description: &completions_prompt_description |
+                        The prompt(s) to generate completions for, encoded as a string, array of strings, array of tokens, or array of token arrays.
+
+                        Note that <|endoftext|> is the document separator that the model sees during training, so if a prompt is not specified the model will generate as if from the beginning of a new document.
+                    default: "<|endoftext|>"
+                    nullable: true
+                    oneOf:
+                        - type: string
+                          default: ""
+                          example: "This is a test."
+                        - type: array
+                          items:
+                              type: string
+                              default: ""
+                              example: "This is a test."
+                        - type: array
+                          minItems: 1
+                          items:
+                              type: integer
+                          example: "[1212, 318, 257, 1332, 13]"
+                        - type: array
+                          minItems: 1
+                          items:
+                              type: array
+                              minItems: 1
+                              items:
+                                  type: integer
+                          example: "[[1212, 318, 257, 1332, 13]]"
+                best_of:
+                    type: integer
+                    default: 1
+                    minimum: 0
+                    maximum: 20
+                    nullable: true
+                    description: &completions_best_of_description |
+                        Generates `best_of` completions server-side and returns the "best" (the one with the highest log probability per token). Results cannot be streamed.
+
+                        When used with `n`, `best_of` controls the number of candidate completions and `n` specifies how many to return – `best_of` must be greater than `n`.
+
+                        **Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
+                echo:
+                    type: boolean
+                    default: false
+                    nullable: true
+                    description: &completions_echo_description >
+                        Echo back the prompt in addition to the completion
+                frequency_penalty:
+                    type: number
+                    default: 0
+                    minimum: -2
+                    maximum: 2
+                    nullable: true
+                    description: &completions_frequency_penalty_description |
+                        Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+
+                        [See more information about frequency and presence penalties.](/docs/guides/text-generation/parameter-details)
+                logit_bias: &completions_logit_bias
+                    type: object
+                    x-oaiTypeLabel: map
+                    default: null
+                    nullable: true
+                    additionalProperties:
+                        type: integer
+                    description: &completions_logit_bias_description |
+                        Modify the likelihood of specified tokens appearing in the completion.
+
+                        Accepts a JSON object that maps tokens (specified by their token ID in the GPT tokenizer) to an associated bias value from -100 to 100. You can use this [tokenizer tool](/tokenizer?view=bpe) to convert text to token IDs. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
+
+                        As an example, you can pass `{"50256": -100}` to prevent the <|endoftext|> token from being generated.
+                logprobs: &completions_logprobs_configuration
+                    type: integer
+                    minimum: 0
+                    maximum: 5
+                    default: null
+                    nullable: true
+                    description: &completions_logprobs_description |
+                        Include the log probabilities on the `logprobs` most likely output tokens, as well the chosen tokens. For example, if `logprobs` is 5, the API will return a list of the 5 most likely tokens. The API will always return the `logprob` of the sampled token, so there may be up to `logprobs+1` elements in the response.
+
+                        The maximum value for `logprobs` is 5.
+                max_tokens:
+                    type: integer
+                    minimum: 0
+                    default: 16
+                    example: 16
+                    nullable: true
+                    description: &completions_max_tokens_description |
+                        The maximum number of [tokens](/tokenizer) that can be generated in the completion.
+
+                        The token count of your prompt plus `max_tokens` cannot exceed the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
+                n:
+                    type: integer
+                    minimum: 1
+                    maximum: 128
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &completions_completions_description |
+                        How many completions to generate for each prompt.
+
+                        **Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
+                presence_penalty:
+                    type: number
+                    default: 0
+                    minimum: -2
+                    maximum: 2
+                    nullable: true
+                    description: &completions_presence_penalty_description |
+                        Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
+
+                        [See more information about frequency and presence penalties.](/docs/guides/text-generation/parameter-details)
+                seed: &completions_seed_param
+                    type: integer
+                    minimum: -9223372036854775808
+                    maximum: 9223372036854775807
+                    nullable: true
+                    description: |
+                        If specified, our system will make a best effort to sample deterministically, such that repeated requests with the same `seed` and parameters should return the same result.
+
+                        Determinism is not guaranteed, and you should refer to the `system_fingerprint` response parameter to monitor changes in the backend.
+                stop:
+                    description: &completions_stop_description >
+                        Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.
+                    default: null
+                    nullable: true
+                    oneOf:
+                        - type: string
+                          default: <|endoftext|>
+                          example: "\n"
+                          nullable: true
+                        - type: array
+                          minItems: 1
+                          maxItems: 4
+                          items:
+                              type: string
+                              example: '["\n"]'
+                stream:
+                    description: >
+                        Whether to stream back partial progress. If set, tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
+                        as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).
+                    type: boolean
+                    nullable: true
+                    default: false
+                stream_options:
+                    $ref: "#/components/schemas/ChatCompletionStreamOptions"
+                suffix:
+                    description: |
+                        The suffix that comes after a completion of inserted text.
+
+                        This parameter is only supported for `gpt-3.5-turbo-instruct`.
+                    default: null
+                    nullable: true
+                    type: string
+                    example: "test."
+                temperature:
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &completions_temperature_description |
+                        What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+
+                        We generally recommend altering this or `top_p` but not both.
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &completions_top_p_description |
+                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                        We generally recommend altering this or `temperature` but not both.
+                user: &end_user_param_configuration
+                    type: string
+                    example: user-1234
+                    description: |
+                        A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).
+            required:
+                - model
+                - prompt
+
+        CreateCompletionResponse:
+            type: object
+            description: |
+                Represents a completion response from the API. Note: both the streamed and non-streamed response objects share the same shape (unlike the chat endpoint).
+            properties:
+                id:
+                    type: string
+                    description: A unique identifier for the completion.
+                choices:
+                    type: array
+                    description: The list of completion choices the model generated for the input prompt.
+                    items:
+                        type: object
+                        required:
+                            - finish_reason
+                            - index
+                            - logprobs
+                            - text
+                        properties:
+                            finish_reason:
+                                type: string
+                                description: &completion_finish_reason_description |
+                                    The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
+                                    `length` if the maximum number of tokens specified in the request was reached,
+                                    or `content_filter` if content was omitted due to a flag from our content filters.
+                                enum: ["stop", "length", "content_filter"]
+                            index:
+                                type: integer
+                            logprobs:
+                                type: object
+                                nullable: true
+                                properties:
+                                    text_offset:
+                                        type: array
+                                        items:
+                                            type: integer
+                                    token_logprobs:
+                                        type: array
+                                        items:
+                                            type: number
+                                    tokens:
+                                        type: array
+                                        items:
+                                            type: string
+                                    top_logprobs:
+                                        type: array
+                                        items:
+                                            type: object
+                                            additionalProperties:
+                                                type: number
+                            text:
+                                type: string
+                created:
+                    type: integer
+                    description: The Unix timestamp (in seconds) of when the completion was created.
+                model:
+                    type: string
+                    description: The model used for completion.
+                system_fingerprint:
+                    type: string
+                    description: |
+                        This fingerprint represents the backend configuration that the model runs with.
+
+                        Can be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.
+                object:
+                    type: string
+                    description: The object type, which is always "text_completion"
+                    enum: [text_completion]
+                usage:
+                    $ref: "#/components/schemas/CompletionUsage"
+            required:
+                - id
+                - object
+                - created
+                - model
+                - choices
+            x-oaiMeta:
+                name: The completion object
+                legacy: true
+                example: |
+                    {
+                      "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+                      "object": "text_completion",
+                      "created": 1589478378,
+                      "model": "gpt-4-turbo",
+                      "choices": [
+                        {
+                          "text": "\n\nThis is indeed a test",
+                          "index": 0,
+                          "logprobs": null,
+                          "finish_reason": "length"
+                        }
+                      ],
+                      "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 7,
+                        "total_tokens": 12
+                      }
+                    }
+
+        ChatCompletionRequestMessageContentPart:
+            oneOf:
+                - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+                - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartImage"
+            x-oaiExpandable: true
+
+        ChatCompletionRequestMessageContentPartImage:
+            type: object
+            title: Image content part
+            properties:
+                type:
+                    type: string
+                    enum: ["image_url"]
+                    description: The type of the content part.
+                image_url:
+                    type: object
+                    properties:
+                        url:
+                            type: string
+                            description: Either a URL of the image or the base64 encoded image data.
+                            format: uri
+                        detail:
+                            type: string
+                            description: Specifies the detail level of the image. Learn more in the [Vision guide](/docs/guides/vision/low-or-high-fidelity-image-understanding).
+                            enum: ["auto", "low", "high"]
+                            default: "auto"
+                    required:
+                        - url
+            required:
+                - type
+                - image_url
+
+        ChatCompletionRequestMessageContentPartText:
+            type: object
+            title: Text content part
+            properties:
+                type:
+                    type: string
+                    enum: ["text"]
+                    description: The type of the content part.
+                text:
+                    type: string
+                    description: The text content.
+            required:
+                - type
+                - text
+
+        ChatCompletionRequestMessage:
+            oneOf:
+                - $ref: "#/components/schemas/ChatCompletionRequestSystemMessage"
+                - $ref: "#/components/schemas/ChatCompletionRequestUserMessage"
+                - $ref: "#/components/schemas/ChatCompletionRequestAssistantMessage"
+                - $ref: "#/components/schemas/ChatCompletionRequestToolMessage"
+                - $ref: "#/components/schemas/ChatCompletionRequestFunctionMessage"
+            x-oaiExpandable: true
+
+        ChatCompletionRequestSystemMessage:
+            type: object
+            title: System message
+            properties:
+                content:
+                    description: The contents of the system message.
+                    type: string
+                role:
+                    type: string
+                    enum: ["system"]
+                    description: The role of the messages author, in this case `system`.
+                name:
+                    type: string
+                    description: An optional name for the participant. Provides the model information to differentiate between participants of the same role.
+            required:
+                - content
+                - role
+
+        ChatCompletionRequestUserMessage:
+            type: object
+            title: User message
+            properties:
+                content:
+                    description: |
+                        The contents of the user message.
+                    oneOf:
+                        - type: string
+                          description: The text contents of the message.
+                          title: Text content
+                        - type: array
+                          description: An array of content parts with a defined type, each can be of type `text` or `image_url` when passing in images. You can pass multiple images by adding multiple `image_url` content parts. Image input is only supported when using the `gpt-4o` model.
+                          title: Array of content parts
+                          items:
+                              $ref: "#/components/schemas/ChatCompletionRequestMessageContentPart"
+                          minItems: 1
+                    x-oaiExpandable: true
+                role:
+                    type: string
+                    enum: ["user"]
+                    description: The role of the messages author, in this case `user`.
+                name:
+                    type: string
+                    description: An optional name for the participant. Provides the model information to differentiate between participants of the same role.
+            required:
+                - content
+                - role
+
+        ChatCompletionRequestAssistantMessage:
+            type: object
+            title: Assistant message
+            properties:
+                content:
+                    nullable: true
+                    type: string
+                    description: |
+                        The contents of the assistant message. Required unless `tool_calls` or `function_call` is specified.
+                role:
+                    type: string
+                    enum: ["assistant"]
+                    description: The role of the messages author, in this case `assistant`.
+                name:
+                    type: string
+                    description: An optional name for the participant. Provides the model information to differentiate between participants of the same role.
+                tool_calls:
+                    $ref: "#/components/schemas/ChatCompletionMessageToolCalls"
+                function_call:
+                    type: object
+                    deprecated: true
+                    description: "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model."
+                    nullable: true
+                    properties:
+                        arguments:
+                            type: string
+                            description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                    required:
+                        - arguments
+                        - name
+            required:
+                - role
+        
+        FineTuneChatCompletionRequestAssistantMessage:
+            allOf:
+                - type: object
+                  title: Assistant message
+                  deprecated: false
+                  properties:
+                    weight:
+                      type: integer
+                      enum: [0, 1]
+                      description: "Controls whether the assistant message is trained against (0 or 1)"
+                - $ref: "#/components/schemas/ChatCompletionRequestAssistantMessage"
+            required:
+                - role                    
+
+        ChatCompletionRequestToolMessage:
+            type: object
+            title: Tool message
+            properties:
+                role:
+                    type: string
+                    enum: ["tool"]
+                    description: The role of the messages author, in this case `tool`.
+                content:
+                    type: string
+                    description: The contents of the tool message.
+                tool_call_id:
+                    type: string
+                    description: Tool call that this message is responding to.
+            required:
+                - role
+                - content
+                - tool_call_id
+
+        ChatCompletionRequestFunctionMessage:
+            type: object
+            title: Function message
+            deprecated: true
+            properties:
+                role:
+                    type: string
+                    enum: ["function"]
+                    description: The role of the messages author, in this case `function`.
+                content:
+                    nullable: true
+                    type: string
+                    description: The contents of the function message.
+                name:
+                    type: string
+                    description: The name of the function to call.
+            required:
+                - role
+                - content
+                - name
+
+        FunctionParameters:
+            type: object
+            description: "The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format. \n\nOmitting `parameters` defines a function with an empty parameter list."
+            additionalProperties: true
+
+        ChatCompletionFunctions:
+            type: object
+            deprecated: true
+            properties:
+                description:
+                    type: string
+                    description: A description of what the function does, used by the model to choose when and how to call the function.
+                name:
+                    type: string
+                    description: The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.
+                parameters:
+                    $ref: "#/components/schemas/FunctionParameters"
+            required:
+                - name
+
+        ChatCompletionFunctionCallOption:
+            type: object
+            description: >
+                Specifying a particular function via `{"name": "my_function"}` forces the model to call that function.
+            properties:
+                name:
+                    type: string
+                    description: The name of the function to call.
+            required:
+                - name
+
+        ChatCompletionTool:
+            type: object
+            properties:
+                type:
+                    type: string
+                    enum: ["function"]
+                    description: The type of the tool. Currently, only `function` is supported.
+                function:
+                    $ref: "#/components/schemas/FunctionObject"
+            required:
+                - type
+                - function
+
+        FunctionObject:
+            type: object
+            properties:
+                description:
+                    type: string
+                    description: A description of what the function does, used by the model to choose when and how to call the function.
+                name:
+                    type: string
+                    description: The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.
+                parameters:
+                    $ref: "#/components/schemas/FunctionParameters"
+            required:
+                - name
+
+        ChatCompletionToolChoiceOption:
+            description: |
+                Controls which (if any) tool is called by the model.
+                `none` means the model will not call any tool and instead generates a message.
+                `auto` means the model can pick between generating a message or calling one or more tools.
+                `required` means the model must call one or more tools.
+                Specifying a particular tool via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool.
+
+                `none` is the default when no tools are present. `auto` is the default if tools are present.
+            oneOf:
+                - type: string
+                  description: >
+                      `none` means the model will not call any tool and instead generates a message.
+                      `auto` means the model can pick between generating a message or calling one or more tools.
+                      `required` means the model must call one or more tools.
+                  enum: [none, auto, required]
+                - $ref: "#/components/schemas/ChatCompletionNamedToolChoice"
+            x-oaiExpandable: true
+
+        ChatCompletionNamedToolChoice:
+            type: object
+            description: Specifies a tool the model should use. Use to force the model to call a specific function.
+            properties:
+                type:
+                    type: string
+                    enum: ["function"]
+                    description: The type of the tool. Currently, only `function` is supported.
+                function:
+                    type: object
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                    required:
+                        - name
+            required:
+                - type
+                - function
+
+        ParallelToolCalls:
+            description: Whether to enable [parallel function calling](/docs/guides/function-calling/parallel-function-calling) during tool use.
+            type: boolean
+            default: true
+
+        ChatCompletionMessageToolCalls:
+            type: array
+            description: The tool calls generated by the model, such as function calls.
+            items:
+                $ref: "#/components/schemas/ChatCompletionMessageToolCall"
+
+        ChatCompletionMessageToolCall:
+            type: object
+            properties:
+                # TODO: index included when streaming
+                id:
+                    type: string
+                    description: The ID of the tool call.
+                type:
+                    type: string
+                    enum: ["function"]
+                    description: The type of the tool. Currently, only `function` is supported.
+                function:
+                    type: object
+                    description: The function that the model called.
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                        arguments:
+                            type: string
+                            description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+                    required:
+                        - name
+                        - arguments
+            required:
+                - id
+                - type
+                - function
+
+        ChatCompletionMessageToolCallChunk:
+            type: object
+            properties:
+                index:
+                    type: integer
+                id:
+                    type: string
+                    description: The ID of the tool call.
+                type:
+                    type: string
+                    enum: ["function"]
+                    description: The type of the tool. Currently, only `function` is supported.
+                function:
+                    type: object
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                        arguments:
+                            type: string
+                            description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+            required:
+                - index
+
+        # Note, this isn't referenced anywhere, but is kept as a convenience to record all possible roles in one place.
+        ChatCompletionRole:
+            type: string
+            description: The role of the author of a message
+            enum:
+                - system
+                - user
+                - assistant
+                - tool
+                - function
+
+        ChatCompletionStreamOptions:
+            description: |
+                Options for streaming response. Only set this when you set `stream: true`.
+            type: object
+            nullable: true
+            default: null
+            properties:
+                include_usage:
+                    type: boolean
+                    description: |
+                        If set, an additional chunk will be streamed before the `data: [DONE]` message. The `usage` field on this chunk shows the token usage statistics for the entire request, and the `choices` field will always be an empty array. All other chunks will also include a `usage` field, but with a null value.
+
+        ChatCompletionResponseMessage:
+            type: object
+            description: A chat completion message generated by the model.
+            properties:
+                content:
+                    type: string
+                    description: The contents of the message.
+                    nullable: true
+                tool_calls:
+                    $ref: "#/components/schemas/ChatCompletionMessageToolCalls"
+                role:
+                    type: string
+                    enum: ["assistant"]
+                    description: The role of the author of this message.
+                function_call:
+                    type: object
+                    deprecated: true
+                    description: "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model."
+                    properties:
+                        arguments:
+                            type: string
+                            description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                    required:
+                        - name
+                        - arguments
+            required:
+                - role
+                - content
+
+        ChatCompletionStreamResponseDelta:
+            type: object
+            description: A chat completion delta generated by streamed model responses.
+            properties:
+                content:
+                    type: string
+                    description: The contents of the chunk message.
+                    nullable: true
+                function_call:
+                    deprecated: true
+                    type: object
+                    description: "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model."
+                    properties:
+                        arguments:
+                            type: string
+                            description: The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                tool_calls:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionMessageToolCallChunk"
+                role:
+                    type: string
+                    enum: ["system", "user", "assistant", "tool"]
+                    description: The role of the author of this message.
+
+        CreateChatCompletionRequest:
+            type: object
+            properties:
+                messages:
+                    description: A list of messages comprising the conversation so far. [Example Python code](https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models).
+                    type: array
+                    minItems: 1
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionRequestMessage"
+                model:
+                    description: ID of the model to use. See the [model endpoint compatibility](/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.
+                    example: "gpt-4-turbo"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "gpt-4o",
+                                  "gpt-4o-2024-05-13",
+                                  "gpt-4o-mini",
+                                  "gpt-4o-mini-2024-07-18",
+                                  "gpt-4-turbo",
+                                  "gpt-4-turbo-2024-04-09",
+                                  "gpt-4-0125-preview",
+                                  "gpt-4-turbo-preview",
+                                  "gpt-4-1106-preview",
+                                  "gpt-4-vision-preview",
+                                  "gpt-4",
+                                  "gpt-4-0314",
+                                  "gpt-4-0613",
+                                  "gpt-4-32k",
+                                  "gpt-4-32k-0314",
+                                  "gpt-4-32k-0613",
+                                  "gpt-3.5-turbo",
+                                  "gpt-3.5-turbo-16k",
+                                  "gpt-3.5-turbo-0301",
+                                  "gpt-3.5-turbo-0613",
+                                  "gpt-3.5-turbo-1106",
+                                  "gpt-3.5-turbo-0125",
+                                  "gpt-3.5-turbo-16k-0613",
+                              ]
+                    x-oaiTypeLabel: string
+                frequency_penalty:
+                    type: number
+                    default: 0
+                    minimum: -2
+                    maximum: 2
+                    nullable: true
+                    description: *completions_frequency_penalty_description
+                logit_bias:
+                    type: object
+                    x-oaiTypeLabel: map
+                    default: null
+                    nullable: true
+                    additionalProperties:
+                        type: integer
+                    description: |
+                        Modify the likelihood of specified tokens appearing in the completion.
+
+                        Accepts a JSON object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
+                logprobs:
+                    description: Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the `content` of `message`.
+                    type: boolean
+                    default: false
+                    nullable: true
+                top_logprobs:
+                    description: An integer between 0 and 20 specifying the number of most likely tokens to return at each token position, each with an associated log probability. `logprobs` must be set to `true` if this parameter is used.
+                    type: integer
+                    minimum: 0
+                    maximum: 20
+                    nullable: true
+                max_tokens:
+                    description: |
+                        The maximum number of [tokens](/tokenizer) that can be generated in the chat completion.
+
+                        The total length of input tokens and generated tokens is limited by the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
+                    type: integer
+                    nullable: true
+                n:
+                    type: integer
+                    minimum: 1
+                    maximum: 128
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Keep `n` as `1` to minimize costs.
+                presence_penalty:
+                    type: number
+                    default: 0
+                    minimum: -2
+                    maximum: 2
+                    nullable: true
+                    description: *completions_presence_penalty_description
+                response_format:
+                    type: object
+                    description: |
+                        An object specifying the format that the model must output. Compatible with [GPT-4 Turbo](/docs/models/gpt-4-and-gpt-4-turbo) and all GPT-3.5 Turbo models newer than `gpt-3.5-turbo-1106`.
+
+                        Setting to `{ "type": "json_object" }` enables JSON mode, which guarantees the message the model generates is valid JSON.
+
+                        **Important:** when using JSON mode, you **must** also instruct the model to produce JSON yourself via a system or user message. Without this, the model may generate an unending stream of whitespace until the generation reaches the token limit, resulting in a long-running and seemingly "stuck" request. Also note that the message content may be partially cut off if `finish_reason="length"`, which indicates the generation exceeded `max_tokens` or the conversation exceeded the max context length.
+                    properties:
+                        type:
+                            type: string
+                            enum: ["text", "json_object"]
+                            example: "json_object"
+                            default: "text"
+                            description: Must be one of `text` or `json_object`.
+                seed:
+                    type: integer
+                    minimum: -9223372036854775808
+                    maximum: 9223372036854775807
+                    nullable: true
+                    description: |
+                        This feature is in Beta.
+                        If specified, our system will make a best effort to sample deterministically, such that repeated requests with the same `seed` and parameters should return the same result.
+                        Determinism is not guaranteed, and you should refer to the `system_fingerprint` response parameter to monitor changes in the backend.
+                    x-oaiMeta:
+                        beta: true
+                service_tier:
+                  description: |
+                      Specifies the latency tier to use for processing the request. This parameter is relevant for customers subscribed to the scale tier service:
+                        - If set to 'auto', the system will utilize scale tier credits until they are exhausted.
+                        - If set to 'default', the request will be processed using the default service tier with a lower uptime SLA and no latency guarentee.
+                        - When not set, the default behavior is 'auto'.
+
+                        When this parameter is set, the response body will include the `service_tier` utilized.
+                  type: string
+                  enum: ["auto", "default"]
+                  nullable: true
+                  default: null
+                stop:
+                    description: |
+                        Up to 4 sequences where the API will stop generating further tokens.
+                    default: null
+                    oneOf:
+                        - type: string
+                          nullable: true
+                        - type: array
+                          minItems: 1
+                          maxItems: 4
+                          items:
+                              type: string
+                stream:
+                    description: >
+                        If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
+                        as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).
+                    type: boolean
+                    nullable: true
+                    default: false
+                stream_options:
+                    $ref: "#/components/schemas/ChatCompletionStreamOptions"
+                temperature:
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: *completions_temperature_description
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: *completions_top_p_description
+                tools:
+                    type: array
+                    description: >
+                        A list of tools the model may call. Currently, only functions are supported as a tool.
+                        Use this to provide a list of functions the model may generate JSON inputs for. A max of 128 functions are supported.
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionTool"
+                tool_choice:
+                    $ref: "#/components/schemas/ChatCompletionToolChoiceOption"
+                parallel_tool_calls:
+                    $ref: "#/components/schemas/ParallelToolCalls"
+                user: *end_user_param_configuration
+                function_call:
+                    deprecated: true
+                    description: |
+                        Deprecated in favor of `tool_choice`.
+
+                        Controls which (if any) function is called by the model.
+                        `none` means the model will not call a function and instead generates a message.
+                        `auto` means the model can pick between generating a message or calling a function.
+                        Specifying a particular function via `{"name": "my_function"}` forces the model to call that function.
+
+                        `none` is the default when no functions are present. `auto` is the default if functions are present.
+                    oneOf:
+                        - type: string
+                          description: >
+                              `none` means the model will not call a function and instead generates a message.
+                              `auto` means the model can pick between generating a message or calling a function.
+                          enum: [none, auto]
+                        - $ref: "#/components/schemas/ChatCompletionFunctionCallOption"
+                    x-oaiExpandable: true
+                functions:
+                    deprecated: true
+                    description: |
+                        Deprecated in favor of `tools`.
+
+                        A list of functions the model may generate JSON inputs for.
+                    type: array
+                    minItems: 1
+                    maxItems: 128
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionFunctions"
+
+            required:
+                - model
+                - messages
+
+        CreateChatCompletionResponse:
+            type: object
+            description: Represents a chat completion response returned by model, based on the provided input.
+            properties:
+                id:
+                    type: string
+                    description: A unique identifier for the chat completion.
+                choices:
+                    type: array
+                    description: A list of chat completion choices. Can be more than one if `n` is greater than 1.
+                    items:
+                        type: object
+                        required:
+                            - finish_reason
+                            - index
+                            - message
+                            - logprobs
+                        properties:
+                            finish_reason:
+                                type: string
+                                description: &chat_completion_finish_reason_description |
+                                    The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
+                                    `length` if the maximum number of tokens specified in the request was reached,
+                                    `content_filter` if content was omitted due to a flag from our content filters,
+                                    `tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.
+                                enum:
+                                    [
+                                        "stop",
+                                        "length",
+                                        "tool_calls",
+                                        "content_filter",
+                                        "function_call",
+                                    ]
+                            index:
+                                type: integer
+                                description: The index of the choice in the list of choices.
+                            message:
+                                $ref: "#/components/schemas/ChatCompletionResponseMessage"
+                            logprobs: &chat_completion_response_logprobs
+                                description: Log probability information for the choice.
+                                type: object
+                                nullable: true
+                                properties:
+                                    content:
+                                        description: A list of message content tokens with log probability information.
+                                        type: array
+                                        items:
+                                            $ref: "#/components/schemas/ChatCompletionTokenLogprob"
+                                        nullable: true
+                                required:
+                                    - content
+                created:
+                    type: integer
+                    description: The Unix timestamp (in seconds) of when the chat completion was created.
+                model:
+                    type: string
+                    description: The model used for the chat completion.
+                service_tier:
+                    description: The service tier used for processing the request. This field is only included if the `service_tier` parameter is specified in the request.
+                    type: string
+                    enum: ["scale", "default"]
+                    example: "scale"
+                    nullable: true
+                system_fingerprint:
+                    type: string
+                    description: |
+                        This fingerprint represents the backend configuration that the model runs with.
+
+                        Can be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.
+                object:
+                    type: string
+                    description: The object type, which is always `chat.completion`.
+                    enum: [chat.completion]
+                usage:
+                    $ref: "#/components/schemas/CompletionUsage"
+            required:
+                - choices
+                - created
+                - id
+                - model
+                - object
+            x-oaiMeta:
+                name: The chat completion object
+                group: chat
+                example: *chat_completion_example
+
+        CreateChatCompletionFunctionResponse:
+            type: object
+            description: Represents a chat completion response returned by model, based on the provided input.
+            properties:
+                id:
+                    type: string
+                    description: A unique identifier for the chat completion.
+                choices:
+                    type: array
+                    description: A list of chat completion choices. Can be more than one if `n` is greater than 1.
+                    items:
+                        type: object
+                        required:
+                            - finish_reason
+                            - index
+                            - message
+                            - logprobs
+                        properties:
+                            finish_reason:
+                                type: string
+                                description:
+                                    &chat_completion_function_finish_reason_description |
+                                    The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence, `length` if the maximum number of tokens specified in the request was reached, `content_filter` if content was omitted due to a flag from our content filters, or `function_call` if the model called a function.
+                                enum:
+                                    ["stop", "length", "function_call", "content_filter"]
+                            index:
+                                type: integer
+                                description: The index of the choice in the list of choices.
+                            message:
+                                $ref: "#/components/schemas/ChatCompletionResponseMessage"
+                created:
+                    type: integer
+                    description: The Unix timestamp (in seconds) of when the chat completion was created.
+                model:
+                    type: string
+                    description: The model used for the chat completion.
+                system_fingerprint:
+                    type: string
+                    description: |
+                        This fingerprint represents the backend configuration that the model runs with.
+
+                        Can be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.
+                object:
+                    type: string
+                    description: The object type, which is always `chat.completion`.
+                    enum: [chat.completion]
+                usage:
+                    $ref: "#/components/schemas/CompletionUsage"
+            required:
+                - choices
+                - created
+                - id
+                - model
+                - object
+            x-oaiMeta:
+                name: The chat completion object
+                group: chat
+                example: *chat_completion_function_example
+
+        ChatCompletionTokenLogprob:
+            type: object
+            properties:
+                token: &chat_completion_response_logprobs_token
+                    description: The token.
+                    type: string
+                logprob: &chat_completion_response_logprobs_token_logprob
+                    description: The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely.
+                    type: number
+                bytes: &chat_completion_response_logprobs_bytes
+                    description: A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token.
+                    type: array
+                    items:
+                        type: integer
+                    nullable: true
+                top_logprobs:
+                    description: List of the most likely tokens and their log probability, at this token position. In rare cases, there may be fewer than the number of requested `top_logprobs` returned.
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            token: *chat_completion_response_logprobs_token
+                            logprob: *chat_completion_response_logprobs_token_logprob
+                            bytes: *chat_completion_response_logprobs_bytes
+                        required:
+                            - token
+                            - logprob
+                            - bytes
+            required:
+                - token
+                - logprob
+                - bytes
+                - top_logprobs
+
+        ListPaginatedFineTuningJobsResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FineTuningJob"
+                has_more:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [list]
+            required:
+                - object
+                - data
+                - has_more
+
+        CreateChatCompletionStreamResponse:
+            type: object
+            description: Represents a streamed chunk of a chat completion response returned by model, based on the provided input.
+            properties:
+                id:
+                    type: string
+                    description: A unique identifier for the chat completion. Each chunk has the same ID.
+                choices:
+                    type: array
+                    description: |
+                        A list of chat completion choices. Can contain more than one elements if `n` is greater than 1. Can also be empty for the
+                        last chunk if you set `stream_options: {"include_usage": true}`.
+                    items:
+                        type: object
+                        required:
+                            - delta
+                            - finish_reason
+                            - index
+                        properties:
+                            delta:
+                                $ref: "#/components/schemas/ChatCompletionStreamResponseDelta"
+                            logprobs: *chat_completion_response_logprobs
+                            finish_reason:
+                                type: string
+                                description: *chat_completion_finish_reason_description
+                                enum:
+                                    [
+                                        "stop",
+                                        "length",
+                                        "tool_calls",
+                                        "content_filter",
+                                        "function_call",
+                                    ]
+                                nullable: true
+                            index:
+                                type: integer
+                                description: The index of the choice in the list of choices.
+                created:
+                    type: integer
+                    description: The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp.
+                model:
+                    type: string
+                    description: The model to generate the completion.
+                service_tier:
+                    description: The service tier used for processing the request. This field is only included if the `service_tier` parameter is specified in the request.
+                    type: string
+                    enum: ["scale", "default"]
+                    example: "scale"
+                    nullable: true
+                system_fingerprint:
+                    type: string
+                    description: |
+                        This fingerprint represents the backend configuration that the model runs with.
+                        Can be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.
+                object:
+                    type: string
+                    description: The object type, which is always `chat.completion.chunk`.
+                    enum: [chat.completion.chunk]
+                usage:
+                    type: object
+                    description: |
+                        An optional field that will only be present when you set `stream_options: {"include_usage": true}` in your request.
+                        When present, it contains a null value except for the last chunk which contains the token usage statistics for the entire request.
+                    properties:
+                        completion_tokens:
+                            type: integer
+                            description: Number of tokens in the generated completion.
+                        prompt_tokens:
+                            type: integer
+                            description: Number of tokens in the prompt.
+                        total_tokens:
+                            type: integer
+                            description: Total number of tokens used in the request (prompt + completion).
+                    required:
+                        - prompt_tokens
+                        - completion_tokens
+                        - total_tokens
+            required:
+                - choices
+                - created
+                - id
+                - model
+                - object
+            x-oaiMeta:
+                name: The chat completion chunk object
+                group: chat
+                example: *chat_completion_chunk_example
+
+        CreateChatCompletionImageResponse:
+            type: object
+            description: Represents a streamed chunk of a chat completion response returned by model, based on the provided input.
+            x-oaiMeta:
+                name: The chat completion chunk object
+                group: chat
+                example: *chat_completion_image_example
+
+        CreateImageRequest:
+            type: object
+            properties:
+                prompt:
+                    description: A text description of the desired image(s). The maximum length is 1000 characters for `dall-e-2` and 4000 characters for `dall-e-3`.
+                    type: string
+                    example: "A cute baby sea otter"
+                model:
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["dall-e-2", "dall-e-3"]
+                    x-oaiTypeLabel: string
+                    default: "dall-e-2"
+                    example: "dall-e-3"
+                    nullable: true
+                    description: The model to use for image generation.
+                n: &images_n
+                    type: integer
+                    minimum: 1
+                    maximum: 10
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: The number of images to generate. Must be between 1 and 10. For `dall-e-3`, only `n=1` is supported.
+                quality:
+                    type: string
+                    enum: ["standard", "hd"]
+                    default: "standard"
+                    example: "standard"
+                    description: The quality of the image that will be generated. `hd` creates images with finer details and greater consistency across the image. This param is only supported for `dall-e-3`.
+                response_format: &images_response_format
+                    type: string
+                    enum: ["url", "b64_json"]
+                    default: "url"
+                    example: "url"
+                    nullable: true
+                    description: The format in which the generated images are returned. Must be one of `url` or `b64_json`. URLs are only valid for 60 minutes after the image has been generated.
+                size: &images_size
+                    type: string
+                    enum: ["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]
+                    default: "1024x1024"
+                    example: "1024x1024"
+                    nullable: true
+                    description: The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024` for `dall-e-2`. Must be one of `1024x1024`, `1792x1024`, or `1024x1792` for `dall-e-3` models.
+                style:
+                    type: string
+                    enum: ["vivid", "natural"]
+                    default: "vivid"
+                    example: "vivid"
+                    nullable: true
+                    description: The style of the generated images. Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images. This param is only supported for `dall-e-3`.
+                user: *end_user_param_configuration
+            required:
+                - prompt
+
+        ImagesResponse:
+            properties:
+                created:
+                    type: integer
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/Image"
+            required:
+                - created
+                - data
+
+        Image:
+            type: object
+            description: Represents the url or the content of an image generated by the OpenAI API.
+            properties:
+                b64_json:
+                    type: string
+                    description: The base64-encoded JSON of the generated image, if `response_format` is `b64_json`.
+                url:
+                    type: string
+                    description: The URL of the generated image, if `response_format` is `url` (default).
+                revised_prompt:
+                    type: string
+                    description: The prompt that was used to generate the image, if there was any revision to the prompt.
+            x-oaiMeta:
+                name: The image object
+                example: |
+                    {
+                      "url": "...",
+                      "revised_prompt": "..."
+                    }
+
+        CreateImageEditRequest:
+            type: object
+            properties:
+                image:
+                    description: The image to edit. Must be a valid PNG file, less than 4MB, and square. If mask is not provided, image must have transparency, which will be used as the mask.
+                    type: string
+                    format: binary
+                prompt:
+                    description: A text description of the desired image(s). The maximum length is 1000 characters.
+                    type: string
+                    example: "A cute baby sea otter wearing a beret"
+                mask:
+                    description: An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where `image` should be edited. Must be a valid PNG file, less than 4MB, and have the same dimensions as `image`.
+                    type: string
+                    format: binary
+                model:
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["dall-e-2"]
+                    x-oaiTypeLabel: string
+                    default: "dall-e-2"
+                    example: "dall-e-2"
+                    nullable: true
+                    description: The model to use for image generation. Only `dall-e-2` is supported at this time.
+                n:
+                    type: integer
+                    minimum: 1
+                    maximum: 10
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: The number of images to generate. Must be between 1 and 10.
+                size: &dalle2_images_size
+                    type: string
+                    enum: ["256x256", "512x512", "1024x1024"]
+                    default: "1024x1024"
+                    example: "1024x1024"
+                    nullable: true
+                    description: The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`.
+                response_format: *images_response_format
+                user: *end_user_param_configuration
+            required:
+                - prompt
+                - image
+
+        CreateImageVariationRequest:
+            type: object
+            properties:
+                image:
+                    description: The image to use as the basis for the variation(s). Must be a valid PNG file, less than 4MB, and square.
+                    type: string
+                    format: binary
+                model:
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["dall-e-2"]
+                    x-oaiTypeLabel: string
+                    default: "dall-e-2"
+                    example: "dall-e-2"
+                    nullable: true
+                    description: The model to use for image generation. Only `dall-e-2` is supported at this time.
+                n: *images_n
+                response_format: *images_response_format
+                size: *dalle2_images_size
+                user: *end_user_param_configuration
+            required:
+                - image
+
+        CreateModerationRequest:
+            type: object
+            properties:
+                input:
+                    description: The input text to classify
+                    oneOf:
+                        - type: string
+                          default: ""
+                          example: "I want to kill them."
+                        - type: array
+                          items:
+                              type: string
+                              default: ""
+                              example: "I want to kill them."
+                model:
+                    description: |
+                        Two content moderations models are available: `text-moderation-stable` and `text-moderation-latest`.
+
+                        The default is `text-moderation-latest` which will be automatically upgraded over time. This ensures you are always using our most accurate model. If you use `text-moderation-stable`, we will provide advanced notice before updating the model. Accuracy of `text-moderation-stable` may be slightly lower than for `text-moderation-latest`.
+                    nullable: false
+                    default: "text-moderation-latest"
+                    example: "text-moderation-stable"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["text-moderation-latest", "text-moderation-stable"]
+                    x-oaiTypeLabel: string
+            required:
+                - input
+
+        CreateModerationResponse:
+            type: object
+            description: Represents if a given text input is potentially harmful.
+            properties:
+                id:
+                    type: string
+                    description: The unique identifier for the moderation request.
+                model:
+                    type: string
+                    description: The model used to generate the moderation results.
+                results:
+                    type: array
+                    description: A list of moderation objects.
+                    items:
+                        type: object
+                        properties:
+                            flagged:
+                                type: boolean
+                                description: Whether any of the below categories are flagged.
+                            categories:
+                                type: object
+                                description: A list of the categories, and whether they are flagged or not.
+                                properties:
+                                    hate:
+                                        type: boolean
+                                        description: Content that expresses, incites, or promotes hate based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste. Hateful content aimed at non-protected groups (e.g., chess players) is harassment.
+                                    hate/threatening:
+                                        type: boolean
+                                        description: Hateful content that also includes violence or serious harm towards the targeted group based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste.
+                                    harassment:
+                                        type: boolean
+                                        description: Content that expresses, incites, or promotes harassing language towards any target.
+                                    harassment/threatening:
+                                        type: boolean
+                                        description: Harassment content that also includes violence or serious harm towards any target.
+                                    self-harm:
+                                        type: boolean
+                                        description: Content that promotes, encourages, or depicts acts of self-harm, such as suicide, cutting, and eating disorders.
+                                    self-harm/intent:
+                                        type: boolean
+                                        description: Content where the speaker expresses that they are engaging or intend to engage in acts of self-harm, such as suicide, cutting, and eating disorders.
+                                    self-harm/instructions:
+                                        type: boolean
+                                        description: Content that encourages performing acts of self-harm, such as suicide, cutting, and eating disorders, or that gives instructions or advice on how to commit such acts.
+                                    sexual:
+                                        type: boolean
+                                        description: Content meant to arouse sexual excitement, such as the description of sexual activity, or that promotes sexual services (excluding sex education and wellness).
+                                    sexual/minors:
+                                        type: boolean
+                                        description: Sexual content that includes an individual who is under 18 years old.
+                                    violence:
+                                        type: boolean
+                                        description: Content that depicts death, violence, or physical injury.
+                                    violence/graphic:
+                                        type: boolean
+                                        description: Content that depicts death, violence, or physical injury in graphic detail.
+                                required:
+                                    - hate
+                                    - hate/threatening
+                                    - harassment
+                                    - harassment/threatening
+                                    - self-harm
+                                    - self-harm/intent
+                                    - self-harm/instructions
+                                    - sexual
+                                    - sexual/minors
+                                    - violence
+                                    - violence/graphic
+                            category_scores:
+                                type: object
+                                description: A list of the categories along with their scores as predicted by model.
+                                properties:
+                                    hate:
+                                        type: number
+                                        description: The score for the category 'hate'.
+                                    hate/threatening:
+                                        type: number
+                                        description: The score for the category 'hate/threatening'.
+                                    harassment:
+                                        type: number
+                                        description: The score for the category 'harassment'.
+                                    harassment/threatening:
+                                        type: number
+                                        description: The score for the category 'harassment/threatening'.
+                                    self-harm:
+                                        type: number
+                                        description: The score for the category 'self-harm'.
+                                    self-harm/intent:
+                                        type: number
+                                        description: The score for the category 'self-harm/intent'.
+                                    self-harm/instructions:
+                                        type: number
+                                        description: The score for the category 'self-harm/instructions'.
+                                    sexual:
+                                        type: number
+                                        description: The score for the category 'sexual'.
+                                    sexual/minors:
+                                        type: number
+                                        description: The score for the category 'sexual/minors'.
+                                    violence:
+                                        type: number
+                                        description: The score for the category 'violence'.
+                                    violence/graphic:
+                                        type: number
+                                        description: The score for the category 'violence/graphic'.
+                                required:
+                                    - hate
+                                    - hate/threatening
+                                    - harassment
+                                    - harassment/threatening
+                                    - self-harm
+                                    - self-harm/intent
+                                    - self-harm/instructions
+                                    - sexual
+                                    - sexual/minors
+                                    - violence
+                                    - violence/graphic
+                        required:
+                            - flagged
+                            - categories
+                            - category_scores
+            required:
+                - id
+                - model
+                - results
+            x-oaiMeta:
+                name: The moderation object
+                example: *moderation_example
+
+        ListFilesResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/OpenAIFile"
+                object:
+                    type: string
+                    enum: [list]
+            required:
+                - object
+                - data
+
+        CreateFileRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file:
+                    description: |
+                        The File object (not file name) to be uploaded.
+                    type: string
+                    format: binary
+                purpose:
+                    description: |
+                        The intended purpose of the uploaded file.
+
+                        Use "assistants" for [Assistants](/docs/api-reference/assistants) and [Message](/docs/api-reference/messages) files, "vision" for Assistants image file inputs, "batch" for [Batch API](/docs/guides/batch), and "fine-tune" for [Fine-tuning](/docs/api-reference/fine-tuning).
+                    type: string
+                    enum: ["assistants", "batch", "fine-tune", "vision"]
+            required:
+                - file
+                - purpose
+
+        DeleteFileResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                object:
+                    type: string
+                    enum: [file]
+                deleted:
+                    type: boolean
+            required:
+                - id
+                - object
+                - deleted
+
+        CreateUploadRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                filename:
+                    description: |
+                        The name of the file to upload.
+                    type: string
+                purpose:
+                    description: |
+                        The intended purpose of the uploaded file.
+            
+                        See the [documentation on File purposes](/docs/api-reference/files/create#files-create-purpose).
+                    type: string
+                    enum: ["assistants", "batch", "fine-tune", "vision"]
+                bytes:
+                    description: |
+                        The number of bytes in the file you are uploading.
+                    type: integer
+                mime_type:
+                    description: |
+                        The MIME type of the file.
+                        
+                        This must fall within the supported MIME types for your file purpose. See the supported MIME types for assistants and vision.
+                    type: string
+            required:
+                - filename
+                - purpose
+                - bytes
+                - mime_type
+
+        AddUploadPartRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                data:
+                    description: |
+                        The chunk of bytes for this Part.
+                    type: string
+                    format: binary
+            required:
+                - data
+
+        CompleteUploadRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                part_ids:
+                    type: array
+                    description: |
+                        The ordered list of Part IDs.
+                    items:
+                        type: string
+                md5:
+                    description: |
+                        The optional md5 checksum for the file contents to verify if the bytes uploaded matches what you expect.
+                    type: string
+            required:
+                - part_ids
+
+        CancelUploadRequest:
+            type: object
+            additionalProperties: false
+
+        CreateFineTuningJobRequest:
+            type: object
+            properties:
+                model:
+                    description: |
+                        The name of the model to fine-tune. You can select one of the
+                        [supported models](/docs/guides/fine-tuning/what-models-can-be-fine-tuned).
+                    example: "gpt-3.5-turbo"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["babbage-002", "davinci-002", "gpt-3.5-turbo"]
+                    x-oaiTypeLabel: string
+                training_file:
+                    description: |
+                        The ID of an uploaded file that contains training data.
+
+                        See [upload file](/docs/api-reference/files/create) for how to upload a file.
+
+                        Your dataset must be formatted as a JSONL file. Additionally, you must upload your file with the purpose `fine-tune`.
+
+                        The contents of the file should differ depending on if the model uses the [chat](/docs/api-reference/fine-tuning/chat-input) or [completions](/docs/api-reference/fine-tuning/completions-input) format.
+
+                        See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.
+                    type: string
+                    example: "file-abc123"
+                hyperparameters:
+                    type: object
+                    description: The hyperparameters used for the fine-tuning job.
+                    properties:
+                        batch_size:
+                            description: |
+                                Number of examples in each batch. A larger batch size means that model parameters
+                                are updated less frequently, but with lower variance.
+                            oneOf:
+                                - type: string
+                                  enum: [auto]
+                                - type: integer
+                                  minimum: 1
+                                  maximum: 256
+                            default: auto
+                        learning_rate_multiplier:
+                            description: |
+                                Scaling factor for the learning rate. A smaller learning rate may be useful to avoid
+                                overfitting.
+                            oneOf:
+                                - type: string
+                                  enum: [auto]
+                                - type: number
+                                  minimum: 0
+                                  exclusiveMinimum: true
+                            default: auto
+                        n_epochs:
+                            description: |
+                                The number of epochs to train the model for. An epoch refers to one full cycle
+                                through the training dataset.
+                            oneOf:
+                                - type: string
+                                  enum: [auto]
+                                - type: integer
+                                  minimum: 1
+                                  maximum: 50
+                            default: auto
+                suffix:
+                    description: |
+                        A string of up to 18 characters that will be added to your fine-tuned model name.
+
+                        For example, a `suffix` of "custom-model-name" would produce a model name like `ft:gpt-3.5-turbo:openai:custom-model-name:7p4lURel`.
+                    type: string
+                    minLength: 1
+                    maxLength: 40
+                    default: null
+                    nullable: true
+                validation_file:
+                    description: |
+                        The ID of an uploaded file that contains validation data.
+
+                        If you provide this file, the data is used to generate validation
+                        metrics periodically during fine-tuning. These metrics can be viewed in
+                        the fine-tuning results file.
+                        The same data should not be present in both train and validation files.
+
+                        Your dataset must be formatted as a JSONL file. You must upload your file with the purpose `fine-tune`.
+
+                        See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.
+                    type: string
+                    nullable: true
+                    example: "file-abc123"
+                integrations:
+                    type: array
+                    description: A list of integrations to enable for your fine-tuning job.
+                    nullable: true
+                    items:
+                        type: object
+                        required:
+                            - type
+                            - wandb
+                        properties:
+                            type:
+                                description: |
+                                    The type of integration to enable. Currently, only "wandb" (Weights and Biases) is supported.
+                                oneOf:
+                                    - type: string
+                                      enum: [wandb]
+                            wandb:
+                                type: object
+                                description: |
+                                    The settings for your integration with Weights and Biases. This payload specifies the project that
+                                    metrics will be sent to. Optionally, you can set an explicit display name for your run, add tags
+                                    to your run, and set a default entity (team, username, etc) to be associated with your run.
+                                required:
+                                    - project
+                                properties:
+                                    project:
+                                        description: |
+                                            The name of the project that the new run will be created under.
+                                        type: string
+                                        example: "my-wandb-project"
+                                    name:
+                                        description: |
+                                            A display name to set for the run. If not set, we will use the Job ID as the name.
+                                        nullable: true
+                                        type: string
+                                    entity:
+                                        description: |
+                                            The entity to use for the run. This allows you to set the team or username of the WandB user that you would
+                                            like associated with the run. If not set, the default entity for the registered WandB API key is used.
+                                        nullable: true
+                                        type: string
+                                    tags:
+                                        description: |
+                                            A list of tags to be attached to the newly created run. These tags are passed through directly to WandB. Some
+                                            default tags are generated by OpenAI: "openai/finetune", "openai/{base-model}", "openai/{ftjob-abcdef}".
+                                        type: array
+                                        items:
+                                            type: string
+                                            example: "custom-tag"
+
+                seed:
+                    description: |
+                        The seed controls the reproducibility of the job. Passing in the same seed and job parameters should produce the same results, but may differ in rare cases.
+                        If a seed is not specified, one will be generated for you.
+                    type: integer
+                    nullable: true
+                    minimum: 0
+                    maximum: 2147483647
+                    example: 42
+            required:
+                - model
+                - training_file
+
+        ListFineTuningJobEventsResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FineTuningJobEvent"
+                object:
+                    type: string
+                    enum: [list]
+            required:
+                - object
+                - data
+
+        ListFineTuningJobCheckpointsResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FineTuningJobCheckpoint"
+                object:
+                    type: string
+                    enum: [list]
+                first_id:
+                    type: string
+                    nullable: true
+                last_id:
+                    type: string
+                    nullable: true
+                has_more:
+                    type: boolean
+            required:
+                - object
+                - data
+                - has_more
+
+        CreateEmbeddingRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                input:
+                    description: |
+                        Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `text-embedding-ada-002`), cannot be an empty string, and any array must be 2048 dimensions or less. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
+                    example: "The quick brown fox jumped over the lazy dog"
+                    oneOf:
+                        - type: string
+                          title: string
+                          description: The string that will be turned into an embedding.
+                          default: ""
+                          example: "This is a test."
+                        - type: array
+                          title: array
+                          description: The array of strings that will be turned into an embedding.
+                          minItems: 1
+                          maxItems: 2048
+                          items:
+                              type: string
+                              default: ""
+                              example: "['This is a test.']"
+                        - type: array
+                          title: array
+                          description: The array of integers that will be turned into an embedding.
+                          minItems: 1
+                          maxItems: 2048
+                          items:
+                              type: integer
+                          example: "[1212, 318, 257, 1332, 13]"
+                        - type: array
+                          title: array
+                          description: The array of arrays containing integers that will be turned into an embedding.
+                          minItems: 1
+                          maxItems: 2048
+                          items:
+                              type: array
+                              minItems: 1
+                              items:
+                                  type: integer
+                          example: "[[1212, 318, 257, 1332, 13]]"
+                    x-oaiExpandable: true
+                model:
+                    description: *model_description
+                    example: "text-embedding-3-small"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "text-embedding-ada-002",
+                                  "text-embedding-3-small",
+                                  "text-embedding-3-large",
+                              ]
+                    x-oaiTypeLabel: string
+                encoding_format:
+                    description: "The format to return the embeddings in. Can be either `float` or [`base64`](https://pypi.org/project/pybase64/)."
+                    example: "float"
+                    default: "float"
+                    type: string
+                    enum: ["float", "base64"]
+                dimensions:
+                    description: |
+                        The number of dimensions the resulting output embeddings should have. Only supported in `text-embedding-3` and later models.
+                    type: integer
+                    minimum: 1
+                user: *end_user_param_configuration
+            required:
+                - model
+                - input
+
+        CreateEmbeddingResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    description: The list of embeddings generated by the model.
+                    items:
+                        $ref: "#/components/schemas/Embedding"
+                model:
+                    type: string
+                    description: The name of the model used to generate the embedding.
+                object:
+                    type: string
+                    description: The object type, which is always "list".
+                    enum: [list]
+                usage:
+                    type: object
+                    description: The usage information for the request.
+                    properties:
+                        prompt_tokens:
+                            type: integer
+                            description: The number of tokens used by the prompt.
+                        total_tokens:
+                            type: integer
+                            description: The total number of tokens used by the request.
+                    required:
+                        - prompt_tokens
+                        - total_tokens
+            required:
+                - object
+                - model
+                - data
+                - usage
+
+        CreateTranscriptionRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file:
+                    description: |
+                        The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+                    type: string
+                    x-oaiTypeLabel: file
+                    format: binary
+                model:
+                    description: |
+                        ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.
+                    example: whisper-1
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["whisper-1"]
+                    x-oaiTypeLabel: string
+                language:
+                    description: |
+                        The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format will improve accuracy and latency.
+                    type: string
+                prompt:
+                    description: |
+                        An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text/prompting) should match the audio language.
+                    type: string
+                response_format:
+                    description: |
+                        The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.
+                    type: string
+                    enum:
+                        - json
+                        - text
+                        - srt
+                        - verbose_json
+                        - vtt
+                    default: json
+                temperature:
+                    description: |
+                        The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.
+                    type: number
+                    default: 0
+                timestamp_granularities[]:
+                    description: |
+                        The timestamp granularities to populate for this transcription. `response_format` must be set `verbose_json` to use timestamp granularities. Either or both of these options are supported: `word`, or `segment`. Note: There is no additional latency for segment timestamps, but generating word timestamps incurs additional latency.
+                    type: array
+                    items:
+                        type: string
+                        enum:
+                            - word
+                            - segment
+                    default: [segment]
+            required:
+                - file
+                - model
+
+        # Note: This does not currently support the non-default response format types.
+        CreateTranscriptionResponseJson:
+            type: object
+            description: Represents a transcription response returned by model, based on the provided input.
+            properties:
+                text:
+                    type: string
+                    description: The transcribed text.
+            required:
+                - text
+            x-oaiMeta:
+                name: The transcription object (JSON)
+                group: audio
+                example: *basic_transcription_response_example
+
+        TranscriptionSegment:
+            type: object
+            properties:
+                id:
+                    type: integer
+                    description: Unique identifier of the segment.
+                seek:
+                    type: integer
+                    description: Seek offset of the segment.
+                start:
+                    type: number
+                    format: float
+                    description: Start time of the segment in seconds.
+                end:
+                    type: number
+                    format: float
+                    description: End time of the segment in seconds.
+                text:
+                    type: string
+                    description: Text content of the segment.
+                tokens:
+                    type: array
+                    items:
+                        type: integer
+                    description: Array of token IDs for the text content.
+                temperature:
+                    type: number
+                    format: float
+                    description: Temperature parameter used for generating the segment.
+                avg_logprob:
+                    type: number
+                    format: float
+                    description: Average logprob of the segment. If the value is lower than -1, consider the logprobs failed.
+                compression_ratio:
+                    type: number
+                    format: float
+                    description: Compression ratio of the segment. If the value is greater than 2.4, consider the compression failed.
+                no_speech_prob:
+                    type: number
+                    format: float
+                    description: Probability of no speech in the segment. If the value is higher than 1.0 and the `avg_logprob` is below -1, consider this segment silent.
+            required:
+                - id
+                - seek
+                - start
+                - end
+                - text
+                - tokens
+                - temperature
+                - avg_logprob
+                - compression_ratio
+                - no_speech_prob
+
+        TranscriptionWord:
+            type: object
+            properties:
+                word:
+                    type: string
+                    description: The text content of the word.
+                start:
+                    type: number
+                    format: float
+                    description: Start time of the word in seconds.
+                end:
+                    type: number
+                    format: float
+                    description: End time of the word in seconds.
+            required: [word, start, end]
+
+        CreateTranscriptionResponseVerboseJson:
+            type: object
+            description: Represents a verbose json transcription response returned by model, based on the provided input.
+            properties:
+                language:
+                    type: string
+                    description: The language of the input audio.
+                duration:
+                    type: string
+                    description: The duration of the input audio.
+                text:
+                    type: string
+                    description: The transcribed text.
+                words:
+                    type: array
+                    description: Extracted words and their corresponding timestamps.
+                    items:
+                        $ref: "#/components/schemas/TranscriptionWord"
+                segments:
+                    type: array
+                    description: Segments of the transcribed text and their corresponding details.
+                    items:
+                        $ref: "#/components/schemas/TranscriptionSegment"
+            required: [language, duration, text]
+            x-oaiMeta:
+                name: The transcription object (Verbose JSON)
+                group: audio
+                example: *verbose_transcription_response_example
+
+        CreateTranslationRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file:
+                    description: |
+                        The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+                    type: string
+                    x-oaiTypeLabel: file
+                    format: binary
+                model:
+                    description: |
+                        ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.
+                    example: whisper-1
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["whisper-1"]
+                    x-oaiTypeLabel: string
+                prompt:
+                    description: |
+                        An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text/prompting) should be in English.
+                    type: string
+                response_format:
+                    description: |
+                        The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.
+                    type: string
+                    default: json
+                temperature:
+                    description: |
+                        The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.
+                    type: number
+                    default: 0
+            required:
+                - file
+                - model
+
+        # Note: This does not currently support the non-default response format types.
+        CreateTranslationResponseJson:
+            type: object
+            properties:
+                text:
+                    type: string
+            required:
+                - text
+
+        CreateTranslationResponseVerboseJson:
+            type: object
+            properties:
+                language:
+                    type: string
+                    description: The language of the output translation (always `english`).
+                duration:
+                    type: string
+                    description: The duration of the input audio.
+                text:
+                    type: string
+                    description: The translated text.
+                segments:
+                    type: array
+                    description: Segments of the translated text and their corresponding details.
+                    items:
+                        $ref: "#/components/schemas/TranscriptionSegment"
+            required: [language, duration, text]
+
+        CreateSpeechRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                model:
+                    description: |
+                        One of the available [TTS models](/docs/models/tts): `tts-1` or `tts-1-hd`
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum: ["tts-1", "tts-1-hd"]
+                    x-oaiTypeLabel: string
+                input:
+                    type: string
+                    description: The text to generate audio for. The maximum length is 4096 characters.
+                    maxLength: 4096
+                voice:
+                    description: The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`. Previews of the voices are available in the [Text to speech guide](/docs/guides/text-to-speech/voice-options).
+                    type: string
+                    enum: ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
+                response_format:
+                    description: "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`."
+                    default: "mp3"
+                    type: string
+                    enum: ["mp3", "opus", "aac", "flac", "wav", "pcm"]
+                speed:
+                    description: "The speed of the generated audio. Select a value from `0.25` to `4.0`. `1.0` is the default."
+                    type: number
+                    default: 1.0
+                    minimum: 0.25
+                    maximum: 4.0
+            required:
+                - model
+                - input
+                - voice
+
+        Model:
+            title: Model
+            description: Describes an OpenAI model offering that can be used with the API.
+            properties:
+                id:
+                    type: string
+                    description: The model identifier, which can be referenced in the API endpoints.
+                created:
+                    type: integer
+                    description: The Unix timestamp (in seconds) when the model was created.
+                object:
+                    type: string
+                    description: The object type, which is always "model".
+                    enum: [model]
+                owned_by:
+                    type: string
+                    description: The organization that owns the model.
+            required:
+                - id
+                - object
+                - created
+                - owned_by
+            x-oaiMeta:
+                name: The model object
+                example: *retrieve_model_response
+
+        OpenAIFile:
+            title: OpenAIFile
+            description: The `File` object represents a document that has been uploaded to OpenAI.
+            properties:
+                id:
+                    type: string
+                    description: The file identifier, which can be referenced in the API endpoints.
+                bytes:
+                    type: integer
+                    description: The size of the file, in bytes.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the file was created.
+                filename:
+                    type: string
+                    description: The name of the file.
+                object:
+                    type: string
+                    description: The object type, which is always `file`.
+                    enum: ["file"]
+                purpose:
+                    type: string
+                    description: The intended purpose of the file. Supported values are `assistants`, `assistants_output`, `batch`, `batch_output`, `fine-tune`, `fine-tune-results` and `vision`.
+                    enum:
+                        [
+                            "assistants",
+                            "assistants_output",
+                            "batch",
+                            "batch_output",
+                            "fine-tune",
+                            "fine-tune-results",
+                            "vision",
+                        ]
+                status:
+                    type: string
+                    deprecated: true
+                    description: Deprecated. The current status of the file, which can be either `uploaded`, `processed`, or `error`.
+                    enum: ["uploaded", "processed", "error"]
+                status_details:
+                    type: string
+                    deprecated: true
+                    description: Deprecated. For details on why a fine-tuning training file failed validation, see the `error` field on `fine_tuning.job`.
+            required:
+                - id
+                - object
+                - bytes
+                - created_at
+                - filename
+                - purpose
+                - status
+            x-oaiMeta:
+                name: The file object
+                example: |
+                    {
+                      "id": "file-abc123",
+                      "object": "file",
+                      "bytes": 120000,
+                      "created_at": 1677610602,
+                      "filename": "salesOverview.pdf",
+                      "purpose": "assistants",
+                    }
+        Upload:
+            type: object
+            title: Upload
+            description: |
+                The Upload object can accept byte chunks in the form of Parts.
+            properties:
+                id:
+                    type: string
+                    description: The Upload unique identifier, which can be referenced in API endpoints.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the Upload was created.
+                filename:
+                    type: string
+                    description: The name of the file to be uploaded.
+                bytes:
+                    type: integer
+                    description: The intended number of bytes to be uploaded.
+                purpose:
+                    type: string
+                    description: The intended purpose of the file. [Please refer here](/docs/api-reference/files/object#files/object-purpose) for acceptable values.
+                status:
+                    type: string
+                    description: The status of the Upload.
+                    enum: ["pending", "completed", "cancelled", "expired"]
+                expires_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the Upload was created.
+                object:
+                    type: string
+                    description: The object type, which is always "upload".
+                    enum: [upload]
+                file: 
+                    $ref: "#/components/schemas/OpenAIFile"
+                    nullable: true
+                    description: The ready File object after the Upload is completed.
+            required:
+                - bytes
+                - created_at
+                - expires_at
+                - filename
+                - id
+                - purpose
+                - status
+                - step_number
+            x-oaiMeta:
+                name: The upload object
+                example: |
+                    {
+                      "id": "upload_abc123",
+                      "object": "upload",
+                      "bytes": 2147483648,
+                      "created_at": 1719184911,
+                      "filename": "training_examples.jsonl",
+                      "purpose": "fine-tune",
+                      "status": "completed",
+                      "expires_at": 1719127296,
+                      "file": {
+                        "id": "file-xyz321",
+                        "object": "file",
+                        "bytes": 2147483648,
+                        "created_at": 1719186911,
+                        "filename": "training_examples.jsonl",
+                        "purpose": "fine-tune",
+                      }
+                    }
+        UploadPart:
+            type: object
+            title: UploadPart
+            description: |
+                The upload Part represents a chunk of bytes we can add to an Upload object.
+            properties:
+                id:
+                    type: string
+                    description: The upload Part unique identifier, which can be referenced in API endpoints.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the Part was created.
+                upload_id:
+                    type: string
+                    description: The ID of the Upload object that this Part was added to.
+                object:
+                    type: string
+                    description: The object type, which is always `upload.part`.
+                    enum: ['upload.part']
+            required:
+                - created_at
+                - id
+                - object
+                - upload_id
+            x-oaiMeta:
+                name: The upload part object
+                example: |
+                    {
+                        "id": "part_def456",
+                        "object": "upload.part",
+                        "created_at": 1719186911,
+                        "upload_id": "upload_abc123"
+                    }
+        Embedding:
+            type: object
+            description: |
+                Represents an embedding vector returned by embedding endpoint.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the embedding in the list of embeddings.
+                embedding:
+                    type: array
+                    description: |
+                        The embedding vector, which is a list of floats. The length of vector depends on the model as listed in the [embedding guide](/docs/guides/embeddings).
+                    items:
+                        type: number
+                object:
+                    type: string
+                    description: The object type, which is always "embedding".
+                    enum: [embedding]
+            required:
+                - index
+                - object
+                - embedding
+            x-oaiMeta:
+                name: The embedding object
+                example: |
+                    {
+                      "object": "embedding",
+                      "embedding": [
+                        0.0023064255,
+                        -0.009327292,
+                        .... (1536 floats total for ada-002)
+                        -0.0028842222,
+                      ],
+                      "index": 0
+                    }
+
+        FineTuningJob:
+            type: object
+            title: FineTuningJob
+            description: |
+                The `fine_tuning.job` object represents a fine-tuning job that has been created through the API.
+            properties:
+                id:
+                    type: string
+                    description: The object identifier, which can be referenced in the API endpoints.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the fine-tuning job was created.
+                error:
+                    type: object
+                    nullable: true
+                    description: For fine-tuning jobs that have `failed`, this will contain more information on the cause of the failure.
+                    properties:
+                        code:
+                            type: string
+                            description: A machine-readable error code.
+                        message:
+                            type: string
+                            description: A human-readable error message.
+                        param:
+                            type: string
+                            description: The parameter that was invalid, usually `training_file` or `validation_file`. This field will be null if the failure was not parameter-specific.
+                            nullable: true
+                    required:
+                        - code
+                        - message
+                        - param
+                fine_tuned_model:
+                    type: string
+                    nullable: true
+                    description: The name of the fine-tuned model that is being created. The value will be null if the fine-tuning job is still running.
+                finished_at:
+                    type: integer
+                    nullable: true
+                    description: The Unix timestamp (in seconds) for when the fine-tuning job was finished. The value will be null if the fine-tuning job is still running.
+                hyperparameters:
+                    type: object
+                    description: The hyperparameters used for the fine-tuning job. See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.
+                    properties:
+                        n_epochs:
+                            oneOf:
+                                - type: string
+                                  enum: [auto]
+                                - type: integer
+                                  minimum: 1
+                                  maximum: 50
+                            default: auto
+                            description:
+                                The number of epochs to train the model for. An epoch refers to one full cycle through the training dataset.
+
+                                "auto" decides the optimal number of epochs based on the size of the dataset. If setting the number manually, we support any number between 1 and 50 epochs.
+                    required:
+                        - n_epochs
+                model:
+                    type: string
+                    description: The base model that is being fine-tuned.
+                object:
+                    type: string
+                    description: The object type, which is always "fine_tuning.job".
+                    enum: [fine_tuning.job]
+                organization_id:
+                    type: string
+                    description: The organization that owns the fine-tuning job.
+                result_files:
+                    type: array
+                    description: The compiled results file ID(s) for the fine-tuning job. You can retrieve the results with the [Files API](/docs/api-reference/files/retrieve-contents).
+                    items:
+                        type: string
+                        example: file-abc123
+                status:
+                    type: string
+                    description: The current status of the fine-tuning job, which can be either `validating_files`, `queued`, `running`, `succeeded`, `failed`, or `cancelled`.
+                    enum:
+                        [
+                            "validating_files",
+                            "queued",
+                            "running",
+                            "succeeded",
+                            "failed",
+                            "cancelled",
+                        ]
+                trained_tokens:
+                    type: integer
+                    nullable: true
+                    description: The total number of billable tokens processed by this fine-tuning job. The value will be null if the fine-tuning job is still running.
+                training_file:
+                    type: string
+                    description: The file ID used for training. You can retrieve the training data with the [Files API](/docs/api-reference/files/retrieve-contents).
+                validation_file:
+                    type: string
+                    nullable: true
+                    description: The file ID used for validation. You can retrieve the validation results with the [Files API](/docs/api-reference/files/retrieve-contents).
+                integrations:
+                    type: array
+                    nullable: true
+                    description: A list of integrations to enable for this fine-tuning job.
+                    maxItems: 5
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/FineTuningIntegration"
+                        x-oaiExpandable: true
+                seed:
+                    type: integer
+                    description: The seed used for the fine-tuning job.
+                estimated_finish:
+                    type: integer
+                    nullable: true
+                    description: The Unix timestamp (in seconds) for when the fine-tuning job is estimated to finish. The value will be null if the fine-tuning job is not running.
+            required:
+                - created_at
+                - error
+                - finished_at
+                - fine_tuned_model
+                - hyperparameters
+                - id
+                - model
+                - object
+                - organization_id
+                - result_files
+                - status
+                - trained_tokens
+                - training_file
+                - validation_file
+                - seed
+            x-oaiMeta:
+                name: The fine-tuning job object
+                example: *fine_tuning_example
+
+        FineTuningIntegration:
+            type: object
+            title: Fine-Tuning Job Integration
+            required:
+                - type
+                - wandb
+            properties:
+                type:
+                    type: string
+                    description: "The type of the integration being enabled for the fine-tuning job"
+                    enum: ["wandb"]
+                wandb:
+                    type: object
+                    description: |
+                        The settings for your integration with Weights and Biases. This payload specifies the project that
+                        metrics will be sent to. Optionally, you can set an explicit display name for your run, add tags
+                        to your run, and set a default entity (team, username, etc) to be associated with your run.
+                    required:
+                        - project
+                    properties:
+                        project:
+                            description: |
+                                The name of the project that the new run will be created under.
+                            type: string
+                            example: "my-wandb-project"
+                        name:
+                            description: |
+                                A display name to set for the run. If not set, we will use the Job ID as the name.
+                            nullable: true
+                            type: string
+                        entity:
+                            description: |
+                                The entity to use for the run. This allows you to set the team or username of the WandB user that you would
+                                like associated with the run. If not set, the default entity for the registered WandB API key is used.
+                            nullable: true
+                            type: string
+                        tags:
+                            description: |
+                                A list of tags to be attached to the newly created run. These tags are passed through directly to WandB. Some
+                                default tags are generated by OpenAI: "openai/finetune", "openai/{base-model}", "openai/{ftjob-abcdef}".
+                            type: array
+                            items:
+                                type: string
+                                example: "custom-tag"
+
+        FineTuningJobEvent:
+            type: object
+            description: Fine-tuning job event object
+            properties:
+                id:
+                    type: string
+                created_at:
+                    type: integer
+                level:
+                    type: string
+                    enum: ["info", "warn", "error"]
+                message:
+                    type: string
+                object:
+                    type: string
+                    enum: [fine_tuning.job.event]
+            required:
+                - id
+                - object
+                - created_at
+                - level
+                - message
+            x-oaiMeta:
+                name: The fine-tuning job event object
+                example: |
+                    {
+                      "object": "fine_tuning.job.event",
+                      "id": "ftevent-abc123"
+                      "created_at": 1677610602,
+                      "level": "info",
+                      "message": "Created fine-tuning job"
+                    }
+
+        FineTuningJobCheckpoint:
+            type: object
+            title: FineTuningJobCheckpoint
+            description: |
+                The `fine_tuning.job.checkpoint` object represents a model checkpoint for a fine-tuning job that is ready to use.
+            properties:
+                id:
+                    type: string
+                    description: The checkpoint identifier, which can be referenced in the API endpoints.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the checkpoint was created.
+                fine_tuned_model_checkpoint:
+                    type: string
+                    description: The name of the fine-tuned checkpoint model that is created.
+                step_number:
+                    type: integer
+                    description: The step number that the checkpoint was created at.
+                metrics:
+                    type: object
+                    description: Metrics at the step number during the fine-tuning job.
+                    properties:
+                        step:
+                            type: number
+                        train_loss:
+                            type: number
+                        train_mean_token_accuracy:
+                            type: number
+                        valid_loss:
+                            type: number
+                        valid_mean_token_accuracy:
+                            type: number
+                        full_valid_loss:
+                            type: number
+                        full_valid_mean_token_accuracy:
+                            type: number
+                fine_tuning_job_id:
+                    type: string
+                    description: The name of the fine-tuning job that this checkpoint was created from.
+                object:
+                    type: string
+                    description: The object type, which is always "fine_tuning.job.checkpoint".
+                    enum: [fine_tuning.job.checkpoint]
+            required:
+                - created_at
+                - fine_tuning_job_id
+                - fine_tuned_model_checkpoint
+                - id
+                - metrics
+                - object
+                - step_number
+            x-oaiMeta:
+                name: The fine-tuning job checkpoint object
+                example: |
+                    {
+                      "object": "fine_tuning.job.checkpoint",
+                      "id": "ftckpt_qtZ5Gyk4BLq1SfLFWp3RtO3P",
+                      "created_at": 1712211699,
+                      "fine_tuned_model_checkpoint": "ft:gpt-3.5-turbo-0125:my-org:custom_suffix:9ABel2dg:ckpt-step-88",
+                      "fine_tuning_job_id": "ftjob-fpbNQ3H1GrMehXRf8cO97xTN",
+                      "metrics": {
+                        "step": 88,
+                        "train_loss": 0.478,
+                        "train_mean_token_accuracy": 0.924,
+                        "valid_loss": 10.112,
+                        "valid_mean_token_accuracy": 0.145,
+                        "full_valid_loss": 0.567,
+                        "full_valid_mean_token_accuracy": 0.944
+                      },
+                      "step_number": 88
+                    }
+
+        FinetuneChatRequestInput:
+            type: object
+            description: The per-line training example of a fine-tuning input file for chat models
+            properties:
+                messages:
+                    type: array
+                    minItems: 1
+                    items:
+                      oneOf:
+                      - $ref: "#/components/schemas/ChatCompletionRequestSystemMessage"
+                      - $ref: "#/components/schemas/ChatCompletionRequestUserMessage"
+                      - $ref: "#/components/schemas/FineTuneChatCompletionRequestAssistantMessage"
+                      - $ref: "#/components/schemas/ChatCompletionRequestToolMessage"
+                      - $ref: "#/components/schemas/ChatCompletionRequestFunctionMessage"
+                      x-oaiExpandable: true
+                tools:
+                    type: array
+                    description: A list of tools the model may generate JSON inputs for.
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionTool"
+                parallel_tool_calls:
+                    $ref: "#/components/schemas/ParallelToolCalls"
+                functions:
+                    deprecated: true
+                    description:
+                        A list of functions the model may generate JSON inputs for.
+                    type: array
+                    minItems: 1
+                    maxItems: 128
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionFunctions"
+            x-oaiMeta:
+                name: Training format for chat models
+                example: |
+                  {
+                    "messages": [
+                      { "role": "user", "content": "What is the weather in San Francisco?" },
+                      {
+                        "role": "assistant",
+                        "tool_calls": [
+                          {
+                            "id": "call_id",
+                            "type": "function",
+                            "function": {
+                              "name": "get_current_weather",
+                              "arguments": "{\"location\": \"San Francisco, USA\", \"format\": \"celsius\"}"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "parallel_tool_calls": false,
+                    "tools": [
+                      {
+                        "type": "function",
+                        "function": {
+                          "name": "get_current_weather",
+                          "description": "Get the current weather",
+                          "parameters": {
+                            "type": "object",
+                            "properties": {
+                              "location": {
+                                  "type": "string",
+                                  "description": "The city and country, eg. San Francisco, USA"
+                              },
+                              "format": { "type": "string", "enum": ["celsius", "fahrenheit"] }
+                            },
+                            "required": ["location", "format"]
+                          }
+                        }
+                      }
+                    ]
+                  }
+        
+        FinetuneCompletionRequestInput:
+            type: object
+            description: The per-line training example of a fine-tuning input file for completions models
+            properties:
+                prompt:
+                    type: string
+                    description: The input prompt for this training example.
+                completion:
+                    type: string
+                    description: The desired completion for this training example.
+            x-oaiMeta:
+                name: Training format for completions models
+                example: |
+                    {
+                      "prompt": "What is the answer to 2+2",
+                      "completion": "4"
+                    }
+
+        CompletionUsage:
+            type: object
+            description: Usage statistics for the completion request.
+            properties:
+                completion_tokens:
+                    type: integer
+                    description: Number of tokens in the generated completion.
+                prompt_tokens:
+                    type: integer
+                    description: Number of tokens in the prompt.
+                total_tokens:
+                    type: integer
+                    description: Total number of tokens used in the request (prompt + completion).
+            required:
+                - prompt_tokens
+                - completion_tokens
+                - total_tokens
+
+        RunCompletionUsage:
+            type: object
+            description: Usage statistics related to the run. This value will be `null` if the run is not in a terminal state (i.e. `in_progress`, `queued`, etc.).
+            properties:
+                completion_tokens:
+                    type: integer
+                    description: Number of completion tokens used over the course of the run.
+                prompt_tokens:
+                    type: integer
+                    description: Number of prompt tokens used over the course of the run.
+                total_tokens:
+                    type: integer
+                    description: Total number of tokens used (prompt + completion).
+            required:
+                - prompt_tokens
+                - completion_tokens
+                - total_tokens
+            nullable: true
+
+        RunStepCompletionUsage:
+            type: object
+            description: Usage statistics related to the run step. This value will be `null` while the run step's status is `in_progress`.
+            properties:
+                completion_tokens:
+                    type: integer
+                    description: Number of completion tokens used over the course of the run step.
+                prompt_tokens:
+                    type: integer
+                    description: Number of prompt tokens used over the course of the run step.
+                total_tokens:
+                    type: integer
+                    description: Total number of tokens used (prompt + completion).
+            required:
+                - prompt_tokens
+                - completion_tokens
+                - total_tokens
+            nullable: true
+
+        AssistantsApiResponseFormatOption:
+            description: |
+                Specifies the format that the model must output. Compatible with [GPT-4o](/docs/models/gpt-4o), [GPT-4 Turbo](/docs/models/gpt-4-turbo-and-gpt-4), and all GPT-3.5 Turbo models since `gpt-3.5-turbo-1106`.
+
+                Setting to `{ "type": "json_object" }` enables JSON mode, which guarantees the message the model generates is valid JSON.
+
+                **Important:** when using JSON mode, you **must** also instruct the model to produce JSON yourself via a system or user message. Without this, the model may generate an unending stream of whitespace until the generation reaches the token limit, resulting in a long-running and seemingly "stuck" request. Also note that the message content may be partially cut off if `finish_reason="length"`, which indicates the generation exceeded `max_tokens` or the conversation exceeded the max context length.
+            oneOf:
+                - type: string
+                  description: >
+                      `auto` is the default value
+                  enum: [none, auto]
+                - $ref: "#/components/schemas/AssistantsApiResponseFormat"
+            x-oaiExpandable: true
+
+        AssistantsApiResponseFormat:
+            type: object
+            description: |
+                An object describing the expected output of the model. If `json_object` only `function` type `tools` are allowed to be passed to the Run. If `text` the model can return text or any value needed.
+            properties:
+                type:
+                    type: string
+                    enum: ["text", "json_object"]
+                    example: "json_object"
+                    default: "text"
+                    description: Must be one of `text` or `json_object`.
+
+        AssistantObject:
+            type: object
+            title: Assistant
+            description: Represents an `assistant` that can call the model and use tools.
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `assistant`.
+                    type: string
+                    enum: [assistant]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the assistant was created.
+                    type: integer
+                name:
+                    description: &assistant_name_param_description |
+                        The name of the assistant. The maximum length is 256 characters.
+                    type: string
+                    maxLength: 256
+                    nullable: true
+                description:
+                    description: &assistant_description_param_description |
+                        The description of the assistant. The maximum length is 512 characters.
+                    type: string
+                    maxLength: 512
+                    nullable: true
+                model:
+                    description: *model_description
+                    type: string
+                instructions:
+                    description: &assistant_instructions_param_description |
+                        The system instructions that the assistant uses. The maximum length is 256,000 characters.
+                    type: string
+                    maxLength: 256000
+                    nullable: true
+                tools:
+                    description: &assistant_tools_param_description |
+                        A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `file_search`, or `function`.
+                    default: []
+                    type: array
+                    maxItems: 128
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                        x-oaiExpandable: true
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter`` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The ID of the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                    nullable: true
+                metadata:
+                    description: &metadata_description |
+                        Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                temperature:
+                    description: &run_temperature_description |
+                        What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &run_top_p_description |
+                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                        We generally recommend altering this or temperature but not both.
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+            required:
+                - id
+                - object
+                - created_at
+                - name
+                - description
+                - model
+                - instructions
+                - tools
+                - metadata
+            x-oaiMeta:
+                name: The assistant object
+                beta: true
+                example: *create_assistants_example
+
+        CreateAssistantRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                model:
+                    description: *model_description
+                    example: "gpt-4-turbo"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "gpt-4o",
+                                  "gpt-4o-2024-05-13",
+                                  "gpt-4o-mini",
+                                  "gpt-4o-mini-2024-07-18",
+                                  "gpt-4-turbo",
+                                  "gpt-4-turbo-2024-04-09",
+                                  "gpt-4-0125-preview",
+                                  "gpt-4-turbo-preview",
+                                  "gpt-4-1106-preview",
+                                  "gpt-4-vision-preview",
+                                  "gpt-4",
+                                  "gpt-4-0314",
+                                  "gpt-4-0613",
+                                  "gpt-4-32k",
+                                  "gpt-4-32k-0314",
+                                  "gpt-4-32k-0613",
+                                  "gpt-3.5-turbo",
+                                  "gpt-3.5-turbo-16k",
+                                  "gpt-3.5-turbo-0613",
+                                  "gpt-3.5-turbo-1106",
+                                  "gpt-3.5-turbo-0125",
+                                  "gpt-3.5-turbo-16k-0613",
+                              ]
+                    x-oaiTypeLabel: string
+                name:
+                    description: *assistant_name_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 256
+                description:
+                    description: *assistant_description_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 512
+                instructions:
+                    description: *assistant_instructions_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 256000
+                tools:
+                    description: *assistant_tools_param_description
+                    default: []
+                    type: array
+                    maxItems: 128
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                        x-oaiExpandable: true
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                                vector_stores:
+                                    type: array
+                                    description: |
+                                        A helper to create a [vector store](/docs/api-reference/vector-stores/object) with file_ids and attach it to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                                    maxItems: 1
+                                    items:
+                                        type: object
+                                        properties:
+                                            file_ids:
+                                                type: array
+                                                description: |
+                                                    A list of [file](/docs/api-reference/files) IDs to add to the vector store. There can be a maximum of 10000 files in a vector store.
+                                                maxItems: 10000
+                                                items:
+                                                    type: string
+                                            chunking_strategy:
+                                                # Ideally we'd reuse the chunking strategy schema here, but it doesn't expand properly
+                                                type: object
+                                                description: The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.
+                                                oneOf:
+                                                    - type: object
+                                                      title: Auto Chunking Strategy
+                                                      description: The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.
+                                                      additionalProperties: false
+                                                      properties:
+                                                          type:
+                                                              type: string
+                                                              description: Always `auto`.
+                                                              enum: ["auto"]
+                                                      required:
+                                                          - type 
+                                                    - type: object
+                                                      title: Static Chunking Strategy
+                                                      additionalProperties: false
+                                                      properties:
+                                                          type:
+                                                              type: string
+                                                              description: Always `static`.
+                                                              enum: ["static"]
+                                                          static:
+                                                              type: object
+                                                              additionalProperties: false
+                                                              properties:
+                                                                  max_chunk_size_tokens:
+                                                                      type: integer
+                                                                      minimum: 100
+                                                                      maximum: 4096
+                                                                      description: The maximum number of tokens in each chunk. The default value is `800`. The minimum value is `100` and the maximum value is `4096`.
+                                                                  chunk_overlap_tokens:
+                                                                      type: integer
+                                                                      description: |
+                                                                          The number of tokens that overlap between chunks. The default value is `400`.
+                                                                          
+                                                                          Note that the overlap must not exceed half of `max_chunk_size_tokens`.
+                                                              required:
+                                                                  - max_chunk_size_tokens
+                                                                  - chunk_overlap_tokens
+                                                      required:
+                                                          - type
+                                                          - static
+                                                x-oaiExpandable: true
+                                            metadata:
+                                                type: object
+                                                description: |
+                                                    Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                                                x-oaiTypeLabel: map
+                            oneOf:
+                                - required: [vector_store_ids]
+                                - required: [vector_stores]
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                temperature:
+                    description: &run_temperature_description |
+                        What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &run_top_p_description |
+                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                        We generally recommend altering this or temperature but not both.
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+            required:
+                - model
+
+        ModifyAssistantRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                model:
+                    description: *model_description
+                    anyOf:
+                        - type: string
+                name:
+                    description: *assistant_name_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 256
+                description:
+                    description: *assistant_description_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 512
+                instructions:
+                    description: *assistant_instructions_param_description
+                    type: string
+                    nullable: true
+                    maxLength: 256000
+                tools:
+                    description: *assistant_tools_param_description
+                    default: []
+                    type: array
+                    maxItems: 128
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                        x-oaiExpandable: true
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        Overrides the list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        Overrides the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                temperature:
+                    description: *run_temperature_description
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &run_top_p_description |
+                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                        We generally recommend altering this or temperature but not both.
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+
+        DeleteAssistantResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [assistant.deleted]
+            required:
+                - id
+                - object
+                - deleted
+
+        ListAssistantsResponse:
+            type: object
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AssistantObject"
+                first_id:
+                    type: string
+                    example: "asst_abc123"
+                last_id:
+                    type: string
+                    example: "asst_abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+            x-oaiMeta:
+                name: List assistants response object
+                group: chat
+                example: *list_assistants_example
+
+        AssistantToolsCode:
+            type: object
+            title: Code interpreter tool
+            properties:
+                type:
+                    type: string
+                    description: "The type of tool being defined: `code_interpreter`"
+                    enum: ["code_interpreter"]
+            required:
+                - type
+
+        AssistantToolsFileSearch:
+            type: object
+            title: FileSearch tool
+            properties:
+                type:
+                    type: string
+                    description: "The type of tool being defined: `file_search`"
+                    enum: ["file_search"]
+                file_search:
+                    type: object
+                    description: Overrides for the file search tool.
+                    properties:
+                        max_num_results:
+                            type: integer
+                            minimum: 1
+                            maximum: 50
+                            description: |
+                                The maximum number of results the file search tool should output. The default is 20 for gpt-4* models and 5 for gpt-3.5-turbo. This number should be between 1 and 50 inclusive.
+
+                                Note that the file search tool may output fewer than `max_num_results` results. See the [file search tool documentation](/docs/assistants/tools/file-search/number-of-chunks-returned) for more information.
+            required:
+                - type
+
+        AssistantToolsFileSearchTypeOnly:
+            type: object
+            title: FileSearch tool
+            properties:
+                type:
+                    type: string
+                    description: "The type of tool being defined: `file_search`"
+                    enum: ["file_search"]
+            required:
+                - type
+
+        AssistantToolsFunction:
+            type: object
+            title: Function tool
+            properties:
+                type:
+                    type: string
+                    description: "The type of tool being defined: `function`"
+                    enum: ["function"]
+                function:
+                    $ref: "#/components/schemas/FunctionObject"
+            required:
+                - type
+                - function
+
+        TruncationObject:
+            type: object
+            title: Thread Truncation Controls
+            description: Controls for how a thread will be truncated prior to the run. Use this to control the intial context window of the run.
+            properties:
+                type:
+                    type: string
+                    description: The truncation strategy to use for the thread. The default is `auto`. If set to `last_messages`, the thread will be truncated to the n most recent messages in the thread. When set to `auto`, messages in the middle of the thread will be dropped to fit the context length of the model, `max_prompt_tokens`.
+                    enum: ["auto", "last_messages"]
+                last_messages:
+                    type: integer
+                    description: The number of most recent messages from the thread when constructing the context for the run.
+                    minimum: 1
+                    nullable: true
+            required:
+                - type
+
+        AssistantsApiToolChoiceOption:
+            description: |
+                Controls which (if any) tool is called by the model.
+                `none` means the model will not call any tools and instead generates a message.
+                `auto` is the default value and means the model can pick between generating a message or calling one or more tools.
+                `required` means the model must call one or more tools before responding to the user.
+                Specifying a particular tool like `{"type": "file_search"}` or `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool.
+
+            oneOf:
+                - type: string
+                  description: >
+                      `none` means the model will not call any tools and instead generates a message.
+                      `auto` means the model can pick between generating a message or calling one or more tools.
+                      `required` means the model must call one or more tools before responding to the user.
+                  enum: [none, auto, required]
+                - $ref: "#/components/schemas/AssistantsNamedToolChoice"
+            x-oaiExpandable: true
+
+        AssistantsNamedToolChoice:
+            type: object
+            description: Specifies a tool the model should use. Use to force the model to call a specific tool.
+            properties:
+                type:
+                    type: string
+                    enum: ["function", "code_interpreter", "file_search"]
+                    description: The type of the tool. If type is `function`, the function name must be set
+                function:
+                    type: object
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function to call.
+                    required:
+                        - name
+            required:
+                - type
+
+        RunObject:
+            type: object
+            title: A run on a thread
+            description: Represents an execution run on a [thread](/docs/api-reference/threads).
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread.run`.
+                    type: string
+                    enum: ["thread.run"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the run was created.
+                    type: integer
+                thread_id:
+                    description: The ID of the [thread](/docs/api-reference/threads) that was executed on as a part of this run.
+                    type: string
+                assistant_id:
+                    description: The ID of the [assistant](/docs/api-reference/assistants) used for execution of this run.
+                    type: string
+                status:
+                    description: The status of the run, which can be either `queued`, `in_progress`, `requires_action`, `cancelling`, `cancelled`, `failed`, `completed`, `incomplete`, or `expired`.
+                    type: string
+                    enum:
+                        [
+                            "queued",
+                            "in_progress",
+                            "requires_action",
+                            "cancelling",
+                            "cancelled",
+                            "failed",
+                            "completed",
+                            "incomplete",
+                            "expired",
+                        ]
+                required_action:
+                    type: object
+                    description: Details on the action required to continue the run. Will be `null` if no action is required.
+                    nullable: true
+                    properties:
+                        type:
+                            description: For now, this is always `submit_tool_outputs`.
+                            type: string
+                            enum: ["submit_tool_outputs"]
+                        submit_tool_outputs:
+                            type: object
+                            description: Details on the tool outputs needed for this run to continue.
+                            properties:
+                                tool_calls:
+                                    type: array
+                                    description: A list of the relevant tool calls.
+                                    items:
+                                        $ref: "#/components/schemas/RunToolCallObject"
+                            required:
+                                - tool_calls
+                    required:
+                        - type
+                        - submit_tool_outputs
+                last_error:
+                    type: object
+                    description: The last error associated with this run. Will be `null` if there are no errors.
+                    nullable: true
+                    properties:
+                        code:
+                            type: string
+                            description: One of `server_error`, `rate_limit_exceeded`, or `invalid_prompt`.
+                            enum:
+                                ["server_error", "rate_limit_exceeded", "invalid_prompt"]
+                        message:
+                            type: string
+                            description: A human-readable description of the error.
+                    required:
+                        - code
+                        - message
+                expires_at:
+                    description: The Unix timestamp (in seconds) for when the run will expire.
+                    type: integer
+                    nullable: true
+                started_at:
+                    description: The Unix timestamp (in seconds) for when the run was started.
+                    type: integer
+                    nullable: true
+                cancelled_at:
+                    description: The Unix timestamp (in seconds) for when the run was cancelled.
+                    type: integer
+                    nullable: true
+                failed_at:
+                    description: The Unix timestamp (in seconds) for when the run failed.
+                    type: integer
+                    nullable: true
+                completed_at:
+                    description: The Unix timestamp (in seconds) for when the run was completed.
+                    type: integer
+                    nullable: true
+                incomplete_details:
+                    description: Details on why the run is incomplete. Will be `null` if the run is not incomplete.
+                    type: object
+                    nullable: true
+                    properties:
+                        reason:
+                            description: The reason why the run is incomplete. This will point to which specific token limit was reached over the course of the run.
+                            type: string
+                            enum: ["max_completion_tokens", "max_prompt_tokens"]
+                model:
+                    description: The model that the [assistant](/docs/api-reference/assistants) used for this run.
+                    type: string
+                instructions:
+                    description: The instructions that the [assistant](/docs/api-reference/assistants) used for this run.
+                    type: string
+                tools:
+                    description: The list of tools that the [assistant](/docs/api-reference/assistants) used for this run.
+                    default: []
+                    type: array
+                    maxItems: 20
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                        x-oaiExpandable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                usage:
+                    $ref: "#/components/schemas/RunCompletionUsage"
+                temperature:
+                    description: The sampling temperature used for this run. If not set, defaults to 1.
+                    type: number
+                    nullable: true
+                top_p:
+                    description: The nucleus sampling value used for this run. If not set, defaults to 1.
+                    type: number
+                    nullable: true
+                max_prompt_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of prompt tokens specified to have been used over the course of the run.
+                    minimum: 256
+                max_completion_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of completion tokens specified to have been used over the course of the run.
+                    minimum: 256
+                truncation_strategy:
+                    $ref: "#/components/schemas/TruncationObject"
+                    nullable: true
+                tool_choice:
+                    $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+                    nullable: true
+                parallel_tool_calls:
+                    $ref: "#/components/schemas/ParallelToolCalls"
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+            required:
+                - id
+                - object
+                - created_at
+                - thread_id
+                - assistant_id
+                - status
+                - required_action
+                - last_error
+                - expires_at
+                - started_at
+                - cancelled_at
+                - failed_at
+                - completed_at
+                - model
+                - instructions
+                - tools
+                - metadata
+                - usage
+                - incomplete_details
+                - max_prompt_tokens
+                - max_completion_tokens
+                - truncation_strategy
+                - tool_choice
+                - parallel_tool_calls
+                - response_format
+            x-oaiMeta:
+                name: The run object
+                beta: true
+                example: |
+                    {
+                      "id": "run_abc123",
+                      "object": "thread.run",
+                      "created_at": 1698107661,
+                      "assistant_id": "asst_abc123",
+                      "thread_id": "thread_abc123",
+                      "status": "completed",
+                      "started_at": 1699073476,
+                      "expires_at": null,
+                      "cancelled_at": null,
+                      "failed_at": null,
+                      "completed_at": 1699073498,
+                      "last_error": null,
+                      "model": "gpt-4-turbo",
+                      "instructions": null,
+                      "tools": [{"type": "file_search"}, {"type": "code_interpreter"}],
+                      "metadata": {},
+                      "incomplete_details": null,
+                      "usage": {
+                        "prompt_tokens": 123,
+                        "completion_tokens": 456,
+                        "total_tokens": 579
+                      },
+                      "temperature": 1.0,
+                      "top_p": 1.0,
+                      "max_prompt_tokens": 1000,
+                      "max_completion_tokens": 1000,
+                      "truncation_strategy": {
+                        "type": "auto",
+                        "last_messages": null
+                      },
+                      "response_format": "auto",
+                      "tool_choice": "auto",
+                      "parallel_tool_calls": true
+                    }
+        CreateRunRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                assistant_id:
+                    description: The ID of the [assistant](/docs/api-reference/assistants) to use to execute this run.
+                    type: string
+                model:
+                    description: The ID of the [Model](/docs/api-reference/models) to be used to execute this run. If a value is provided here, it will override the model associated with the assistant. If not, the model associated with the assistant will be used.
+                    example: "gpt-4-turbo"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "gpt-4o",
+                                  "gpt-4o-2024-05-13",
+                                  "gpt-4o-mini",
+                                  "gpt-4o-mini-2024-07-18",
+                                  "gpt-4-turbo",
+                                  "gpt-4-turbo-2024-04-09",
+                                  "gpt-4-0125-preview",
+                                  "gpt-4-turbo-preview",
+                                  "gpt-4-1106-preview",
+                                  "gpt-4-vision-preview",
+                                  "gpt-4",
+                                  "gpt-4-0314",
+                                  "gpt-4-0613",
+                                  "gpt-4-32k",
+                                  "gpt-4-32k-0314",
+                                  "gpt-4-32k-0613",
+                                  "gpt-3.5-turbo",
+                                  "gpt-3.5-turbo-16k",
+                                  "gpt-3.5-turbo-0613",
+                                  "gpt-3.5-turbo-1106",
+                                  "gpt-3.5-turbo-0125",
+                                  "gpt-3.5-turbo-16k-0613",
+                              ]
+                    x-oaiTypeLabel: string
+                    nullable: true
+                instructions:
+                    description: Overrides the [instructions](/docs/api-reference/assistants/createAssistant) of the assistant. This is useful for modifying the behavior on a per-run basis.
+                    type: string
+                    nullable: true
+                additional_instructions:
+                    description: Appends additional instructions at the end of the instructions for the run. This is useful for modifying the behavior on a per-run basis without overriding other instructions.
+                    type: string
+                    nullable: true
+                additional_messages:
+                    description: Adds additional messages to the thread before creating the run.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/CreateMessageRequest"
+                    nullable: true
+                tools:
+                    description: Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis.
+                    nullable: true
+                    type: array
+                    maxItems: 20
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                        x-oaiExpandable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                temperature:
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: *run_temperature_description
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: &run_top_p_description |
+                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                        We generally recommend altering this or temperature but not both.
+                stream:
+                    type: boolean
+                    nullable: true
+                    description: |
+                        If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
+                max_prompt_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only the number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+                    minimum: 256
+                max_completion_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+                    minimum: 256
+                truncation_strategy:
+                    $ref: "#/components/schemas/TruncationObject"
+                    nullable: true
+                tool_choice:
+                    $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+                    nullable: true
+                parallel_tool_calls:
+                    $ref: "#/components/schemas/ParallelToolCalls"
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+            required:
+                - thread_id
+                - assistant_id
+        ListRunsResponse:
+            type: object
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/RunObject"
+                first_id:
+                    type: string
+                    example: "run_abc123"
+                last_id:
+                    type: string
+                    example: "run_abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+        ModifyRunRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+        SubmitToolOutputsRunRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                tool_outputs:
+                    description: A list of tools for which the outputs are being submitted.
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            tool_call_id:
+                                type: string
+                                description: The ID of the tool call in the `required_action` object within the run object the output is being submitted for.
+                            output:
+                                type: string
+                                description: The output of the tool call to be submitted to continue the run.
+                stream:
+                    type: boolean
+                    nullable: true
+                    description: |
+                        If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
+            required:
+                - tool_outputs
+
+        RunToolCallObject:
+            type: object
+            description: Tool call objects
+            properties:
+                id:
+                    type: string
+                    description: The ID of the tool call. This ID must be referenced when you submit the tool outputs in using the [Submit tool outputs to run](/docs/api-reference/runs/submitToolOutputs) endpoint.
+                type:
+                    type: string
+                    description: The type of tool call the output is required for. For now, this is always `function`.
+                    enum: ["function"]
+                function:
+                    type: object
+                    description: The function definition.
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function.
+                        arguments:
+                            type: string
+                            description: The arguments that the model expects you to pass to the function.
+                    required:
+                        - name
+                        - arguments
+            required:
+                - id
+                - type
+                - function
+
+        CreateThreadAndRunRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                assistant_id:
+                    description: The ID of the [assistant](/docs/api-reference/assistants) to use to execute this run.
+                    type: string
+                thread:
+                    $ref: "#/components/schemas/CreateThreadRequest"
+                    description: If no thread is provided, an empty thread will be created.
+                model:
+                    description: The ID of the [Model](/docs/api-reference/models) to be used to execute this run. If a value is provided here, it will override the model associated with the assistant. If not, the model associated with the assistant will be used.
+                    example: "gpt-4-turbo"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "gpt-4o",
+                                  "gpt-4o-2024-05-13",
+                                  "gpt-4o-mini",
+                                  "gpt-4o-mini-2024-07-18",
+                                  "gpt-4-turbo",
+                                  "gpt-4-turbo-2024-04-09",
+                                  "gpt-4-0125-preview",
+                                  "gpt-4-turbo-preview",
+                                  "gpt-4-1106-preview",
+                                  "gpt-4-vision-preview",
+                                  "gpt-4",
+                                  "gpt-4-0314",
+                                  "gpt-4-0613",
+                                  "gpt-4-32k",
+                                  "gpt-4-32k-0314",
+                                  "gpt-4-32k-0613",
+                                  "gpt-3.5-turbo",
+                                  "gpt-3.5-turbo-16k",
+                                  "gpt-3.5-turbo-0613",
+                                  "gpt-3.5-turbo-1106",
+                                  "gpt-3.5-turbo-0125",
+                                  "gpt-3.5-turbo-16k-0613",
+                              ]
+                    x-oaiTypeLabel: string
+                    nullable: true
+                instructions:
+                    description: Override the default system message of the assistant. This is useful for modifying the behavior on a per-run basis.
+                    type: string
+                    nullable: true
+                tools:
+                    description: Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis.
+                    nullable: true
+                    type: array
+                    maxItems: 20
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/AssistantToolsCode"
+                            - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                            - $ref: "#/components/schemas/AssistantToolsFunction"
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The ID of the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                temperature:
+                    type: number
+                    minimum: 0
+                    maximum: 2
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: *run_temperature_description
+                top_p:
+                    type: number
+                    minimum: 0
+                    maximum: 1
+                    default: 1
+                    example: 1
+                    nullable: true
+                    description: *run_top_p_description
+                stream:
+                    type: boolean
+                    nullable: true
+                    description: |
+                        If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
+                max_prompt_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only the number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+                    minimum: 256
+                max_completion_tokens:
+                    type: integer
+                    nullable: true
+                    description: |
+                        The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+                    minimum: 256
+                truncation_strategy:
+                    $ref: "#/components/schemas/TruncationObject"
+                    nullable: true
+                tool_choice:
+                    $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+                    nullable: true
+                parallel_tool_calls:
+                    $ref: "#/components/schemas/ParallelToolCalls"
+                response_format:
+                    $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+                    nullable: true
+            required:
+                - thread_id
+                - assistant_id
+
+        ThreadObject:
+            type: object
+            title: Thread
+            description: Represents a thread that contains [messages](/docs/api-reference/messages).
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread`.
+                    type: string
+                    enum: ["thread"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the thread was created.
+                    type: integer
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+            required:
+                - id
+                - object
+                - created_at
+                - tool_resources
+                - metadata
+            x-oaiMeta:
+                name: The thread object
+                beta: true
+                example: |
+                    {
+                      "id": "thread_abc123",
+                      "object": "thread",
+                      "created_at": 1698107661,
+                      "metadata": {}
+                    }
+
+        CreateThreadRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                messages:
+                    description: A list of [messages](/docs/api-reference/messages) to start the thread with.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/CreateMessageRequest"
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                                vector_stores:
+                                    type: array
+                                    description: |
+                                        A helper to create a [vector store](/docs/api-reference/vector-stores/object) with file_ids and attach it to this thread. There can be a maximum of 1 vector store attached to the thread.
+                                    maxItems: 1
+                                    items:
+                                        type: object
+                                        properties:
+                                            file_ids:
+                                                type: array
+                                                description: |
+                                                    A list of [file](/docs/api-reference/files) IDs to add to the vector store. There can be a maximum of 10000 files in a vector store.
+                                                maxItems: 10000
+                                                items:
+                                                    type: string
+                                            chunking_strategy:
+                                                # Ideally we'd reuse the chunking strategy schema here, but it doesn't expand properly
+                                                type: object
+                                                description: The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.
+                                                oneOf:
+                                                    - type: object
+                                                      title: Auto Chunking Strategy
+                                                      description: The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.
+                                                      additionalProperties: false
+                                                      properties:
+                                                          type:
+                                                              type: string
+                                                              description: Always `auto`.
+                                                              enum: ["auto"]
+                                                      required:
+                                                          - type 
+                                                    - type: object
+                                                      title: Static Chunking Strategy
+                                                      additionalProperties: false
+                                                      properties:
+                                                          type:
+                                                              type: string
+                                                              description: Always `static`.
+                                                              enum: ["static"]
+                                                          static:
+                                                              type: object
+                                                              additionalProperties: false
+                                                              properties:
+                                                                  max_chunk_size_tokens:
+                                                                      type: integer
+                                                                      minimum: 100
+                                                                      maximum: 4096
+                                                                      description: The maximum number of tokens in each chunk. The default value is `800`. The minimum value is `100` and the maximum value is `4096`.
+                                                                  chunk_overlap_tokens:
+                                                                      type: integer
+                                                                      description: |
+                                                                          The number of tokens that overlap between chunks. The default value is `400`.
+                                                                          
+                                                                          Note that the overlap must not exceed half of `max_chunk_size_tokens`.
+                                                              required:
+                                                                  - max_chunk_size_tokens
+                                                                  - chunk_overlap_tokens
+                                                      required:
+                                                          - type
+                                                          - static
+                                                x-oaiExpandable: true
+                                            metadata:
+                                                type: object
+                                                description: |
+                                                    Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                                                x-oaiTypeLabel: map
+                                        x-oaiExpandable: true
+                            oneOf:
+                                - required: [vector_store_ids]
+                                - required: [vector_stores]
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        ModifyThreadRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                tool_resources:
+                    type: object
+                    description: |
+                        A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+                    properties:
+                        code_interpreter:
+                            type: object
+                            properties:
+                                file_ids:
+                                    type: array
+                                    description: |
+                                        A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                                    default: []
+                                    maxItems: 20
+                                    items:
+                                        type: string
+                        file_search:
+                            type: object
+                            properties:
+                                vector_store_ids:
+                                    type: array
+                                    description: |
+                                        The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.
+                                    maxItems: 1
+                                    items:
+                                        type: string
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        DeleteThreadResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [thread.deleted]
+            required:
+                - id
+                - object
+                - deleted
+
+        ListThreadsResponse:
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ThreadObject"
+                first_id:
+                    type: string
+                    example: "asst_abc123"
+                last_id:
+                    type: string
+                    example: "asst_abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
+        MessageObject:
+            type: object
+            title: The message object
+            description: Represents a message within a [thread](/docs/api-reference/threads).
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread.message`.
+                    type: string
+                    enum: ["thread.message"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the message was created.
+                    type: integer
+                thread_id:
+                    description: The [thread](/docs/api-reference/threads) ID that this message belongs to.
+                    type: string
+                status:
+                    description: The status of the message, which can be either `in_progress`, `incomplete`, or `completed`.
+                    type: string
+                    enum: ["in_progress", "incomplete", "completed"]
+                incomplete_details:
+                    description: On an incomplete message, details about why the message is incomplete.
+                    type: object
+                    properties:
+                        reason:
+                            type: string
+                            description: The reason the message is incomplete.
+                            enum:
+                                [
+                                    "content_filter",
+                                    "max_tokens",
+                                    "run_cancelled",
+                                    "run_expired",
+                                    "run_failed",
+                                ]
+                    nullable: true
+                    required:
+                        - reason
+                completed_at:
+                    description: The Unix timestamp (in seconds) for when the message was completed.
+                    type: integer
+                    nullable: true
+                incomplete_at:
+                    description: The Unix timestamp (in seconds) for when the message was marked as incomplete.
+                    type: integer
+                    nullable: true
+                role:
+                    description: The entity that produced the message. One of `user` or `assistant`.
+                    type: string
+                    enum: ["user", "assistant"]
+                content:
+                    description: The content of the message in array of text and/or images.
+                    type: array
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/MessageContentImageFileObject"
+                            - $ref: "#/components/schemas/MessageContentImageUrlObject"
+                            - $ref: "#/components/schemas/MessageContentTextObject"
+                        x-oaiExpandable: true
+                assistant_id:
+                    description: If applicable, the ID of the [assistant](/docs/api-reference/assistants) that authored this message.
+                    type: string
+                    nullable: true
+                run_id:
+                    description: The ID of the [run](/docs/api-reference/runs) associated with the creation of this message. Value is `null` when messages are created manually using the create message or create thread endpoints.
+                    type: string
+                    nullable: true
+                attachments:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            file_id:
+                                type: string
+                                description: The ID of the file to attach to the message.
+                            tools:
+                                description: The tools to add this file to.
+                                type: array
+                                items:
+                                    oneOf:
+                                        - $ref: "#/components/schemas/AssistantToolsCode"
+                                        - $ref: "#/components/schemas/AssistantToolsFileSearchTypeOnly"
+                                    x-oaiExpandable: true
+                    description: A list of files attached to the message, and the tools they were added to.
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+            required:
+                - id
+                - object
+                - created_at
+                - thread_id
+                - status
+                - incomplete_details
+                - completed_at
+                - incomplete_at
+                - role
+                - content
+                - assistant_id
+                - run_id
+                - attachments
+                - metadata
+            x-oaiMeta:
+                name: The message object
+                beta: true
+                example: |
+                    {
+                      "id": "msg_abc123",
+                      "object": "thread.message",
+                      "created_at": 1698983503,
+                      "thread_id": "thread_abc123",
+                      "role": "assistant",
+                      "content": [
+                        {
+                          "type": "text",
+                          "text": {
+                            "value": "Hi! How can I help you today?",
+                            "annotations": []
+                          }
+                        }
+                      ],
+                      "assistant_id": "asst_abc123",
+                      "run_id": "run_abc123",
+                      "attachments": [],
+                      "metadata": {}
+                    }
+
+        MessageDeltaObject:
+            type: object
+            title: Message delta object
+            description: |
+                Represents a message delta i.e. any changed fields on a message during streaming.
+            properties:
+                id:
+                    description: The identifier of the message, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread.message.delta`.
+                    type: string
+                    enum: ["thread.message.delta"]
+                delta:
+                    description: The delta containing the fields that have changed on the Message.
+                    type: object
+                    properties:
+                        role:
+                            description: The entity that produced the message. One of `user` or `assistant`.
+                            type: string
+                            enum: ["user", "assistant"]
+                        content:
+                            description: The content of the message in array of text and/or images.
+                            type: array
+                            items:
+                                oneOf:
+                                    - $ref: "#/components/schemas/MessageDeltaContentImageFileObject"
+                                    - $ref: "#/components/schemas/MessageDeltaContentTextObject"
+                                    - $ref: "#/components/schemas/MessageDeltaContentImageUrlObject"
+                                x-oaiExpandable: true
+            required:
+                - id
+                - object
+                - delta
+            x-oaiMeta:
+                name: The message delta object
+                beta: true
+                example: |
+                    {
+                      "id": "msg_123",
+                      "object": "thread.message.delta",
+                      "delta": {
+                        "content": [
+                          {
+                            "index": 0,
+                            "type": "text",
+                            "text": { "value": "Hello", "annotations": [] }
+                          }
+                        ]
+                      }
+                    }
+
+        CreateMessageRequest:
+            type: object
+            additionalProperties: false
+            required:
+                - role
+                - content
+            properties:
+                role:
+                    type: string
+                    enum: ["user", "assistant"]
+                    description: |
+                        The role of the entity that is creating the message. Allowed values include:
+                        - `user`: Indicates the message is sent by an actual user and should be used in most cases to represent user-generated messages.
+                        - `assistant`: Indicates the message is generated by the assistant. Use this value to insert messages from the assistant into the conversation.
+                content:
+                    oneOf:
+                        - type: string
+                          description: The text contents of the message.
+                          title: Text content
+                        - type: array
+                          description: An array of content parts with a defined type, each can be of type `text` or images can be passed with `image_url` or `image_file`. Image types are only supported on [Vision-compatible models](/docs/models/overview).
+                          title: Array of content parts
+                          items:
+                              oneOf:
+                                  - $ref: "#/components/schemas/MessageContentImageFileObject"
+                                  - $ref: "#/components/schemas/MessageContentImageUrlObject"
+                                  - $ref: "#/components/schemas/MessageRequestContentTextObject"
+                              x-oaiExpandable: true
+                          minItems: 1
+                    x-oaiExpandable: true
+                attachments:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            file_id:
+                                type: string
+                                description: The ID of the file to attach to the message.
+                            tools:
+                                description: The tools to add this file to.
+                                type: array
+                                items:
+                                    oneOf:
+                                        - $ref: "#/components/schemas/AssistantToolsCode"
+                                        - $ref: "#/components/schemas/AssistantToolsFileSearchTypeOnly"
+                                    x-oaiExpandable: true
+                    description: A list of files attached to the message, and the tools they should be added to.
+                    required:
+                        - file_id
+                        - tools
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        ModifyMessageRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        DeleteMessageResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [thread.message.deleted]
+            required:
+                - id
+                - object
+                - deleted
+
+        ListMessagesResponse:
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/MessageObject"
+                first_id:
+                    type: string
+                    example: "msg_abc123"
+                last_id:
+                    type: string
+                    example: "msg_abc123"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
+        MessageContentImageFileObject:
+            title: Image file
+            type: object
+            description: References an image [File](/docs/api-reference/files) in the content of a message.
+            properties:
+                type:
+                    description: Always `image_file`.
+                    type: string
+                    enum: ["image_file"]
+                image_file:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The [File](/docs/api-reference/files) ID of the image in the message content. Set `purpose="vision"` when uploading the File if you need to later display the file content.
+                            type: string
+                        detail:
+                            type: string
+                            description: Specifies the detail level of the image if specified by the user. `low` uses fewer tokens, you can opt in to high resolution using `high`.
+                            enum: ["auto", "low", "high"]
+                            default: "auto"
+                    required:
+                        - file_id
+            required:
+                - type
+                - image_file
+
+        MessageDeltaContentImageFileObject:
+            title: Image file
+            type: object
+            description: References an image [File](/docs/api-reference/files) in the content of a message.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the content part in the message.
+                type:
+                    description: Always `image_file`.
+                    type: string
+                    enum: ["image_file"]
+                image_file:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The [File](/docs/api-reference/files) ID of the image in the message content. Set `purpose="vision"` when uploading the File if you need to later display the file content.
+                            type: string
+                        detail:
+                            type: string
+                            description: Specifies the detail level of the image if specified by the user. `low` uses fewer tokens, you can opt in to high resolution using `high`.
+                            enum: ["auto", "low", "high"]
+                            default: "auto"
+            required:
+                - index
+                - type
+
+        MessageContentImageUrlObject:
+            title: Image URL
+            type: object
+            description: References an image URL in the content of a message.
+            properties:
+                type:
+                    type: string
+                    enum: ["image_url"]
+                    description: The type of the content part.
+                image_url:
+                    type: object
+                    properties:
+                        url:
+                            type: string
+                            description: "The external URL of the image, must be a supported image types: jpeg, jpg, png, gif, webp."
+                            format: uri
+                        detail:
+                            type: string
+                            description: Specifies the detail level of the image. `low` uses fewer tokens, you can opt in to high resolution using `high`. Default value is `auto`
+                            enum: ["auto", "low", "high"]
+                            default: "auto"
+                    required:
+                        - url
+            required:
+                - type
+                - image_url
+
+        MessageDeltaContentImageUrlObject:
+            title: Image URL
+            type: object
+            description: References an image URL in the content of a message.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the content part in the message.
+                type:
+                    description: Always `image_url`.
+                    type: string
+                    enum: ["image_url"]
+                image_url:
+                    type: object
+                    properties:
+                        url:
+                            description: "The URL of the image, must be a supported image types: jpeg, jpg, png, gif, webp."
+                            type: string
+                        detail:
+                            type: string
+                            description: Specifies the detail level of the image. `low` uses fewer tokens, you can opt in to high resolution using `high`.
+                            enum: ["auto", "low", "high"]
+                            default: "auto"
+            required:
+                - index
+                - type
+
+        MessageContentTextObject:
+            title: Text
+            type: object
+            description: The text content that is part of a message.
+            properties:
+                type:
+                    description: Always `text`.
+                    type: string
+                    enum: ["text"]
+                text:
+                    type: object
+                    properties:
+                        value:
+                            description: The data that makes up the text.
+                            type: string
+                        annotations:
+                            type: array
+                            items:
+                                oneOf:
+                                    - $ref: "#/components/schemas/MessageContentTextAnnotationsFileCitationObject"
+                                    - $ref: "#/components/schemas/MessageContentTextAnnotationsFilePathObject"
+                                x-oaiExpandable: true
+                    required:
+                        - value
+                        - annotations
+            required:
+                - type
+                - text
+
+        MessageRequestContentTextObject:
+            title: Text
+            type: object
+            description: The text content that is part of a message.
+            properties:
+                type:
+                    description: Always `text`.
+                    type: string
+                    enum: ["text"]
+                text:
+                    type: string
+                    description: Text content to be sent to the model
+            required:
+                - type
+                - text
+
+        MessageContentTextAnnotationsFileCitationObject:
+            title: File citation
+            type: object
+            description: A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the "file_search" tool to search files.
+            properties:
+                type:
+                    description: Always `file_citation`.
+                    type: string
+                    enum: ["file_citation"]
+                text:
+                    description: The text in the message content that needs to be replaced.
+                    type: string
+                file_citation:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The ID of the specific File the citation is from.
+                            type: string
+                    required:
+                        - file_id
+                start_index:
+                    type: integer
+                    minimum: 0
+                end_index:
+                    type: integer
+                    minimum: 0
+            required:
+                - type
+                - text
+                - file_citation
+                - start_index
+                - end_index
+
+        MessageContentTextAnnotationsFilePathObject:
+            title: File path
+            type: object
+            description: A URL for the file that's generated when the assistant used the `code_interpreter` tool to generate a file.
+            properties:
+                type:
+                    description: Always `file_path`.
+                    type: string
+                    enum: ["file_path"]
+                text:
+                    description: The text in the message content that needs to be replaced.
+                    type: string
+                file_path:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The ID of the file that was generated.
+                            type: string
+                    required:
+                        - file_id
+                start_index:
+                    type: integer
+                    minimum: 0
+                end_index:
+                    type: integer
+                    minimum: 0
+            required:
+                - type
+                - text
+                - file_path
+                - start_index
+                - end_index
+
+        MessageDeltaContentTextObject:
+            title: Text
+            type: object
+            description: The text content that is part of a message.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the content part in the message.
+                type:
+                    description: Always `text`.
+                    type: string
+                    enum: ["text"]
+                text:
+                    type: object
+                    properties:
+                        value:
+                            description: The data that makes up the text.
+                            type: string
+                        annotations:
+                            type: array
+                            items:
+                                oneOf:
+                                    - $ref: "#/components/schemas/MessageDeltaContentTextAnnotationsFileCitationObject"
+                                    - $ref: "#/components/schemas/MessageDeltaContentTextAnnotationsFilePathObject"
+                                x-oaiExpandable: true
+            required:
+                - index
+                - type
+
+        MessageDeltaContentTextAnnotationsFileCitationObject:
+            title: File citation
+            type: object
+            description: A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the "file_search" tool to search files.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the annotation in the text content part.
+                type:
+                    description: Always `file_citation`.
+                    type: string
+                    enum: ["file_citation"]
+                text:
+                    description: The text in the message content that needs to be replaced.
+                    type: string
+                file_citation:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The ID of the specific File the citation is from.
+                            type: string
+                        quote:
+                            description: The specific quote in the file.
+                            type: string
+                start_index:
+                    type: integer
+                    minimum: 0
+                end_index:
+                    type: integer
+                    minimum: 0
+            required:
+                - index
+                - type
+
+        MessageDeltaContentTextAnnotationsFilePathObject:
+            title: File path
+            type: object
+            description: A URL for the file that's generated when the assistant used the `code_interpreter` tool to generate a file.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the annotation in the text content part.
+                type:
+                    description: Always `file_path`.
+                    type: string
+                    enum: ["file_path"]
+                text:
+                    description: The text in the message content that needs to be replaced.
+                    type: string
+                file_path:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The ID of the file that was generated.
+                            type: string
+                start_index:
+                    type: integer
+                    minimum: 0
+                end_index:
+                    type: integer
+                    minimum: 0
+            required:
+                - index
+                - type
+
+        RunStepObject:
+            type: object
+            title: Run steps
+            description: |
+                Represents a step in execution of a run.
+            properties:
+                id:
+                    description: The identifier of the run step, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread.run.step`.
+                    type: string
+                    enum: ["thread.run.step"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the run step was created.
+                    type: integer
+                assistant_id:
+                    description: The ID of the [assistant](/docs/api-reference/assistants) associated with the run step.
+                    type: string
+                thread_id:
+                    description: The ID of the [thread](/docs/api-reference/threads) that was run.
+                    type: string
+                run_id:
+                    description: The ID of the [run](/docs/api-reference/runs) that this run step is a part of.
+                    type: string
+                type:
+                    description: The type of run step, which can be either `message_creation` or `tool_calls`.
+                    type: string
+                    enum: ["message_creation", "tool_calls"]
+                status:
+                    description: The status of the run step, which can be either `in_progress`, `cancelled`, `failed`, `completed`, or `expired`.
+                    type: string
+                    enum: ["in_progress", "cancelled", "failed", "completed", "expired"]
+                step_details:
+                    type: object
+                    description: The details of the run step.
+                    oneOf:
+                        - $ref: "#/components/schemas/RunStepDetailsMessageCreationObject"
+                        - $ref: "#/components/schemas/RunStepDetailsToolCallsObject"
+                    x-oaiExpandable: true
+                last_error:
+                    type: object
+                    description: The last error associated with this run step. Will be `null` if there are no errors.
+                    nullable: true
+                    properties:
+                        code:
+                            type: string
+                            description: One of `server_error` or `rate_limit_exceeded`.
+                            enum: ["server_error", "rate_limit_exceeded"]
+                        message:
+                            type: string
+                            description: A human-readable description of the error.
+                    required:
+                        - code
+                        - message
+                expired_at:
+                    description: The Unix timestamp (in seconds) for when the run step expired. A step is considered expired if the parent run is expired.
+                    type: integer
+                    nullable: true
+                cancelled_at:
+                    description: The Unix timestamp (in seconds) for when the run step was cancelled.
+                    type: integer
+                    nullable: true
+                failed_at:
+                    description: The Unix timestamp (in seconds) for when the run step failed.
+                    type: integer
+                    nullable: true
+                completed_at:
+                    description: The Unix timestamp (in seconds) for when the run step completed.
+                    type: integer
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+                usage:
+                    $ref: "#/components/schemas/RunStepCompletionUsage"
+            required:
+                - id
+                - object
+                - created_at
+                - assistant_id
+                - thread_id
+                - run_id
+                - type
+                - status
+                - step_details
+                - last_error
+                - expired_at
+                - cancelled_at
+                - failed_at
+                - completed_at
+                - metadata
+                - usage
+            x-oaiMeta:
+                name: The run step object
+                beta: true
+                example: *run_step_object_example
+
+        RunStepDeltaObject:
+            type: object
+            title: Run step delta object
+            description: |
+                Represents a run step delta i.e. any changed fields on a run step during streaming.
+            properties:
+                id:
+                    description: The identifier of the run step, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `thread.run.step.delta`.
+                    type: string
+                    enum: ["thread.run.step.delta"]
+                delta:
+                    description: The delta containing the fields that have changed on the run step.
+                    type: object
+                    properties:
+                        step_details:
+                            type: object
+                            description: The details of the run step.
+                            oneOf:
+                                - $ref: "#/components/schemas/RunStepDeltaStepDetailsMessageCreationObject"
+                                - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsObject"
+                            x-oaiExpandable: true
+            required:
+                - id
+                - object
+                - delta
+            x-oaiMeta:
+                name: The run step delta object
+                beta: true
+                example: |
+                    {
+                      "id": "step_123",
+                      "object": "thread.run.step.delta",
+                      "delta": {
+                        "step_details": {
+                          "type": "tool_calls",
+                          "tool_calls": [
+                            {
+                              "index": 0,
+                              "id": "call_123",
+                              "type": "code_interpreter",
+                              "code_interpreter": { "input": "", "outputs": [] }
+                            }
+                          ]
+                        }
+                      }
+                    }
+
+        ListRunStepsResponse:
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/RunStepObject"
+                first_id:
+                    type: string
+                    example: "step_abc123"
+                last_id:
+                    type: string
+                    example: "step_abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
+        RunStepDetailsMessageCreationObject:
+            title: Message creation
+            type: object
+            description: Details of the message creation by the run step.
+            properties:
+                type:
+                    description: Always `message_creation`.
+                    type: string
+                    enum: ["message_creation"]
+                message_creation:
+                    type: object
+                    properties:
+                        message_id:
+                            type: string
+                            description: The ID of the message that was created by this run step.
+                    required:
+                        - message_id
+            required:
+                - type
+                - message_creation
+
+        RunStepDeltaStepDetailsMessageCreationObject:
+            title: Message creation
+            type: object
+            description: Details of the message creation by the run step.
+            properties:
+                type:
+                    description: Always `message_creation`.
+                    type: string
+                    enum: ["message_creation"]
+                message_creation:
+                    type: object
+                    properties:
+                        message_id:
+                            type: string
+                            description: The ID of the message that was created by this run step.
+            required:
+                - type
+
+        RunStepDetailsToolCallsObject:
+            title: Tool calls
+            type: object
+            description: Details of the tool call.
+            properties:
+                type:
+                    description: Always `tool_calls`.
+                    type: string
+                    enum: ["tool_calls"]
+                tool_calls:
+                    type: array
+                    description: |
+                        An array of tool calls the run step was involved in. These can be associated with one of three types of tools: `code_interpreter`, `file_search`, or `function`.
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/RunStepDetailsToolCallsCodeObject"
+                            - $ref: "#/components/schemas/RunStepDetailsToolCallsFileSearchObject"
+                            - $ref: "#/components/schemas/RunStepDetailsToolCallsFunctionObject"
+                        x-oaiExpandable: true
+            required:
+                - type
+                - tool_calls
+
+        RunStepDeltaStepDetailsToolCallsObject:
+            title: Tool calls
+            type: object
+            description: Details of the tool call.
+            properties:
+                type:
+                    description: Always `tool_calls`.
+                    type: string
+                    enum: ["tool_calls"]
+                tool_calls:
+                    type: array
+                    description: |
+                        An array of tool calls the run step was involved in. These can be associated with one of three types of tools: `code_interpreter`, `file_search`, or `function`.
+                    items:
+                        oneOf:
+                            - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeObject"
+                            - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsFileSearchObject"
+                            - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsFunctionObject"
+                        x-oaiExpandable: true
+            required:
+                - type
+
+        RunStepDetailsToolCallsCodeObject:
+            title: Code Interpreter tool call
+            type: object
+            description: Details of the Code Interpreter tool call the run step was involved in.
+            properties:
+                id:
+                    type: string
+                    description: The ID of the tool call.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `code_interpreter` for this type of tool call.
+                    enum: ["code_interpreter"]
+                code_interpreter:
+                    type: object
+                    description: The Code Interpreter tool call definition.
+                    required:
+                        - input
+                        - outputs
+                    properties:
+                        input:
+                            type: string
+                            description: The input to the Code Interpreter tool call.
+                        outputs:
+                            type: array
+                            description: The outputs from the Code Interpreter tool call. Code Interpreter can output one or more items, including text (`logs`) or images (`image`). Each of these are represented by a different object type.
+                            items:
+                                type: object
+                                oneOf:
+                                    - $ref: "#/components/schemas/RunStepDetailsToolCallsCodeOutputLogsObject"
+                                    - $ref: "#/components/schemas/RunStepDetailsToolCallsCodeOutputImageObject"
+                                x-oaiExpandable: true
+            required:
+                - id
+                - type
+                - code_interpreter
+
+        RunStepDeltaStepDetailsToolCallsCodeObject:
+            title: Code interpreter tool call
+            type: object
+            description: Details of the Code Interpreter tool call the run step was involved in.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the tool call in the tool calls array.
+                id:
+                    type: string
+                    description: The ID of the tool call.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `code_interpreter` for this type of tool call.
+                    enum: ["code_interpreter"]
+                code_interpreter:
+                    type: object
+                    description: The Code Interpreter tool call definition.
+                    properties:
+                        input:
+                            type: string
+                            description: The input to the Code Interpreter tool call.
+                        outputs:
+                            type: array
+                            description: The outputs from the Code Interpreter tool call. Code Interpreter can output one or more items, including text (`logs`) or images (`image`). Each of these are represented by a different object type.
+                            items:
+                                type: object
+                                oneOf:
+                                    - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeOutputLogsObject"
+                                    - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeOutputImageObject"
+                                x-oaiExpandable: true
+            required:
+                - index
+                - type
+
+        RunStepDetailsToolCallsCodeOutputLogsObject:
+            title: Code Interpreter log output
+            type: object
+            description: Text output from the Code Interpreter tool call as part of a run step.
+            properties:
+                type:
+                    description: Always `logs`.
+                    type: string
+                    enum: ["logs"]
+                logs:
+                    type: string
+                    description: The text output from the Code Interpreter tool call.
+            required:
+                - type
+                - logs
+
+        RunStepDeltaStepDetailsToolCallsCodeOutputLogsObject:
+            title: Code interpreter log output
+            type: object
+            description: Text output from the Code Interpreter tool call as part of a run step.
+            properties:
+                index:
+                    type: integer
+                    description: The index of the output in the outputs array.
+                type:
+                    description: Always `logs`.
+                    type: string
+                    enum: ["logs"]
+                logs:
+                    type: string
+                    description: The text output from the Code Interpreter tool call.
+            required:
+                - index
+                - type
+
+        RunStepDetailsToolCallsCodeOutputImageObject:
+            title: Code Interpreter image output
+            type: object
+            properties:
+                type:
+                    description: Always `image`.
+                    type: string
+                    enum: ["image"]
+                image:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The [file](/docs/api-reference/files) ID of the image.
+                            type: string
+                    required:
+                        - file_id
+            required:
+                - type
+                - image
+
+        RunStepDeltaStepDetailsToolCallsCodeOutputImageObject:
+            title: Code interpreter image output
+            type: object
+            properties:
+                index:
+                    type: integer
+                    description: The index of the output in the outputs array.
+                type:
+                    description: Always `image`.
+                    type: string
+                    enum: ["image"]
+                image:
+                    type: object
+                    properties:
+                        file_id:
+                            description: The [file](/docs/api-reference/files) ID of the image.
+                            type: string
+            required:
+                - index
+                - type
+
+        RunStepDetailsToolCallsFileSearchObject:
+            title: File search tool call
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: The ID of the tool call object.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `file_search` for this type of tool call.
+                    enum: ["file_search"]
+                file_search:
+                    type: object
+                    description: For now, this is always going to be an empty object.
+                    x-oaiTypeLabel: map
+            required:
+                - id
+                - type
+                - file_search
+
+        RunStepDeltaStepDetailsToolCallsFileSearchObject:
+            title: File search tool call
+            type: object
+            properties:
+                index:
+                    type: integer
+                    description: The index of the tool call in the tool calls array.
+                id:
+                    type: string
+                    description: The ID of the tool call object.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `file_search` for this type of tool call.
+                    enum: ["file_search"]
+                file_search:
+                    type: object
+                    description: For now, this is always going to be an empty object.
+                    x-oaiTypeLabel: map
+            required:
+                - index
+                - type
+                - file_search
+
+        RunStepDetailsToolCallsFunctionObject:
+            type: object
+            title: Function tool call
+            properties:
+                id:
+                    type: string
+                    description: The ID of the tool call object.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `function` for this type of tool call.
+                    enum: ["function"]
+                function:
+                    type: object
+                    description: The definition of the function that was called.
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function.
+                        arguments:
+                            type: string
+                            description: The arguments passed to the function.
+                        output:
+                            type: string
+                            description: The output of the function. This will be `null` if the outputs have not been [submitted](/docs/api-reference/runs/submitToolOutputs) yet.
+                            nullable: true
+                    required:
+                        - name
+                        - arguments
+                        - output
+            required:
+                - id
+                - type
+                - function
+
+        RunStepDeltaStepDetailsToolCallsFunctionObject:
+            type: object
+            title: Function tool call
+            properties:
+                index:
+                    type: integer
+                    description: The index of the tool call in the tool calls array.
+                id:
+                    type: string
+                    description: The ID of the tool call object.
+                type:
+                    type: string
+                    description: The type of tool call. This is always going to be `function` for this type of tool call.
+                    enum: ["function"]
+                function:
+                    type: object
+                    description: The definition of the function that was called.
+                    properties:
+                        name:
+                            type: string
+                            description: The name of the function.
+                        arguments:
+                            type: string
+                            description: The arguments passed to the function.
+                        output:
+                            type: string
+                            description: The output of the function. This will be `null` if the outputs have not been [submitted](/docs/api-reference/runs/submitToolOutputs) yet.
+                            nullable: true
+            required:
+                - index
+                - type
+
+        VectorStoreExpirationAfter:
+            type: object
+            title: Vector store expiration policy
+            description: The expiration policy for a vector store.
+            properties:
+                anchor:
+                    description: "Anchor timestamp after which the expiration policy applies. Supported anchors: `last_active_at`."
+                    type: string
+                    enum: ["last_active_at"]
+                days:
+                    description: The number of days after the anchor time that the vector store will expire.
+                    type: integer
+                    minimum: 1
+                    maximum: 365
+            required:
+                - anchor
+                - days
+
+        VectorStoreObject:
+            type: object
+            title: Vector store
+            description: A vector store is a collection of processed files can be used by the `file_search` tool.
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `vector_store`.
+                    type: string
+                    enum: ["vector_store"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the vector store was created.
+                    type: integer
+                name:
+                    description: The name of the vector store.
+                    type: string
+                usage_bytes:
+                    description: The total number of bytes used by the files in the vector store.
+                    type: integer
+                file_counts:
+                    type: object
+                    properties:
+                        in_progress:
+                            description: The number of files that are currently being processed.
+                            type: integer
+                        completed:
+                            description: The number of files that have been successfully processed.
+                            type: integer
+                        failed:
+                            description: The number of files that have failed to process.
+                            type: integer
+                        cancelled:
+                            description: The number of files that were cancelled.
+                            type: integer
+                        total:
+                            description: The total number of files.
+                            type: integer
+                    required:
+                        - in_progress
+                        - completed
+                        - failed
+                        - cancelled
+                        - total
+                status:
+                    description: The status of the vector store, which can be either `expired`, `in_progress`, or `completed`. A status of `completed` indicates that the vector store is ready for use.
+                    type: string
+                    enum: ["expired", "in_progress", "completed"]
+                expires_after:
+                    $ref: "#/components/schemas/VectorStoreExpirationAfter"
+                expires_at:
+                    description: The Unix timestamp (in seconds) for when the vector store will expire.
+                    type: integer
+                    nullable: true
+                last_active_at:
+                    description: The Unix timestamp (in seconds) for when the vector store was last active.
+                    type: integer
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+            required:
+                - id
+                - object
+                - usage_bytes
+                - created_at
+                - status
+                - last_active_at
+                - name
+                - file_counts
+                - metadata
+            x-oaiMeta:
+                name: The vector store object
+                beta: true
+                example: |
+                    {
+                      "id": "vs_123",
+                      "object": "vector_store",
+                      "created_at": 1698107661,
+                      "usage_bytes": 123456,
+                      "last_active_at": 1698107661,
+                      "name": "my_vector_store",
+                      "status": "completed",
+                      "file_counts": {
+                        "in_progress": 0,
+                        "completed": 100,
+                        "cancelled": 0,
+                        "failed": 0,
+                        "total": 100
+                      },
+                      "metadata": {},
+                      "last_used_at": 1698107661
+                    }
+
+        CreateVectorStoreRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file_ids:
+                    description: A list of [File](/docs/api-reference/files) IDs that the vector store should use. Useful for tools like `file_search` that can access files.
+                    type: array
+                    maxItems: 500
+                    items:
+                        type: string
+                name:
+                    description: The name of the vector store.
+                    type: string
+                expires_after:
+                    $ref: "#/components/schemas/VectorStoreExpirationAfter"
+                chunking_strategy:
+                    type: object
+                    description: The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy. Only applicable if `file_ids` is non-empty.
+                    oneOf:
+                        - $ref: "#/components/schemas/AutoChunkingStrategyRequestParam"
+                        - $ref: "#/components/schemas/StaticChunkingStrategyRequestParam"
+                    x-oaiExpandable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        UpdateVectorStoreRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                name:
+                    description: The name of the vector store.
+                    type: string
+                    nullable: true
+                expires_after:
+                    $ref: "#/components/schemas/VectorStoreExpirationAfter"
+                    nullable: true
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+
+        ListVectorStoresResponse:
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/VectorStoreObject"
+                first_id:
+                    type: string
+                    example: "vs_abc123"
+                last_id:
+                    type: string
+                    example: "vs_abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
+        DeleteVectorStoreResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [vector_store.deleted]
+            required:
+                - id
+                - object
+                - deleted
+
+        VectorStoreFileObject:
+            type: object
+            title: Vector store files
+            description: A list of files attached to a vector store.
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `vector_store.file`.
+                    type: string
+                    enum: ["vector_store.file"]
+                usage_bytes:
+                    description: The total vector store usage in bytes. Note that this may be different from the original file size.
+                    type: integer
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the vector store file was created.
+                    type: integer
+                vector_store_id:
+                    description: The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files) is attached to.
+                    type: string
+                status:
+                    description: The status of the vector store file, which can be either `in_progress`, `completed`, `cancelled`, or `failed`. The status `completed` indicates that the vector store file is ready for use.
+                    type: string
+                    enum: ["in_progress", "completed", "cancelled", "failed"]
+                last_error:
+                    type: object
+                    description: The last error associated with this vector store file. Will be `null` if there are no errors.
+                    nullable: true
+                    properties:
+                        code:
+                            type: string
+                            description: One of `server_error` or `rate_limit_exceeded`.
+                            enum:
+                                [
+                                    "internal_error",
+                                    "file_not_found",
+                                    "parsing_error",
+                                    "unhandled_mime_type",
+                                ]
+                        message:
+                            type: string
+                            description: A human-readable description of the error.
+                    required:
+                        - code
+                        - message
+                chunking_strategy:
+                    type: object
+                    description: The strategy used to chunk the file.
+                    oneOf:
+                        - $ref: "#/components/schemas/StaticChunkingStrategyResponseParam"
+                        - $ref: "#/components/schemas/OtherChunkingStrategyResponseParam"
+                    x-oaiExpandable: true
+            required:
+                - id
+                - object
+                - usage_bytes
+                - created_at
+                - vector_store_id
+                - status
+                - last_error
+            x-oaiMeta:
+                name: The vector store file object
+                beta: true
+                example: |
+                    {
+                      "id": "file-abc123",
+                      "object": "vector_store.file",
+                      "usage_bytes": 1234,
+                      "created_at": 1698107661,
+                      "vector_store_id": "vs_abc123",
+                      "status": "completed",
+                      "last_error": null,
+                      "chunking_strategy": {
+                        "type": "static",
+                        "static": {
+                          "max_chunk_size_tokens": 800,
+                          "chunk_overlap_tokens": 400
+                        }
+                      }
+                    }
+
+        OtherChunkingStrategyResponseParam:
+            type: object
+            title: Other Chunking Strategy
+            description: This is returned when the chunking strategy is unknown. Typically, this is because the file was indexed before the `chunking_strategy` concept was introduced in the API.
+            additionalProperties: false
+            properties:
+                type:
+                    type: string
+                    description: Always `other`.
+                    enum: ["other"]
+            required:
+                - type
+
+        StaticChunkingStrategyResponseParam:
+            type: object
+            title: Static Chunking Strategy
+            additionalProperties: false
+            properties:
+                type:
+                    type: string
+                    description: Always `static`.
+                    enum: ["static"]
+                static:
+                    $ref: "#/components/schemas/StaticChunkingStrategy"
+            required:
+                - type
+                - static
+
+        StaticChunkingStrategy:
+            type: object
+            additionalProperties: false
+            properties:
+                max_chunk_size_tokens:
+                    type: integer
+                    minimum: 100
+                    maximum: 4096
+                    description: The maximum number of tokens in each chunk. The default value is `800`. The minimum value is `100` and the maximum value is `4096`.
+                chunk_overlap_tokens:
+                    type: integer
+                    description: |
+                        The number of tokens that overlap between chunks. The default value is `400`.
+                        
+                        Note that the overlap must not exceed half of `max_chunk_size_tokens`.
+            required:
+                - max_chunk_size_tokens
+                - chunk_overlap_tokens
+
+        AutoChunkingStrategyRequestParam:
+            type: object
+            title: Auto Chunking Strategy
+            description: The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.
+            additionalProperties: false
+            properties:
+                type:
+                    type: string
+                    description: Always `auto`.
+                    enum: ["auto"]
+            required:
+                - type
+
+        StaticChunkingStrategyRequestParam:
+            type: object
+            title: Static Chunking Strategy
+            additionalProperties: false
+            properties:
+                type:
+                    type: string
+                    description: Always `static`.
+                    enum: ["static"]
+                static:
+                    $ref: "#/components/schemas/StaticChunkingStrategy"
+            required:
+                - type
+                - static
+
+        ChunkingStrategyRequestParam:
+            type: object
+            description: The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.
+            oneOf:
+                - $ref: "#/components/schemas/AutoChunkingStrategyRequestParam"
+                - $ref: "#/components/schemas/StaticChunkingStrategyRequestParam"
+            x-oaiExpandable: true
+
+        CreateVectorStoreFileRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file_id:
+                    description: A [File](/docs/api-reference/files) ID that the vector store should use. Useful for tools like `file_search` that can access files.
+                    type: string
+                chunking_strategy:
+                    $ref: "#/components/schemas/ChunkingStrategyRequestParam"
+            required:
+                - file_id
+
+        ListVectorStoreFilesResponse:
+            properties:
+                object:
+                    type: string
+                    example: "list"
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/VectorStoreFileObject"
+                first_id:
+                    type: string
+                    example: "file-abc123"
+                last_id:
+                    type: string
+                    example: "file-abc456"
+                has_more:
+                    type: boolean
+                    example: false
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
+        DeleteVectorStoreFileResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                deleted:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [vector_store.file.deleted]
+            required:
+                - id
+                - object
+                - deleted
+
+        VectorStoreFileBatchObject:
+            type: object
+            title: Vector store file batch
+            description: A batch of files attached to a vector store.
+            properties:
+                id:
+                    description: The identifier, which can be referenced in API endpoints.
+                    type: string
+                object:
+                    description: The object type, which is always `vector_store.file_batch`.
+                    type: string
+                    enum: ["vector_store.files_batch"]
+                created_at:
+                    description: The Unix timestamp (in seconds) for when the vector store files batch was created.
+                    type: integer
+                vector_store_id:
+                    description: The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files) is attached to.
+                    type: string
+                status:
+                    description: The status of the vector store files batch, which can be either `in_progress`, `completed`, `cancelled` or `failed`.
+                    type: string
+                    enum: ["in_progress", "completed", "cancelled", "failed"]
+                file_counts:
+                    type: object
+                    properties:
+                        in_progress:
+                            description: The number of files that are currently being processed.
+                            type: integer
+                        completed:
+                            description: The number of files that have been processed.
+                            type: integer
+                        failed:
+                            description: The number of files that have failed to process.
+                            type: integer
+                        cancelled:
+                            description: The number of files that where cancelled.
+                            type: integer
+                        total:
+                            description: The total number of files.
+                            type: integer
+                    required:
+                        - in_progress
+                        - completed
+                        - cancelled
+                        - failed
+                        - total
+            required:
+                - id
+                - object
+                - created_at
+                - vector_store_id
+                - status
+                - file_counts
+            x-oaiMeta:
+                name: The vector store files batch object
+                beta: true
+                example: |
+                    {
+                      "id": "vsfb_123",
+                      "object": "vector_store.files_batch",
+                      "created_at": 1698107661,
+                      "vector_store_id": "vs_abc123",
+                      "status": "completed",
+                      "file_counts": {
+                        "in_progress": 0,
+                        "completed": 100,
+                        "failed": 0,
+                        "cancelled": 0,
+                        "total": 100
+                      }
+                    }
+
+        CreateVectorStoreFileBatchRequest:
+            type: object
+            additionalProperties: false
+            properties:
+                file_ids:
+                    description: A list of [File](/docs/api-reference/files) IDs that the vector store should use. Useful for tools like `file_search` that can access files.
+                    type: array
+                    minItems: 1
+                    maxItems: 500
+                    items:
+                        type: string
+                chunking_strategy:
+                    $ref: "#/components/schemas/ChunkingStrategyRequestParam"
+            required:
+                - file_ids
+
+        AssistantStreamEvent:
+            description: |
+                Represents an event emitted when streaming a Run.
+
+                Each event in a server-sent events stream has an `event` and `data` property:
+
+                ```
+                event: thread.created
+                data: {"id": "thread_123", "object": "thread", ...}
+                ```
+
+                We emit events whenever a new object is created, transitions to a new state, or is being
+                streamed in parts (deltas). For example, we emit `thread.run.created` when a new run
+                is created, `thread.run.completed` when a run completes, and so on. When an Assistant chooses
+                to create a message during a run, we emit a `thread.message.created event`, a
+                `thread.message.in_progress` event, many `thread.message.delta` events, and finally a
+                `thread.message.completed` event.
+
+                We may add additional events over time, so we recommend handling unknown events gracefully
+                in your code. See the [Assistants API quickstart](/docs/assistants/overview) to learn how to
+                integrate the Assistants API with streaming.
+            oneOf:
+                - $ref: "#/components/schemas/ThreadStreamEvent"
+                - $ref: "#/components/schemas/RunStreamEvent"
+                - $ref: "#/components/schemas/RunStepStreamEvent"
+                - $ref: "#/components/schemas/MessageStreamEvent"
+                - $ref: "#/components/schemas/ErrorEvent"
+                - $ref: "#/components/schemas/DoneEvent"
+            x-oaiMeta:
+                name: Assistant stream events
+                beta: true
+
+        ThreadStreamEvent:
+            oneOf:
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.created"]
+                      data:
+                          $ref: "#/components/schemas/ThreadObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a new [thread](/docs/api-reference/threads/object) is created.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [thread](/docs/api-reference/threads/object)"
+
+        RunStreamEvent:
+            oneOf:
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.created"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a new [run](/docs/api-reference/runs/object) is created.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.queued"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) moves to a `queued` status.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.in_progress"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) moves to an `in_progress` status.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.requires_action"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) moves to a `requires_action` status.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.completed"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) is completed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: [ "thread.run.incomplete" ]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) ends with status `incomplete`.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.failed"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) fails.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.cancelling"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) moves to a `cancelling` status.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.cancelled"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) is cancelled.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.expired"]
+                      data:
+                          $ref: "#/components/schemas/RunObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run](/docs/api-reference/runs/object) expires.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+
+        RunStepStreamEvent:
+            oneOf:
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.created"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) is created.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.in_progress"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) moves to an `in_progress` state.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.delta"]
+                      data:
+                          $ref: "#/components/schemas/RunStepDeltaObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when parts of a [run step](/docs/api-reference/runs/step-object) are being streamed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step delta](/docs/api-reference/assistants-streaming/run-step-delta-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.completed"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) is completed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.failed"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) fails.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.cancelled"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) is cancelled.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.run.step.expired"]
+                      data:
+                          $ref: "#/components/schemas/RunStepObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [run step](/docs/api-reference/runs/step-object) expires.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+
+        MessageStreamEvent:
+            oneOf:
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.message.created"]
+                      data:
+                          $ref: "#/components/schemas/MessageObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [message](/docs/api-reference/messages/object) is created.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.message.in_progress"]
+                      data:
+                          $ref: "#/components/schemas/MessageObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [message](/docs/api-reference/messages/object) moves to an `in_progress` state.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.message.delta"]
+                      data:
+                          $ref: "#/components/schemas/MessageDeltaObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when parts of a [Message](/docs/api-reference/messages/object) are being streamed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [message delta](/docs/api-reference/assistants-streaming/message-delta-object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.message.completed"]
+                      data:
+                          $ref: "#/components/schemas/MessageObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [message](/docs/api-reference/messages/object) is completed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+                - type: object
+                  properties:
+                      event:
+                          type: string
+                          enum: ["thread.message.incomplete"]
+                      data:
+                          $ref: "#/components/schemas/MessageObject"
+                  required:
+                      - event
+                      - data
+                  description: Occurs when a [message](/docs/api-reference/messages/object) ends before it is completed.
+                  x-oaiMeta:
+                      dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+
+        ErrorEvent:
+            type: object
+            properties:
+                event:
+                    type: string
+                    enum: ["error"]
+                data:
+                    $ref: "#/components/schemas/Error"
+            required:
+                - event
+                - data
+            description: Occurs when an [error](/docs/guides/error-codes/api-errors) occurs. This can happen due to an internal server error or a timeout.
+            x-oaiMeta:
+                dataDescription: "`data` is an [error](/docs/guides/error-codes/api-errors)"
+
+        DoneEvent:
+            type: object
+            properties:
+                event:
+                    type: string
+                    enum: ["done"]
+                data:
+                    type: string
+                    enum: ["[DONE]"]
+            required:
+                - event
+                - data
+            description: Occurs when a stream ends.
+            x-oaiMeta:
+                dataDescription: "`data` is `[DONE]`"
+
+        Batch:
+            type: object
+            properties:
+                id:
+                    type: string
+                object:
+                    type: string
+                    enum: [batch]
+                    description: The object type, which is always `batch`.
+                endpoint:
+                    type: string
+                    description: The OpenAI API endpoint used by the batch.
+
+                errors:
+                    type: object
+                    properties:
+                        object:
+                            type: string
+                            description: The object type, which is always `list`.
+                        data:
+                            type: array
+                            items:
+                                type: object
+                                properties:
+                                    code:
+                                        type: string
+                                        description: An error code identifying the error type.
+                                    message:
+                                        type: string
+                                        description: A human-readable message providing more details about the error.
+                                    param:
+                                        type: string
+                                        description: The name of the parameter that caused the error, if applicable.
+                                        nullable: true
+                                    line:
+                                        type: integer
+                                        description: The line number of the input file where the error occurred, if applicable.
+                                        nullable: true
+                input_file_id:
+                    type: string
+                    description: The ID of the input file for the batch.
+                completion_window:
+                    type: string
+                    description: The time frame within which the batch should be processed.
+                status:
+                    type: string
+                    description: The current status of the batch.
+                    enum:
+                        - validating
+                        - failed
+                        - in_progress
+                        - finalizing
+                        - completed
+                        - expired
+                        - cancelling
+                        - cancelled
+                output_file_id:
+                    type: string
+                    description: The ID of the file containing the outputs of successfully executed requests.
+                error_file_id:
+                    type: string
+                    description: The ID of the file containing the outputs of requests with errors.
+                created_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch was created.
+                in_progress_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch started processing.
+                expires_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch will expire.
+                finalizing_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch started finalizing.
+                completed_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch was completed.
+                failed_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch failed.
+                expired_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch expired.
+                cancelling_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch started cancelling.
+                cancelled_at:
+                    type: integer
+                    description: The Unix timestamp (in seconds) for when the batch was cancelled.
+                request_counts:
+                    type: object
+                    properties:
+                        total:
+                            type: integer
+                            description: Total number of requests in the batch.
+                        completed:
+                            type: integer
+                            description: Number of requests that have been completed successfully.
+                        failed:
+                            type: integer
+                            description: Number of requests that have failed.
+                    required:
+                        - total
+                        - completed
+                        - failed
+                    description: The request counts for different statuses within the batch.
+                metadata:
+                    description: *metadata_description
+                    type: object
+                    x-oaiTypeLabel: map
+                    nullable: true
+            required:
+                - id
+                - object
+                - endpoint
+                - input_file_id
+                - completion_window
+                - status
+                - created_at
+            x-oaiMeta:
+                name: The batch object
+                example: *batch_object
+
+        BatchRequestInput:
+            type: object
+            description: The per-line object of the batch input file
+            properties:
+                custom_id:
+                    type: string
+                    description: A developer-provided per-request id that will be used to match outputs to inputs. Must be unique for each request in a batch.
+                method:
+                    type: string
+                    enum: ["POST"]
+                    description: The HTTP method to be used for the request. Currently only `POST` is supported.
+                url:
+                    type: string
+                    description: The OpenAI API relative URL to be used for the request. Currently `/v1/chat/completions`, `/v1/embeddings`, and `/v1/completions` are supported.
+            x-oaiMeta:
+                name: The request input object
+                example: |
+                    {"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "What is 2+2?"}]}}
+
+        BatchRequestOutput:
+            type: object
+            description: The per-line object of the batch output and error files
+            properties:
+                id:
+                    type: string
+                custom_id:
+                    type: string
+                    description: A developer-provided per-request id that will be used to match outputs to inputs.
+                response:
+                    type: object
+                    nullable: true
+                    properties:
+                        status_code:
+                            type: integer
+                            description: The HTTP status code of the response
+                        request_id:
+                            type: string
+                            description: An unique identifier for the OpenAI API request. Please include this request ID when contacting support.
+                        body:
+                            type: object
+                            x-oaiTypeLabel: map
+                            description: The JSON body of the response
+                error:
+                    type: object
+                    nullable: true
+                    description: For requests that failed with a non-HTTP error, this will contain more information on the cause of the failure.
+                    properties:
+                        code:
+                            type: string
+                            description: A machine-readable error code.
+                        message:
+                            type: string
+                            description: A human-readable error message.
+            x-oaiMeta:
+                name: The request output object
+                example: |
+                    {"id": "batch_req_wnaDys", "custom_id": "request-2", "response": {"status_code": 200, "request_id": "req_c187b3", "body": {"id": "chatcmpl-9758Iw", "object": "chat.completion", "created": 1711475054, "model": "gpt-3.5-turbo", "choices": [{"index": 0, "message": {"role": "assistant", "content": "2 + 2 equals 4."}, "finish_reason": "stop"}], "usage": {"prompt_tokens": 24, "completion_tokens": 15, "total_tokens": 39}, "system_fingerprint": null}}, "error": null}
+
+        ListBatchesResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/Batch"
+                first_id:
+                    type: string
+                    example: "batch_abc123"
+                last_id:
+                    type: string
+                    example: "batch_abc456"
+                has_more:
+                    type: boolean
+                object:
+                    type: string
+                    enum: [list]
+            required:
+                - object
+                - data
+                - has_more
+
+security:
+    - ApiKeyAuth: []
+
+x-oaiMeta:
+    navigationGroups:
+        - id: endpoints
+          title: Endpoints
+        - id: assistants
+          title: Assistants
+        - id: legacy
+          title: Legacy
+    groups:
+        # > General Notes
+        # The `groups` section is used to generate the API reference pages and navigation, in the same
+        # order listed below. Additionally, each `group` can have a list of `sections`, each of which
+        # will become a navigation subroute and subsection under the group. Each section has:
+        #  - `type`: Currently, either an `endpoint` or `object`, depending on how the section needs to
+        #            be rendered
+        #  - `key`: The reference key that can be used to lookup the section definition
+        #  - `path`: The path (url) of the section, which is used to generate the navigation link.
+        #
+        # > The `object` sections maps to a schema component and the following fields are read for rendering
+        # - `x-oaiMeta.name`: The name of the object, which will become the section title
+        # - `x-oaiMeta.example`: The example object, which will be used to generate the example sample (always JSON)
+        # - `description`: The description of the object, which will be used to generate the section description
+        #
+        # > The `endpoint` section maps to an operation path and the following fields are read for rendering:
+        # - `x-oaiMeta.name`: The name of the endpoint, which will become the section title
+        # - `x-oaiMeta.examples`: The endpoint examples, which can be an object (meaning a single variation, most
+        #                         endpoints, or an array of objects, meaning multiple variations, e.g. the
+        #                         chat completion and completion endpoints, with streamed and non-streamed examples.
+        # - `x-oaiMeta.returns`: text describing what the endpoint returns.
+        # - `summary`: The summary of the endpoint, which will be used to generate the section description
+        - id: audio
+          title: Audio
+          description: |
+              Learn how to turn audio into text or text into audio.
+
+              Related guide: [Speech to text](/docs/guides/speech-to-text)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createSpeech
+                path: createSpeech
+              - type: endpoint
+                key: createTranscription
+                path: createTranscription
+              - type: endpoint
+                key: createTranslation
+                path: createTranslation
+              - type: object
+                key: CreateTranscriptionResponseJson
+                path: json-object
+              - type: object
+                key: CreateTranscriptionResponseVerboseJson
+                path: verbose-json-object
+        - id: chat
+          title: Chat
+          description: |
+              Given a list of messages comprising a conversation, the model will return a response.
+
+              Related guide: [Chat Completions](/docs/guides/text-generation)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createChatCompletion
+                path: create
+              - type: object
+                key: CreateChatCompletionResponse
+                path: object
+              - type: object
+                key: CreateChatCompletionStreamResponse
+                path: streaming
+        - id: embeddings
+          title: Embeddings
+          description: |
+              Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
+
+              Related guide: [Embeddings](/docs/guides/embeddings)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createEmbedding
+                path: create
+              - type: object
+                key: Embedding
+                path: object
+        - id: fine-tuning
+          title: Fine-tuning
+          description: |
+              Manage fine-tuning jobs to tailor a model to your specific training data.
+
+              Related guide: [Fine-tune models](/docs/guides/fine-tuning)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createFineTuningJob
+                path: create
+              - type: endpoint
+                key: listPaginatedFineTuningJobs
+                path: list
+              - type: endpoint
+                key: listFineTuningEvents
+                path: list-events
+              - type: endpoint
+                key: listFineTuningJobCheckpoints
+                path: list-checkpoints
+              - type: endpoint
+                key: retrieveFineTuningJob
+                path: retrieve
+              - type: endpoint
+                key: cancelFineTuningJob
+                path: cancel
+              - type: object
+                key: FinetuneChatRequestInput
+                path: chat-input
+              - type: object
+                key: FinetuneCompletionRequestInput
+                path: completions-input
+              - type: object
+                key: FineTuningJob
+                path: object
+              - type: object
+                key: FineTuningJobEvent
+                path: event-object
+              - type: object
+                key: FineTuningJobCheckpoint
+                path: checkpoint-object
+        - id: batch
+          title: Batch
+          description: |
+              Create large batches of API requests for asynchronous processing. The Batch API returns completions within 24 hours for a 50% discount.
+
+              Related guide: [Batch](/docs/guides/batch)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createBatch
+                path: create
+              - type: endpoint
+                key: retrieveBatch
+                path: retrieve
+              - type: endpoint
+                key: cancelBatch
+                path: cancel
+              - type: endpoint
+                key: listBatches
+                path: list
+              - type: object
+                key: Batch
+                path: object
+              - type: object
+                key: BatchRequestInput
+                path: request-input
+              - type: object
+                key: BatchRequestOutput
+                path: request-output
+        - id: files
+          title: Files
+          description: |
+              Files are used to upload documents that can be used with features like [Assistants](/docs/api-reference/assistants), [Fine-tuning](/docs/api-reference/fine-tuning), and [Batch API](/docs/guides/batch).
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createFile
+                path: create
+              - type: endpoint
+                key: listFiles
+                path: list
+              - type: endpoint
+                key: retrieveFile
+                path: retrieve
+              - type: endpoint
+                key: deleteFile
+                path: delete
+              - type: endpoint
+                key: downloadFile
+                path: retrieve-contents
+              - type: object
+                key: OpenAIFile
+                path: object
+        - id: uploads
+          title: Uploads
+          description: |
+              Allows you to upload large files in multiple parts.
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createUpload
+                path: create
+              - type: endpoint
+                key: addUploadPart
+                path: add-part
+              - type: endpoint
+                key: completeUpload
+                path: complete
+              - type: endpoint
+                key: cancelUpload
+                path: cancel
+              - type: object
+                key: Upload
+                path: object
+              - type: object
+                key: UploadPart
+                path: part-object
+        - id: images
+          title: Images
+          description: |
+              Given a prompt and/or an input image, the model will generate a new image.
+
+              Related guide: [Image generation](/docs/guides/images)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createImage
+                path: create
+              - type: endpoint
+                key: createImageEdit
+                path: createEdit
+              - type: endpoint
+                key: createImageVariation
+                path: createVariation
+              - type: object
+                key: Image
+                path: object
+        - id: models
+          title: Models
+          description: |
+              List and describe the various models available in the API. You can refer to the [Models](/docs/models) documentation to understand what models are available and the differences between them.
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: listModels
+                path: list
+              - type: endpoint
+                key: retrieveModel
+                path: retrieve
+              - type: endpoint
+                key: deleteModel
+                path: delete
+              - type: object
+                key: Model
+                path: object
+        - id: moderations
+          title: Moderations
+          description: |
+              Given some input text, outputs if the model classifies it as potentially harmful across several categories.
+
+              Related guide: [Moderations](/docs/guides/moderation)
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: createModeration
+                path: create
+              - type: object
+                key: CreateModerationResponse
+                path: object
+        - id: assistants
+          title: Assistants
+          beta: true
+          description: |
+              Build assistants that can call models and use tools to perform tasks.
+
+              [Get started with the Assistants API](/docs/assistants)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createAssistant
+                path: createAssistant
+              - type: endpoint
+                key: listAssistants
+                path: listAssistants
+              - type: endpoint
+                key: getAssistant
+                path: getAssistant
+              - type: endpoint
+                key: modifyAssistant
+                path: modifyAssistant
+              - type: endpoint
+                key: deleteAssistant
+                path: deleteAssistant
+              - type: object
+                key: AssistantObject
+                path: object
+        - id: threads
+          title: Threads
+          beta: true
+          description: |
+              Create threads that assistants can interact with.
+
+              Related guide: [Assistants](/docs/assistants/overview)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createThread
+                path: createThread
+              - type: endpoint
+                key: getThread
+                path: getThread
+              - type: endpoint
+                key: modifyThread
+                path: modifyThread
+              - type: endpoint
+                key: deleteThread
+                path: deleteThread
+              - type: object
+                key: ThreadObject
+                path: object
+        - id: messages
+          title: Messages
+          beta: true
+          description: |
+              Create messages within threads
+
+              Related guide: [Assistants](/docs/assistants/overview)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createMessage
+                path: createMessage
+              - type: endpoint
+                key: listMessages
+                path: listMessages
+              - type: endpoint
+                key: getMessage
+                path: getMessage
+              - type: endpoint
+                key: modifyMessage
+                path: modifyMessage
+              - type: endpoint
+                key: deleteMessage
+                path: deleteMessage
+              - type: object
+                key: MessageObject
+                path: object
+        - id: runs
+          title: Runs
+          beta: true
+          description: |
+              Represents an execution run on a thread.
+
+              Related guide: [Assistants](/docs/assistants/overview)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createRun
+                path: createRun
+              - type: endpoint
+                key: createThreadAndRun
+                path: createThreadAndRun
+              - type: endpoint
+                key: listRuns
+                path: listRuns
+              - type: endpoint
+                key: getRun
+                path: getRun
+              - type: endpoint
+                key: modifyRun
+                path: modifyRun
+              - type: endpoint
+                key: submitToolOuputsToRun
+                path: submitToolOutputs
+              - type: endpoint
+                key: cancelRun
+                path: cancelRun
+              - type: object
+                key: RunObject
+                path: object
+        - id: run-steps
+          title: Run Steps
+          beta: true
+          description: |
+              Represents the steps (model and tool calls) taken during the run.
+
+              Related guide: [Assistants](/docs/assistants/overview)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: listRunSteps
+                path: listRunSteps
+              - type: endpoint
+                key: getRunStep
+                path: getRunStep
+              - type: object
+                key: RunStepObject
+                path: step-object
+        - id: vector-stores
+          title: Vector Stores
+          beta: true
+          description: |
+              Vector stores are used to store files for use by the `file_search` tool.
+
+              Related guide: [File Search](/docs/assistants/tools/file-search)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createVectorStore
+                path: create
+              - type: endpoint
+                key: listVectorStores
+                path: list
+              - type: endpoint
+                key: getVectorStore
+                path: retrieve
+              - type: endpoint
+                key: modifyVectorStore
+                path: modify
+              - type: endpoint
+                key: deleteVectorStore
+                path: delete
+              - type: object
+                key: VectorStoreObject
+                path: object
+        - id: vector-stores-files
+          title: Vector Store Files
+          beta: true
+          description: |
+              Vector store files represent files inside a vector store.
+
+              Related guide: [File Search](/docs/assistants/tools/file-search)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createVectorStoreFile
+                path: createFile
+              - type: endpoint
+                key: listVectorStoreFiles
+                path: listFiles
+              - type: endpoint
+                key: getVectorStoreFile
+                path: getFile
+              - type: endpoint
+                key: deleteVectorStoreFile
+                path: deleteFile
+              - type: object
+                key: VectorStoreFileObject
+                path: file-object
+        - id: vector-stores-file-batches
+          title: Vector Store File Batches
+          beta: true
+          description: |
+              Vector store file batches represent operations to add multiple files to a vector store.
+
+              Related guide: [File Search](/docs/assistants/tools/file-search)
+          navigationGroup: assistants
+          sections:
+              - type: endpoint
+                key: createVectorStoreFileBatch
+                path: createBatch
+              - type: endpoint
+                key: getVectorStoreFileBatch
+                path: getBatch
+              - type: endpoint
+                key: cancelVectorStoreFileBatch
+                path: cancelBatch
+              - type: endpoint
+                key: listFilesInVectorStoreBatch
+                path: listBatchFiles
+              - type: object
+                key: VectorStoreFileBatchObject
+                path: batch-object
+        - id: assistants-streaming
+          title: Streaming
+          beta: true
+          description: |
+              Stream the result of executing a Run or resuming a Run after submitting tool outputs.
+
+              You can stream events from the [Create Thread and Run](/docs/api-reference/runs/createThreadAndRun),
+              [Create Run](/docs/api-reference/runs/createRun), and [Submit Tool Outputs](/docs/api-reference/runs/submitToolOutputs)
+              endpoints by passing `"stream": true`. The response will be a [Server-Sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) stream.
+
+              Our Node and Python SDKs provide helpful utilities to make streaming easy. Reference the
+              [Assistants API quickstart](/docs/assistants/overview) to learn more.
+          navigationGroup: assistants
+          sections:
+              - type: object
+                key: MessageDeltaObject
+                path: message-delta-object
+              - type: object
+                key: RunStepDeltaObject
+                path: run-step-delta-object
+              - type: object
+                key: AssistantStreamEvent
+                path: events
+        - id: completions
+          title: Completions
+          legacy: true
+          navigationGroup: legacy
+          description: |
+              Given a prompt, the model will return one or more predicted completions along with the probabilities of alternative tokens at each position. Most developer should use our [Chat Completions API](/docs/guides/text-generation/text-generation-models) to leverage our best and newest models.
+          sections:
+              - type: endpoint
+                key: createCompletion
+                path: create
+              - type: object
+                key: CreateCompletionResponse
+                path: object

--- a/Tests/UITests/TestApp/openapi.yaml
+++ b/Tests/UITests/TestApp/openapi.yaml
@@ -59,6 +59,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/CreateChatCompletionResponse"
+                        text/event-stream:
+                            schema:
+                                $ref: "#/components/schemas/CreateChatCompletionStreamResponse"
 
             x-oaiMeta:
                 name: Create chat completion

--- a/Tests/UITests/TestAppUITests/TestAppLLMOpenAIUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppLLMOpenAIUITests.swift
@@ -64,14 +64,14 @@ class TestAppLLMOpenAIUITests: XCTestCase {
         let alert = app.alerts["Model Selected"]
         
         XCTAssertTrue(alert.waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(alert.staticTexts["gpt-4o"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert.staticTexts["GPT 4O"].exists, "The correct model was not registered.")
         
         let okButton = alert.buttons["OK"]
         XCTAssertTrue(okButton.exists, "The OK button on the alert was not found.")
         okButton.tap()
         #else
         XCTAssertTrue(app.staticTexts["Model Selected"].waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(app.staticTexts["gpt-4-turbo"].exists, "The correct model was not registered.")
+        XCTAssertTrue(app.staticTexts["GPT 4O"].exists, "The correct model was not registered.")
         XCTAssert(app.buttons["OK"].firstMatch.waitForExistence(timeout: 2))
         app.buttons["OK"].firstMatch.tap()
         #endif
@@ -102,14 +102,14 @@ class TestAppLLMOpenAIUITests: XCTestCase {
         let alert2 = app.alerts["Model Selected"]
 
         XCTAssertTrue(alert2.waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(alert2.staticTexts["gpt-3.5-turbo"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert2.staticTexts["GPT 3.5 Turbo"].exists, "The correct model was not registered.")
 
         let okButton2 = alert.buttons["OK"]
         XCTAssertTrue(okButton2.exists, "The OK button on the alert was not found.")
         okButton.tap()
         #else
         XCTAssertTrue(app.staticTexts["Model Selected"].waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(app.staticTexts["gpt-3.5-turbo"].exists, "The correct model was not registered.")
+        XCTAssertTrue(app.staticTexts["GPT 3.5 Turbo"].exists, "The correct model was not registered.")
         XCTAssert(app.buttons["OK"].firstMatch.waitForExistence(timeout: 2))
         app.buttons["OK"].firstMatch.tap()
         #endif

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -42,6 +42,10 @@
 		97A25C952B28DDAB0073B990 /* LLMOpenAITokenOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A25C932B28DDAB0073B990 /* LLMOpenAITokenOnboarding.swift */; };
 		97A36E152B999EA60034D821 /* SpeziLLMFog in Frameworks */ = {isa = PBXBuildFile; productRef = 97A36E142B999EA60034D821 /* SpeziLLMFog */; };
 		97C93FD02B999DD10023F4B9 /* LLMFogChatTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C93FCF2B999DD10023F4B9 /* LLMFogChatTestView.swift */; };
+		DA7ED2862C60D0E400BA8C47 /* openapi.yaml in Resources */ = {isa = PBXBuildFile; fileRef = DA7ED2842C60D0E400BA8C47 /* openapi.yaml */; };
+		DA7ED2872C60D0E400BA8C47 /* openapi-generator-config.yaml in Resources */ = {isa = PBXBuildFile; fileRef = DA7ED2852C60D0E400BA8C47 /* openapi-generator-config.yaml */; };
+		DA7ED28A2C60D1EF00BA8C47 /* OpenAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = DA7ED2892C60D1EF00BA8C47 /* OpenAPIRuntime */; };
+		DA7ED2902C60DA8600BA8C47 /* OpenAPIURLSession in Frameworks */ = {isa = PBXBuildFile; productRef = DA7ED28F2C60DA8600BA8C47 /* OpenAPIURLSession */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +92,8 @@
 		97A25C922B28DDAB0073B990 /* LLMOpenAIModelOnboarding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LLMOpenAIModelOnboarding.swift; sourceTree = "<group>"; };
 		97A25C932B28DDAB0073B990 /* LLMOpenAITokenOnboarding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LLMOpenAITokenOnboarding.swift; sourceTree = "<group>"; };
 		97C93FCF2B999DD10023F4B9 /* LLMFogChatTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMFogChatTestView.swift; sourceTree = "<group>"; };
+		DA7ED2842C60D0E400BA8C47 /* openapi.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = openapi.yaml; sourceTree = "<group>"; };
+		DA7ED2852C60D0E400BA8C47 /* openapi-generator-config.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "openapi-generator-config.yaml"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,8 +105,10 @@
 				9770F2912BB3C40C00478571 /* SpeziFirebaseAccount in Frameworks */,
 				97A36E152B999EA60034D821 /* SpeziLLMFog in Frameworks */,
 				9722A5A22B5B5CB20005645E /* SpeziLLMLocal in Frameworks */,
+				DA7ED2902C60DA8600BA8C47 /* OpenAPIURLSession in Frameworks */,
 				9722A5A62B5B5CB20005645E /* SpeziLLMOpenAI in Frameworks */,
 				9722A5A42B5B5CB20005645E /* SpeziLLMLocalDownload in Frameworks */,
+				DA7ED28A2C60D1EF00BA8C47 /* OpenAPIRuntime in Frameworks */,
 				979D41902BB3EBD8001953BD /* SpeziAccount in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -140,6 +148,8 @@
 		2F6D139428F5F384007C25D6 /* TestApp */ = {
 			isa = PBXGroup;
 			children = (
+				DA7ED2842C60D0E400BA8C47 /* openapi.yaml */,
+				DA7ED2852C60D0E400BA8C47 /* openapi-generator-config.yaml */,
 				977447212B992D3A00D1F85E /* TestApp.entitlements */,
 				9756D25A2B0316790006B6BD /* Resources */,
 				97DD56B32B02F72D00389331 /* LLMLocal */,
@@ -274,6 +284,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				DA7ED2802C5FCAFD00BA8C47 /* PBXTargetDependency */,
 			);
 			name = TestApp;
 			packageProductDependencies = (
@@ -284,6 +295,8 @@
 				97A36E142B999EA60034D821 /* SpeziLLMFog */,
 				9770F2902BB3C40C00478571 /* SpeziFirebaseAccount */,
 				979D418F2BB3EBD8001953BD /* SpeziAccount */,
+				DA7ED2892C60D1EF00BA8C47 /* OpenAPIRuntime */,
+				DA7ED28F2C60DA8600BA8C47 /* OpenAPIURLSession */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -342,6 +355,9 @@
 				2FD590502A19E9F000153BE4 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
 				9770F28F2BB3C40C00478571 /* XCRemoteSwiftPackageReference "SpeziFirebase" */,
 				979D418E2BB3EBD8001953BD /* XCRemoteSwiftPackageReference "SpeziAccount" */,
+				DA7ED27E2C5FCAEC00BA8C47 /* XCRemoteSwiftPackageReference "swift-openapi-generator" */,
+				DA7ED2812C5FF17600BA8C47 /* XCRemoteSwiftPackageReference "swift-openapi-runtime" */,
+				DA7ED28E2C60DA7C00BA8C47 /* XCRemoteSwiftPackageReference "swift-openapi-urlsession" */,
 			);
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
@@ -361,6 +377,8 @@
 				9756D2582B0316740006B6BD /* Localizable.xcstrings in Resources */,
 				976CE5172BA2C05100E21810 /* GoogleService-Info.plist in Resources */,
 				2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */,
+				DA7ED2862C60D0E400BA8C47 /* openapi.yaml in Resources */,
+				DA7ED2872C60D0E400BA8C47 /* openapi-generator-config.yaml in Resources */,
 				9756D2592B0316740006B6BD /* Localizable.xcstrings.license in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -440,6 +458,10 @@
 			isa = PBXTargetDependency;
 			target = 2F6D139128F5F384007C25D6 /* TestApp */;
 			targetProxy = 2F6D13AD28F5F386007C25D6 /* PBXContainerItemProxy */;
+		};
+		DA7ED2802C5FCAFD00BA8C47 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = DA7ED27F2C5FCAFD00BA8C47 /* plugin:OpenAPIGenerator */;
 		};
 /* End PBXTargetDependency section */
 
@@ -749,6 +771,30 @@
 				minimumVersion = 1.2.1;
 			};
 		};
+		DA7ED27E2C5FCAEC00BA8C47 /* XCRemoteSwiftPackageReference "swift-openapi-generator" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-openapi-generator.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
+		DA7ED2812C5FF17600BA8C47 /* XCRemoteSwiftPackageReference "swift-openapi-runtime" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-openapi-runtime.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.5.0;
+			};
+		};
+		DA7ED28E2C60DA7C00BA8C47 /* XCRemoteSwiftPackageReference "swift-openapi-urlsession" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-openapi-urlsession.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -786,6 +832,21 @@
 		97A36E142B999EA60034D821 /* SpeziLLMFog */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SpeziLLMFog;
+		};
+		DA7ED27F2C5FCAFD00BA8C47 /* plugin:OpenAPIGenerator */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DA7ED27E2C5FCAEC00BA8C47 /* XCRemoteSwiftPackageReference "swift-openapi-generator" */;
+			productName = "plugin:OpenAPIGenerator";
+		};
+		DA7ED2892C60D1EF00BA8C47 /* OpenAPIRuntime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DA7ED2812C5FF17600BA8C47 /* XCRemoteSwiftPackageReference "swift-openapi-runtime" */;
+			productName = OpenAPIRuntime;
+		};
+		DA7ED28F2C60DA8600BA8C47 /* OpenAPIURLSession */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DA7ED28E2C60DA7C00BA8C47 /* XCRemoteSwiftPackageReference "swift-openapi-urlsession" */;
+			productName = OpenAPIURLSession;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
# SpeziLLMOpenAI: Repalce MacPaw/OpenAI With Generated API Calls

## :recycle: Current situation & Problem

This PR replaces the MacPaw/OpenAI package with generated API calls by the [swift-openapi-generator](https://github.com/apple/swift-openapi-generator) package. 
Calls are generated from OpenAI's [official OpenAPI spec](https://github.com/openai/openai-openapi).
As discussed with @PSchmiedmayer, this marks the first step in adding the ability to send local image content to the OpenAI API.

This PR does not add any new features but simply replicates the existing feature set with the generated API calls.

I've tried my best to keep track of any known issues in-code with FIXMEs as well as in the following list.

### Current Issues
- [ ] `Sources/SpeziLLMOpenAI/LLMOpenAISession+Generation.swift` does not handle the "[DONE]" message sent by the API to conclude a stream. There is currently a hacky workaround that catches the error that is thrown in that case. I'm not quite sure yet how to handle that case elegantly.
- [ ] There are several do ... catch blocks that catch OpenAI package-specific errors, which I had to commented out. I have not found a semantically equivalent solution for the generated API calls yet.
- [ ] The `LLMFunctionParameterSchema` type does not use a generated type yet.
- [ ] Correct error handling
- [ ] Currently, `openapi-generator-swift` expects and an `openapi.yaml` and a configuration file in the TestApp, which is why there are duplicate openapi specs and configuration files in this PR. I'm not quite sure why it's expecting them in the TestApp, but I suspect it has something to do with the generated types being used in the TestApp's model selection mechanism.

## :gear: Release Notes 
* Replace the MacPaw/OpenAI package with Apple/swift-openapi-generator, which is able to generate API calls directly from OpenAI's official OpenAPI spec.


## :books: Documentation

As no new functionality is added, nothing should change here (unless I missed something).

## :white_check_mark: Testing

This PR passes the existing tests. Since no new functionality has been added, I believe this should suffice.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
