### PR TITLE
Inform users about function call processing time (#108)

### DIFF
--- a/Sources/SpeziLLM/Views/LLMChatView.swift
+++ b/Sources/SpeziLLM/Views/LLMChatView.swift
@@ -68,8 +68,25 @@ public struct LLMChatView<Session: LLMSession>: View {
             exportFormat: self.exportFormat,
             messagePendingAnimation: .automatic
         )
-            .viewStateAlert(state: self.llm.state)
-            .onChange(of: self.llm.context) { oldValue, newValue in
+                .viewStateAlert(state: self.llm.state)
+                .overlay(alignment: .bottom) {
+                    if llm.state == .callingTools {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                            Text("Processing function call...")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(.regularMaterial)
+                        .clipShape(Capsule())
+                        .padding(.bottom, 70)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                }
+                .animation(.easeInOut, value: llm.state)
+                .onChange(of: self.llm.context) { oldValue, newValue in
                 // Once the user enters a message in the chat, increase `messageTaskIdentifier` that triggers LLM inference
                 //
                 // Checking `lastChat.complete == true` to differentiate user initiated messages (complete == true, default)
@@ -133,7 +150,6 @@ public struct LLMChatView<Session: LLMSession>: View {
 #if DEBUG
 #Preview {
     @Previewable @State var llm = LLMMockSession(.init(), schema: .init())
-
 
     return NavigationStack {
         LLMChatView(session: $llm)


### PR DESCRIPTION
# *Inform users about function call processing time (#108)*

## :recycle: Current situation & Problem
Closes #108
*When the LLM is executing function calls, users receive no distinct feedback, which can cause unnecessary app restarts under the false assumption of failure.*


## :gear: Release Notes
*Added a distinct overlay to `LLMChatView` that appears exclusively during `.callingTools` state, displaying a "Processing function call..." label to differentiate function call processing from normal inference delays.*


## :books: Documentation
*n/a* 


## :white_check_mark: Testing
*The indicator appears during the `.callingTools` state, triggered by `FunctionCallLLMSession` in the OpenAI layer during function call execution. Full end-to-end testing requires an OpenAI API key with function calling enabled.*


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual processing indicator that displays when the AI is handling function calls, positioned at the bottom of the chat interface with smooth animation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->