### PR TITLE
Pin MLX library dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         .library(name: "SpeziLLMFog", targets: ["SpeziLLMFog"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.18.1"),
-        .package(url: "https://github.com/ml-explore/mlx-swift-examples", from: "1.16.0"),
+        .package(url: "https://github.com/ml-explore/mlx-swift", branch: "0.21.2"),   // Pin MLX library as it doesn't follow semantic versioning
+        .package(url: "https://github.com/ml-explore/mlx-swift-examples", branch: "1.16.0"),  // Pin MLX library as it doesn't follow semantic versioning
         .package(url: "https://github.com/huggingface/swift-transformers", .upToNextMinor(from: "0.1.12")),
         .package(url: "https://github.com/StanfordBDHG/OpenAI", .upToNextMinor(from: "0.2.9")),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.1"),


### PR DESCRIPTION
# Pin MLX library dependencies

## :recycle: Current situation & Problem
As seen in https://github.com/StanfordSpezi/SpeziLLM/issues/77, the MLX libraries dont follow semantic versioning.
Currently, SpeziLLM allows updates of these dependencies via `from:` (equals the deprecated `upToNextMajor`).
When MLX pushed a breaking change, SpeziLLM used the newest dependency version, leading to a breaking change in SpeziLLM.


## :gear: Release Notes 
- Pin MLX library dependencies


## :books: Documentation
Properly commented reasoning for the pinning


## :white_check_mark: Testing
Tested locally and CI


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
