### PR TITLE
Update model identifier in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ struct LLMOpenAIDemoView: View {
                 let llmSession: LLMOpenAISession = runner(
                     with: LLMOpenAISchema(
                         parameters: .init(
-                            modelType: .gpt4_o,
+                            modelType: .gpt4o,
                             systemPrompt: "You're a helpful assistant that answers questions from users.",
                             overwritingToken: "abc123"
                         )

--- a/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunction.swift
+++ b/Sources/SpeziLLMOpenAI/FunctionCalling/LLMFunction.swift
@@ -51,7 +51,7 @@
 /// struct LLMOpenAIChatTestView: View {
 ///     private let schema = LLMOpenAISchema(
 ///         parameters: .init(
-///             modelType: .gpt4_o,
+///             modelType: .gpt4o,
 ///             systemPrompt: "You're a helpful assistant that answers questions from users."
 ///         )
 ///     ) {

--- a/Sources/SpeziLLMOpenAI/LLMOpenAISession.swift
+++ b/Sources/SpeziLLMOpenAI/LLMOpenAISession.swift
@@ -50,7 +50,7 @@ import SpeziLLM
 ///                 let llmSession: LLMOpenAISession = runner(
 ///                     with: LLMOpenAISchema(
 ///                         parameters: .init(
-///                             modelType: .gpt3_5Turbo,
+///                             modelType: .gpt4o,
 ///                             systemPrompt: "You're a helpful assistant that answers questions from users.",
 ///                             overwritingToken: "abc123"
 ///                         )

--- a/Sources/SpeziLLMOpenAI/SpeziLLMOpenAI.docc/FunctionCalling.md
+++ b/Sources/SpeziLLMOpenAI/SpeziLLMOpenAI.docc/FunctionCalling.md
@@ -57,7 +57,7 @@ struct WeatherFunction: LLMFunction {
 struct LLMOpenAIChatTestView: View {
     private let schema = LLMOpenAISchema(
         parameters: .init(
-            modelType: .gpt4_o,
+            modelType: .gpt4o,
             systemPrompt: "You're a helpful assistant that answers questions from users."
         )
     ) {

--- a/Sources/SpeziLLMOpenAI/SpeziLLMOpenAI.docc/SpeziLLMOpenAI.md
+++ b/Sources/SpeziLLMOpenAI/SpeziLLMOpenAI.docc/SpeziLLMOpenAI.md
@@ -105,7 +105,7 @@ struct LLMOpenAIDemoView: View {
                 let llmSession: LLMOpenAISession = runner(
                     with: LLMOpenAISchema(
                         parameters: .init(
-                            modelType: .gpt3_5Turbo,
+                            modelType: .gpt4o,
                             systemPrompt: "You're a helpful assistant that answers questions from users.",
                             overwritingToken: "abc123"
                         )

--- a/Tests/UITests/TestApp/LLMOpenAI/LLMOpenAIOnboardingView.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/LLMOpenAIOnboardingView.swift
@@ -29,6 +29,7 @@ struct LLMOpenAIOnboardingView: View {
                     } label: {
                         Image(systemName: "xmark")
                             .font(.headline)
+                            .accessibilityLabel(content: Text("Cancel"))
                     }
                 }
             }

--- a/Tests/UITests/TestApp/LLMOpenAI/LLMOpenAIOnboardingView.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/LLMOpenAIOnboardingView.swift
@@ -29,7 +29,7 @@ struct LLMOpenAIOnboardingView: View {
                     } label: {
                         Image(systemName: "xmark")
                             .font(.headline)
-                            .accessibilityLabel(content: "Cancel")
+                            .accessibilityLabel("Cancel")
                     }
                 }
             }

--- a/Tests/UITests/TestApp/LLMOpenAI/LLMOpenAIOnboardingView.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/LLMOpenAIOnboardingView.swift
@@ -29,7 +29,7 @@ struct LLMOpenAIOnboardingView: View {
                     } label: {
                         Image(systemName: "xmark")
                             .font(.headline)
-                            .accessibilityLabel(content: Text("Cancel"))
+                            .accessibilityLabel(content: "Cancel")
                     }
                 }
             }

--- a/Tests/UITests/TestApp/LLMOpenAI/Onboarding/LLMOpenAITokenOnboarding.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/Onboarding/LLMOpenAITokenOnboarding.swift
@@ -30,6 +30,7 @@ struct LLMOpenAITokenOnboarding: View {
                     } label: {
                         Image(systemName: "xmark")
                             .font(.headline)
+                            .accessibilityLabel(content: "Cancel")
                     }
                 }
             }

--- a/Tests/UITests/TestApp/LLMOpenAI/Onboarding/LLMOpenAITokenOnboarding.swift
+++ b/Tests/UITests/TestApp/LLMOpenAI/Onboarding/LLMOpenAITokenOnboarding.swift
@@ -30,7 +30,7 @@ struct LLMOpenAITokenOnboarding: View {
                     } label: {
                         Image(systemName: "xmark")
                             .font(.headline)
-                            .accessibilityLabel(content: "Cancel")
+                            .accessibilityLabel("Cancel")
                     }
                 }
             }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -63,7 +63,6 @@
 		2F8A431229130A8C005D2B8F /* TestAppLLMOpenAIUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppLLMOpenAIUITests.swift; sourceTree = "<group>"; };
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
-		632BF4FF2D81BB5D0096AB5F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		63EF9CEF2BA7398C001D92D7 /* TestAppTestingSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppTestingSetup.swift; sourceTree = "<group>"; };
 		9748DBEB2B5C811E00B917EE /* LLMOpenAIFunctionHealthData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LLMOpenAIFunctionHealthData.swift; sourceTree = "<group>"; };
 		9748DBEC2B5C811E00B917EE /* LLMOpenAIFunctionPerson.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LLMOpenAIFunctionPerson.swift; sourceTree = "<group>"; };
@@ -143,7 +142,6 @@
 		2F6D139428F5F384007C25D6 /* TestApp */ = {
 			isa = PBXGroup;
 			children = (
-				632BF4FF2D81BB5D0096AB5F /* Info.plist */,
 				977447212B992D3A00D1F85E /* TestApp.entitlements */,
 				9756D25A2B0316790006B6BD /* Resources */,
 				97DD56B32B02F72D00389331 /* LLMLocal */,
@@ -588,7 +586,6 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = TestApp/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "The Test Application uses the micophone to test the dication functionality.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Speech recognition necessary for transcribing voice input.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -631,7 +628,6 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = TestApp/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "The Test Application uses the micophone to test the dication functionality.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Speech recognition necessary for transcribing voice input.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		2F8A431229130A8C005D2B8F /* TestAppLLMOpenAIUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppLLMOpenAIUITests.swift; sourceTree = "<group>"; };
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
+		632BF4FF2D81BB5D0096AB5F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		63EF9CEF2BA7398C001D92D7 /* TestAppTestingSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppTestingSetup.swift; sourceTree = "<group>"; };
 		9748DBEB2B5C811E00B917EE /* LLMOpenAIFunctionHealthData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LLMOpenAIFunctionHealthData.swift; sourceTree = "<group>"; };
 		9748DBEC2B5C811E00B917EE /* LLMOpenAIFunctionPerson.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LLMOpenAIFunctionPerson.swift; sourceTree = "<group>"; };
@@ -142,6 +143,7 @@
 		2F6D139428F5F384007C25D6 /* TestApp */ = {
 			isa = PBXGroup;
 			children = (
+				632BF4FF2D81BB5D0096AB5F /* Info.plist */,
 				977447212B992D3A00D1F85E /* TestApp.entitlements */,
 				9756D25A2B0316790006B6BD /* Resources */,
 				97DD56B32B02F72D00389331 /* LLMLocal */,
@@ -586,6 +588,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TestApp/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "The Test Application uses the micophone to test the dication functionality.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Speech recognition necessary for transcribing voice input.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -628,6 +631,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TestApp/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "The Test Application uses the micophone to test the dication functionality.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Speech recognition necessary for transcribing voice input.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;


### PR DESCRIPTION
# Update model identifier in docs

The docs have outdated model identifiers for OpenAI models, leading to confusion for users. Updates model identifiers in the docs all to `.gpt4o`.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
