### PR TITLE
Fix modelConfiguration.prepare(prompt: formattedChat) compile error

### DIFF
--- a/Sources/SpeziLLMLocal/LLMLocalSession+Generate.swift
+++ b/Sources/SpeziLLMLocal/LLMLocalSession+Generate.swift
@@ -32,9 +32,8 @@ extension LLMLocalSession {
             return
         }
         
-        let prompt = modelConfiguration.prepare(prompt: formattedChat)
         let promptTokens = await modelContainer.perform { _, tokenizer in
-            tokenizer.encode(text: prompt)
+            tokenizer.encode(text: formattedChat)
         }
         
         MLXRandom.seed(self.schema.contextParameters.seed ?? UInt64(Date.timeIntervalSinceReferenceDate * 1000))


### PR DESCRIPTION
This pull request includes a change to the `LLMLocalSession` extension in the `Sources/SpeziLLMLocal/LLMLocalSession+Generate.swift` file to simplify the prompt token encoding process.

Codebase simplification:

* [`Sources/SpeziLLMLocal/LLMLocalSession+Generate.swift`](diffhunk://#diff-8c0f1ee1048ae0925471900973cd6d37fea72799232388a67b98e34e6447ff92L35-R36): Removed the `prompt` variable and directly used `formattedChat` in the `tokenizer.encode` method.