### PR TITLE
Add Apple Foundation Models platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
         .library(name: "SpeziLLMFog", targets: ["SpeziLLMFog"]),
         .library(name: "SpeziLLMOpenAIRealtime", targets: ["SpeziLLMOpenAIRealtime"]),
         .library(name: "SpeziLLMAnthropic", targets: ["SpeziLLMAnthropic"]),
-        .library(name: "SpeziLLMGemini", targets: ["SpeziLLMGemini"])
+        .library(name: "SpeziLLMGemini", targets: ["SpeziLLMGemini"]),
+        .library(name: "SpeziLLMFoundationModels", targets: ["SpeziLLMFoundationModels"])
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift.git", .upToNextMinor(from: "0.29.1")),
@@ -151,6 +152,19 @@ let package = Package(
                 .product(name: "SpeziKeychainStorage", package: "SpeziStorage")
             ],
             swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
+        ),
+        .target(
+            name: "SpeziLLMFoundationModels",
+            dependencies: [
+                .target(name: "SpeziLLM"),
+                .product(name: "SpeziChat", package: "SpeziChat"),
+                .product(name: "SpeziFoundation", package: "SpeziFoundation"),
+                .product(name: "Spezi", package: "Spezi")
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("ExistentialAny")
+            ],
+            plugins: [] + swiftLintPlugin()
         ),
         .target(
             name: "SpeziLLMFog",

--- a/Sources/SpeziLLMFoundationModels/Configuration/LLMFoundationModelsParameters.swift
+++ b/Sources/SpeziLLMFoundationModels/Configuration/LLMFoundationModelsParameters.swift
@@ -1,0 +1,57 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+import Foundation
+
+
+/// Parameters that configure inference of a ``LLMFoundationModelsSession``.
+public struct LLMFoundationModelsParameters: Sendable {
+    /// System prompt / instructions handed to the underlying `LanguageModelSession`.
+    public let instructions: String?
+    /// Temperature override. `nil` falls back to the framework default.
+    public let temperature: Double?
+    /// Maximum number of response tokens. `nil` falls back to the framework default.
+    public let maximumResponseTokens: Int?
+    /// When `true`, the schema of a `@Generable` type is included in the prompt for structured output requests.
+    public let includeSchemaInPrompt: Bool
+
+    /// Creates a new ``LLMFoundationModelsParameters`` value.
+    /// - Parameters:
+    ///   - instructions: System prompt handed to the `LanguageModelSession`. Defaults to `nil`.
+    ///   - temperature: Sampling temperature override. Defaults to `nil`.
+    ///   - maximumResponseTokens: Caps the response length. Defaults to `nil`.
+    ///   - includeSchemaInPrompt: Forwarded to structured output APIs. Defaults to `true`.
+    public init(
+        instructions: String? = nil,
+        temperature: Double? = nil,
+        maximumResponseTokens: Int? = nil,
+        includeSchemaInPrompt: Bool = true
+    ) {
+        self.instructions = instructions
+        self.temperature = temperature
+        self.maximumResponseTokens = maximumResponseTokens
+        self.includeSchemaInPrompt = includeSchemaInPrompt
+    }
+}
+
+
+#if canImport(FoundationModels)
+@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+extension LLMFoundationModelsParameters {
+    /// Maps the parameters to the framework's `GenerationOptions`.
+    var generationOptions: GenerationOptions {
+        GenerationOptions(
+            temperature: temperature,
+            maximumResponseTokens: maximumResponseTokens
+        )
+    }
+}
+#endif

--- a/Sources/SpeziLLMFoundationModels/Configuration/LLMFoundationModelsPlatformConfiguration.swift
+++ b/Sources/SpeziLLMFoundationModels/Configuration/LLMFoundationModelsPlatformConfiguration.swift
@@ -1,0 +1,22 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+/// Configuration for the ``LLMFoundationModelsPlatform``.
+public struct LLMFoundationModelsPlatformConfiguration: Sendable {
+    /// Priority of dispatched inference tasks.
+    public let taskPriority: TaskPriority
+
+    /// Creates a new platform configuration.
+    /// - Parameter taskPriority: Priority of dispatched inference tasks. Defaults to `.userInitiated`.
+    public init(taskPriority: TaskPriority = .userInitiated) {
+        self.taskPriority = taskPriority
+    }
+}

--- a/Sources/SpeziLLMFoundationModels/LLMFoundationModelsError.swift
+++ b/Sources/SpeziLLMFoundationModels/LLMFoundationModelsError.swift
@@ -1,0 +1,75 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SpeziLLM
+
+
+/// Errors that can occur during execution of an ``LLMFoundationModelsSession``.
+public enum LLMFoundationModelsError: LLMError {
+    /// The Foundation Models framework is not available on the current OS.
+    case frameworkUnavailable
+    /// The on-device system language model is not available (e.g. Apple Intelligence is disabled or the device is ineligible).
+    case modelUnavailable(reason: String)
+    /// The session was queried but no user prompt is present in the context.
+    case missingPrompt
+    /// Generation failed.
+    case generationFailed(underlying: String)
+    /// Structured output generation failed to decode into the requested type.
+    case structuredOutputDecodingFailed(underlying: String)
+
+
+    public var errorDescription: String? {
+        switch self {
+        case .frameworkUnavailable:
+            "The Foundation Models framework is not available on this OS version."
+        case .modelUnavailable(let reason):
+            "The on-device language model is not available: \(reason)."
+        case .missingPrompt:
+            "Cannot generate without a user prompt in the context."
+        case .generationFailed(let underlying):
+            "Generation failed: \(underlying)."
+        case .structuredOutputDecodingFailed(let underlying):
+            "Structured output decoding failed: \(underlying)."
+        }
+    }
+
+    public var recoverySuggestion: String? {
+        switch self {
+        case .frameworkUnavailable:
+            "Run on iOS 26, macOS 26, or visionOS 26 (or newer)."
+        case .modelUnavailable:
+            "Enable Apple Intelligence in System Settings on a supported device."
+        case .missingPrompt:
+            "Append a user message to the session context before calling generate()."
+        case .generationFailed, .structuredOutputDecodingFailed:
+            "Inspect the underlying error and retry with adjusted parameters."
+        }
+    }
+
+    public var failureReason: String? {
+        errorDescription
+    }
+
+
+    public static func == (lhs: LLMFoundationModelsError, rhs: LLMFoundationModelsError) -> Bool {
+        switch (lhs, rhs) {
+        case (.frameworkUnavailable, .frameworkUnavailable),
+             (.missingPrompt, .missingPrompt):
+            true
+        case let (.modelUnavailable(l), .modelUnavailable(r)):
+            l == r
+        case let (.generationFailed(l), .generationFailed(r)):
+            l == r
+        case let (.structuredOutputDecodingFailed(l), .structuredOutputDecodingFailed(r)):
+            l == r
+        default:
+            false
+        }
+    }
+}

--- a/Sources/SpeziLLMFoundationModels/LLMFoundationModelsPlatform.swift
+++ b/Sources/SpeziLLMFoundationModels/LLMFoundationModelsPlatform.swift
@@ -1,0 +1,79 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import Spezi
+import SpeziFoundation
+import SpeziLLM
+
+
+/// LLM execution platform backed by Apple's `FoundationModels` framework.
+///
+/// The platform turns a received ``LLMFoundationModelsSchema`` into an executable
+/// ``LLMFoundationModelsSession`` by way of the standard SpeziLLM `LLMRunner`.
+///
+/// - Important: The underlying APIs require iOS 26+, macOS 26+, or visionOS 26+ and an Apple Intelligence-eligible
+/// device. On older OS versions, sessions surface ``LLMFoundationModelsError/frameworkUnavailable``.
+///
+/// ### Usage
+///
+/// ```swift
+/// class TestAppDelegate: SpeziAppDelegate {
+///     override var configuration: Configuration {
+///         Configuration {
+///             LLMRunner {
+///                 LLMFoundationModelsPlatform()
+///             }
+///         }
+///     }
+/// }
+/// ```
+public final class LLMFoundationModelsPlatform: LLMPlatform, DefaultInitializable {
+    /// Configuration of the platform.
+    public let configuration: LLMFoundationModelsPlatformConfiguration
+    /// Queue that orders LLM inference tasks.
+    let queue: LLMInferenceQueue<String>
+
+
+    @MainActor public var state: LLMPlatformState {
+        self.queue.platformState
+    }
+
+
+    /// Creates an ``LLMFoundationModelsPlatform`` with a custom configuration.
+    public init(configuration: LLMFoundationModelsPlatformConfiguration) {
+        self.configuration = configuration
+        self.queue = LLMInferenceQueue(
+            maxConcurrentTasks: 1,
+            taskPriority: configuration.taskPriority
+        )
+    }
+
+    /// Creates an ``LLMFoundationModelsPlatform`` with the default configuration.
+    public convenience init() {
+        self.init(configuration: .init())
+    }
+
+    public func run() async {
+        do {
+            try await self.queue.runQueue()
+        } catch is CancellationError {
+            // No-op, shutdown.
+        } catch {
+            fatalError("Inconsistent state of the LLMFoundationModelsPlatform: \(error)")
+        }
+    }
+
+    public func callAsFunction(with llmSchema: LLMFoundationModelsSchema) -> LLMFoundationModelsSession {
+        LLMFoundationModelsSession(self, schema: llmSchema)
+    }
+
+    deinit {
+        self.queue.shutdown()
+    }
+}

--- a/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSchema.swift
+++ b/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSchema.swift
@@ -1,0 +1,39 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SpeziLLM
+
+
+/// Defines the configuration of an ``LLMFoundationModelsSession``.
+///
+/// The schema captures the parameters used to drive Apple's on-device system language model
+/// (provided by the `FoundationModels` framework). It is bound to ``LLMFoundationModelsPlatform``,
+/// which turns it into an executable ``LLMFoundationModelsSession``.
+///
+/// - Tip: For an overview of the schema/session/platform pattern, see the documentation of `LLMSchema`.
+public struct LLMFoundationModelsSchema: LLMSchema {
+    public typealias Platform = LLMFoundationModelsPlatform
+
+    /// Inference parameters.
+    public let parameters: LLMFoundationModelsParameters
+    /// Whether streamed output should be appended to ``LLMFoundationModelsSession/context``.
+    public let injectIntoContext: Bool
+
+    /// Creates a new schema.
+    /// - Parameters:
+    ///   - parameters: Inference parameters. Defaults to `.init()`.
+    ///   - injectIntoContext: Whether streamed output should be appended to the context. Defaults to `false`.
+    public init(
+        parameters: LLMFoundationModelsParameters = .init(),
+        injectIntoContext: Bool = false
+    ) {
+        self.parameters = parameters
+        self.injectIntoContext = injectIntoContext
+    }
+}

--- a/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession+Generate.swift
+++ b/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession+Generate.swift
@@ -52,7 +52,7 @@ extension LLMFoundationModelsSession {
         }
     }
 
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func _generate(with continuationObserver: ContinuationObserver<String, any Error>) async {
         if continuationObserver.isCancelled {
             Self.logger.warning("SpeziLLMFoundationModels: Generation cancelled by the user.")
@@ -72,17 +72,23 @@ extension LLMFoundationModelsSession {
             return
         }
 
-        let prompt = await self.buildPrompt()
-        guard let prompt else {
-            await self.finishGenerationWithError(
-                LLMFoundationModelsError.missingPrompt,
-                on: continuationObserver.continuation
-            )
-            return
-        }
-
         do {
             let session = try await MainActor.run { try self.resolvedLanguageModelSession() }
+
+            // Replay any unsent context entries (prior conversation turns) so the
+            // LanguageModelSession's internal history stays in sync with our context.
+            try await replayUnsentContext(on: session)
+
+            // The last unsent entry must be a user message to generate from.
+            let prompt = await MainActor.run { self.lastUnsentUserPrompt() }
+            guard let prompt else {
+                await self.finishGenerationWithError(
+                    LLMFoundationModelsError.missingPrompt,
+                    on: continuationObserver.continuation
+                )
+                return
+            }
+
             let stream = session.streamResponse(
                 to: prompt,
                 generating: String.self,
@@ -123,6 +129,11 @@ extension LLMFoundationModelsSession {
                 }
             }
 
+            // Mark everything (including the assistant reply we just injected) as sent.
+            await MainActor.run {
+                self.sentContextCount = self.context.count
+            }
+
             continuationObserver.continuation.finish()
             await MainActor.run {
                 self.state = .ready
@@ -141,13 +152,71 @@ extension LLMFoundationModelsSession {
         )
 #endif
     }
+}
 
-    /// Builds the user prompt from the last user message in the context.
+
+#if canImport(FoundationModels)
+@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+extension LLMFoundationModelsSession {
+    /// Returns the last user message in the context that hasn't been sent yet, if any.
     @MainActor
-    func buildPrompt() -> String? {
-        guard let lastUserMessage = self.context.last(where: { $0.role == .user }) else {
+    func lastUnsentUserPrompt() -> String? {
+        let unsent = Array(context[sentContextCount...])
+        guard let lastUser = unsent.last(where: { $0.role == .user }) else {
             return nil
         }
-        return lastUserMessage.content
+        return lastUser.content
+    }
+
+    /// Replays unsent context entries to the `LanguageModelSession` so its internal
+    /// history matches ours.
+    ///
+    /// For each prior user message that we haven't sent yet (excluding the very last one
+    /// which will be streamed), we call `respond(to:)` and discard the response — the
+    /// session records the turn internally. System messages are skipped since they were
+    /// already provided as instructions at session creation. Assistant messages are also
+    /// skipped since they represent prior model responses already tracked by the session.
+    ///
+    /// If the context was modified (e.g. entries before the sent watermark were removed),
+    /// we reset the session and replay from the start.
+    func replayUnsentContext(on session: LanguageModelSession) async throws {
+        let (contextSnapshot, sent) = await MainActor.run {
+            (Array(self.context), self.sentContextCount)
+        }
+
+        // Detect context modification: if the context shrank below our watermark,
+        // the user removed messages — we must start over.
+        if contextSnapshot.count < sent {
+            _ = try await MainActor.run { try self.resetLanguageModelSession() }
+            try await replayUnsentContext(on: await MainActor.run { try self.resolvedLanguageModelSession() })
+            return
+        }
+
+        let unsent = Array(contextSnapshot[sent...])
+
+        // Find the last user message index among the unsent entries — that one
+        // will be streamed, so we only replay everything before it.
+        guard let lastUserIndex = unsent.lastIndex(where: { $0.role == .user }) else {
+            return
+        }
+        let toReplay = unsent[unsent.startIndex..<lastUserIndex]
+
+        for entry in toReplay {
+            switch entry.role {
+            case .user:
+                // Replay this prior user turn. The session records the exchange.
+                _ = try await session.respond(to: entry.content, options: self.schema.parameters.generationOptions)
+            case .system, .assistant, .tool:
+                // System instructions are set at session creation.
+                // Assistant and tool messages are the session's own output.
+                continue
+            }
+        }
+
+        // Update the watermark to cover everything up to (but not including) the last user message.
+        await MainActor.run {
+            self.sentContextCount = sent + (lastUserIndex - unsent.startIndex)
+        }
     }
 }
+#endif

--- a/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession+Generate.swift
+++ b/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession+Generate.swift
@@ -1,0 +1,153 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+import Foundation
+import SpeziChat
+import SpeziLLM
+
+
+extension LLMFoundationModelsSession {
+    @discardableResult
+    public func generate() async throws -> AsyncThrowingStream<String, any Error> {
+        if await self.context.isEmpty {
+            if let instructions = self.schema.parameters.instructions {
+                await MainActor.run {
+                    self.context.append(systemMessage: instructions)
+                }
+            }
+        }
+
+        return try self.platform.queue.submit { continuation in
+            let continuationObserver = ContinuationObserver(track: continuation)
+            defer {
+                continuationObserver.continuation.finish()
+            }
+
+            await self.continuationHolder.withContinuationHold(continuation: continuation) {
+                if continuationObserver.isCancelled {
+                    Self.logger.warning("SpeziLLMFoundationModels: Generation cancelled by the user.")
+                    return
+                }
+
+                do {
+                    try await self.ensureSessionReady()
+                } catch {
+                    await self.finishGenerationWithError(
+                        LLMFoundationModelsError.generationFailed(underlying: String(describing: error)),
+                        on: continuation
+                    )
+                    return
+                }
+
+                await self._generate(with: continuationObserver)
+            }
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    private func _generate(with continuationObserver: ContinuationObserver<String, any Error>) async {
+        if continuationObserver.isCancelled {
+            Self.logger.warning("SpeziLLMFoundationModels: Generation cancelled by the user.")
+            return
+        }
+
+        await MainActor.run {
+            self.state = .generating
+        }
+
+#if canImport(FoundationModels)
+        guard #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) else {
+            await self.finishGenerationWithError(
+                LLMFoundationModelsError.frameworkUnavailable,
+                on: continuationObserver.continuation
+            )
+            return
+        }
+
+        let prompt = await self.buildPrompt()
+        guard let prompt else {
+            await self.finishGenerationWithError(
+                LLMFoundationModelsError.missingPrompt,
+                on: continuationObserver.continuation
+            )
+            return
+        }
+
+        do {
+            let session = try await MainActor.run { try self.resolvedLanguageModelSession() }
+            let stream = session.streamResponse(
+                to: prompt,
+                generating: String.self,
+                options: self.schema.parameters.generationOptions
+            )
+
+            var fullResponse = ""
+            for try await snapshot in stream {
+                if continuationObserver.isCancelled {
+                    Self.logger.warning("SpeziLLMFoundationModels: Generation cancelled by the user.")
+                    break
+                }
+
+                let currentText = snapshot.content
+                let delta: String
+                if currentText.count > fullResponse.count {
+                    delta = String(currentText[currentText.index(currentText.startIndex, offsetBy: fullResponse.count)...])
+                } else {
+                    delta = ""
+                }
+
+                if !delta.isEmpty {
+                    continuationObserver.continuation.yield(delta)
+
+                    if self.schema.injectIntoContext {
+                        await MainActor.run {
+                            self.context.append(assistantOutput: delta)
+                        }
+                    }
+                }
+
+                fullResponse = currentText
+            }
+
+            if self.schema.injectIntoContext {
+                await MainActor.run {
+                    self.context.completeAssistantStreaming()
+                }
+            }
+
+            continuationObserver.continuation.finish()
+            await MainActor.run {
+                self.state = .ready
+            }
+        } catch {
+            Self.logger.error("SpeziLLMFoundationModels: Generation failed: \(error)")
+            await self.finishGenerationWithError(
+                LLMFoundationModelsError.generationFailed(underlying: String(describing: error)),
+                on: continuationObserver.continuation
+            )
+        }
+#else
+        await self.finishGenerationWithError(
+            LLMFoundationModelsError.frameworkUnavailable,
+            on: continuationObserver.continuation
+        )
+#endif
+    }
+
+    /// Builds the user prompt from the last user message in the context.
+    @MainActor
+    func buildPrompt() -> String? {
+        guard let lastUserMessage = self.context.last(where: { $0.role == .user }) else {
+            return nil
+        }
+        return lastUserMessage.content
+    }
+}

--- a/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession+StructuredOutput.swift
+++ b/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession+StructuredOutput.swift
@@ -46,7 +46,7 @@ extension LLMFoundationModelsSession {
     public func streamStructured<T: Generable>(
         generating type: T.Type
     ) async throws -> AsyncThrowingStream<T.PartiallyGenerated, any Error> where T.PartiallyGenerated: Sendable {
-        let prompt = await MainActor.run { self.buildPrompt() }
+        let prompt = await MainActor.run { self.lastUnsentUserPrompt() }
         guard let prompt else {
             throw LLMFoundationModelsError.missingPrompt
         }
@@ -58,6 +58,7 @@ extension LLMFoundationModelsSession {
         }
 
         let session = try await MainActor.run { try self.resolvedLanguageModelSession() }
+        try await replayUnsentContext(on: session)
 
         let (outputStream, outputContinuation) = AsyncThrowingStream<T.PartiallyGenerated, any Error>.makeStream()
 
@@ -78,6 +79,7 @@ extension LLMFoundationModelsSession {
                 outputContinuation.finish()
 
                 await MainActor.run {
+                    self.sentContextCount = self.context.count
                     self.state = .ready
                 }
             } catch {
@@ -103,7 +105,7 @@ extension LLMFoundationModelsSession {
     public func generate<T: Generable>(
         generating type: T.Type
     ) async throws -> T {
-        let prompt = await MainActor.run { self.buildPrompt() }
+        let prompt = await MainActor.run { self.lastUnsentUserPrompt() }
         guard let prompt else {
             throw LLMFoundationModelsError.missingPrompt
         }
@@ -116,6 +118,7 @@ extension LLMFoundationModelsSession {
 
         do {
             let session = try await MainActor.run { try self.resolvedLanguageModelSession() }
+            try await replayUnsentContext(on: session)
             let response = try await session.respond(
                 to: prompt,
                 generating: type,
@@ -123,6 +126,7 @@ extension LLMFoundationModelsSession {
             )
 
             await MainActor.run {
+                self.sentContextCount = self.context.count
                 self.state = .ready
             }
 

--- a/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession+StructuredOutput.swift
+++ b/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession+StructuredOutput.swift
@@ -1,0 +1,142 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+import Foundation
+import SpeziLLM
+
+
+#if canImport(FoundationModels)
+/// Structured output generation using Apple's `@Generable` types.
+///
+/// ### Usage
+///
+/// ```swift
+/// @Generable
+/// struct MedicalSummary {
+///     var diagnosis: String
+///     var confidence: Double
+/// }
+///
+/// let session: LLMFoundationModelsSession = runner(
+///     with: LLMFoundationModelsSchema()
+/// )
+///
+/// // Append user message, then generate a complete value:
+/// await MainActor.run { session.context.append(userInput: "Summarize the diagnosis.") }
+/// let summary = try await session.generate(generating: MedicalSummary.self)
+/// ```
+@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+extension LLMFoundationModelsSession {
+    /// Streams partial values of a `@Generable` type during generation.
+    ///
+    /// Each yielded value is a `T.PartiallyGenerated` snapshot — the partially populated
+    /// representation of the final `T`. Use `generateComplete(generating:)` if you only
+    /// need the final result.
+    ///
+    /// - Parameter type: The `@Generable` type to generate.
+    /// - Returns: An `AsyncThrowingStream` of progressively more complete partial values.
+    public func streamStructured<T: Generable>(
+        generating type: T.Type
+    ) async throws -> AsyncThrowingStream<T.PartiallyGenerated, any Error> where T.PartiallyGenerated: Sendable {
+        let prompt = await MainActor.run { self.buildPrompt() }
+        guard let prompt else {
+            throw LLMFoundationModelsError.missingPrompt
+        }
+
+        try await ensureSessionReady()
+
+        await MainActor.run {
+            self.state = .generating
+        }
+
+        let session = try await MainActor.run { try self.resolvedLanguageModelSession() }
+
+        let (outputStream, outputContinuation) = AsyncThrowingStream<T.PartiallyGenerated, any Error>.makeStream()
+
+        let sendablePrompt = prompt
+        let sendableOptions = self.schema.parameters.generationOptions
+
+        Task {
+            do {
+                let stream = session.streamResponse(
+                    to: sendablePrompt,
+                    generating: type,
+                    options: sendableOptions
+                )
+
+                for try await snapshot in stream {
+                    outputContinuation.yield(snapshot.content)
+                }
+                outputContinuation.finish()
+
+                await MainActor.run {
+                    self.state = .ready
+                }
+            } catch {
+                Self.logger.error("SpeziLLMFoundationModels: Structured output streaming failed: \(error)")
+                outputContinuation.finish(throwing: LLMFoundationModelsError.structuredOutputDecodingFailed(
+                    underlying: String(describing: error)
+                ))
+                await MainActor.run {
+                    self.state = .error(error: LLMFoundationModelsError.structuredOutputDecodingFailed(
+                        underlying: String(describing: error)
+                    ))
+                }
+            }
+        }
+
+        return outputStream
+    }
+
+    /// Generates structured output and returns the final complete value.
+    ///
+    /// - Parameter type: The `@Generable` type to generate.
+    /// - Returns: The fully-generated value of type `T`.
+    public func generate<T: Generable>(
+        generating type: T.Type
+    ) async throws -> T {
+        let prompt = await MainActor.run { self.buildPrompt() }
+        guard let prompt else {
+            throw LLMFoundationModelsError.missingPrompt
+        }
+
+        try await ensureSessionReady()
+
+        await MainActor.run {
+            self.state = .generating
+        }
+
+        do {
+            let session = try await MainActor.run { try self.resolvedLanguageModelSession() }
+            let response = try await session.respond(
+                to: prompt,
+                generating: type,
+                options: self.schema.parameters.generationOptions
+            )
+
+            await MainActor.run {
+                self.state = .ready
+            }
+
+            return response.content
+        } catch {
+            Self.logger.error("SpeziLLMFoundationModels: Structured output generation failed: \(error)")
+            let wrappedError = LLMFoundationModelsError.structuredOutputDecodingFailed(
+                underlying: String(describing: error)
+            )
+            await MainActor.run {
+                self.state = .error(error: wrappedError)
+            }
+            throw wrappedError
+        }
+    }
+}
+#endif

--- a/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession.swift
+++ b/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession.swift
@@ -1,0 +1,130 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+import Foundation
+import os
+import SpeziChat
+import SpeziLLM
+
+
+/// Represents an executing ``LLMFoundationModelsSchema``.
+///
+/// The session bridges SpeziLLM's `LLMSession` surface (`generate() -> AsyncThrowingStream<String, ...>`)
+/// to Apple's `LanguageModelSession` from the `FoundationModels` framework. A single SpeziLLM session
+/// owns a single `LanguageModelSession` and reuses it across calls so that conversational state
+/// is preserved on the framework side.
+///
+/// In addition to the streaming text generation contract, this session exposes a typed
+/// ``LLMFoundationModelsSession/generate(generating:)`` overload that streams the partial values of an
+/// Apple `@Generable` type — this is the recommended path for structured output on Apple OSes.
+///
+/// - Warning: ``LLMFoundationModelsSession`` shouldn't be constructed manually. Always go through
+/// the SpeziLLM `LLMRunner`.
+@Observable
+public final class LLMFoundationModelsSession: LLMSession, Sendable {
+    static let logger = Logger(subsystem: "edu.stanford.spezi", category: "SpeziLLMFoundationModels")
+
+    let platform: LLMFoundationModelsPlatform
+    let schema: LLMFoundationModelsSchema
+
+    /// Holds currently generating continuations so they can be cancelled.
+    let continuationHolder = LLMInferenceQueueContinuationHolder()
+
+    @MainActor public var state: LLMState = .uninitialized
+    @MainActor public var context: LLMContext = []
+
+#if canImport(FoundationModels)
+    /// The underlying framework session, lazily created on first use.
+    @MainActor private var languageModelSession: AnyObject?
+#endif
+
+
+    init(_ platform: LLMFoundationModelsPlatform, schema: LLMFoundationModelsSchema) {
+        self.platform = platform
+        self.schema = schema
+    }
+
+    /// Initializes the underlying `LanguageModelSession` ahead of time.
+    ///
+    /// Calling this before first user interaction reduces latency on the first prompt.
+    public func setup() async throws {
+        try await ensureSessionReady()
+    }
+
+    public func cancel() {
+        self.continuationHolder.cancelAll()
+    }
+
+    deinit {
+        self.cancel()
+    }
+}
+
+
+#if canImport(FoundationModels)
+@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+extension LLMFoundationModelsSession {
+    /// Resolves (and lazily caches) the underlying `LanguageModelSession`.
+    @MainActor
+    func resolvedLanguageModelSession() throws -> LanguageModelSession {
+        if let existing = languageModelSession as? LanguageModelSession {
+            return existing
+        }
+
+        let model = SystemLanguageModel.default
+        switch model.availability {
+        case .available:
+            break
+        case .unavailable(let reason):
+            throw LLMFoundationModelsError.modelUnavailable(reason: String(describing: reason))
+        @unknown default:
+            throw LLMFoundationModelsError.modelUnavailable(reason: "Unknown availability state.")
+        }
+
+        let session: LanguageModelSession
+        if let instructions = schema.parameters.instructions {
+            session = LanguageModelSession(model: model, instructions: { instructions })
+        } else {
+            session = LanguageModelSession(model: model)
+        }
+        languageModelSession = session
+        return session
+    }
+}
+#endif
+
+
+extension LLMFoundationModelsSession {
+    /// Verifies that the framework is available on the current OS and prepares the underlying session.
+    func ensureSessionReady() async throws {
+#if canImport(FoundationModels)
+        guard #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) else {
+            throw LLMFoundationModelsError.frameworkUnavailable
+        }
+        await MainActor.run { self.state = .loading }
+        do {
+            _ = try await MainActor.run { try self.resolvedLanguageModelSession() }
+            await MainActor.run { self.state = .ready }
+        } catch {
+            await MainActor.run {
+                if let llmError = error as? LLMFoundationModelsError {
+                    self.state = .error(error: llmError)
+                } else {
+                    self.state = .error(error: LLMFoundationModelsError.generationFailed(underlying: String(describing: error)))
+                }
+            }
+            throw error
+        }
+#else
+        throw LLMFoundationModelsError.frameworkUnavailable
+#endif
+    }
+}

--- a/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession.swift
+++ b/Sources/SpeziLLMFoundationModels/LLMFoundationModelsSession.swift
@@ -44,6 +44,9 @@ public final class LLMFoundationModelsSession: LLMSession, Sendable {
 #if canImport(FoundationModels)
     /// The underlying framework session, lazily created on first use.
     @MainActor private var languageModelSession: AnyObject?
+    /// Number of context entries already sent to the `LanguageModelSession`.
+    /// Used to replay only new messages on subsequent `generate()` calls.
+    @MainActor var sentContextCount: Int = 0
 #endif
 
 
@@ -96,7 +99,20 @@ extension LLMFoundationModelsSession {
             session = LanguageModelSession(model: model)
         }
         languageModelSession = session
+        sentContextCount = 0
         return session
+    }
+
+    /// Invalidates and recreates the underlying session.
+    ///
+    /// Called when the SpeziLLM context has been modified in a way that's
+    /// incompatible with the `LanguageModelSession`'s internal history
+    /// (e.g. messages were removed or edited).
+    @MainActor
+    func resetLanguageModelSession() throws -> LanguageModelSession {
+        languageModelSession = nil
+        sentContextCount = 0
+        return try resolvedLanguageModelSession()
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Adds `SpeziLLMFoundationModels` module implementing the `LLMPlatform`/`LLMSchema`/`LLMSession` pattern for Apple's on-device Foundation Models framework (iOS 26+/macOS 26+/visionOS 26+)
- Provides streaming text generation via the standard `LLMSession.generate()` interface
- Supports structured output via Apple's `@Generable` types: `generate(generating:)` for final values and `streamStructured(generating:)` for partial snapshots

Closes #138, relates to #128

## Test plan
- [ ] Build `SpeziLLMFoundationModels` target on macOS 26 SDK
- [ ] Verify `LLMFoundationModelsPlatform` integrates with `LLMRunner` in a Spezi app delegate
- [ ] Test streaming text generation on an Apple Intelligence-eligible device
- [ ] Test structured output with a `@Generable` type
- [ ] Verify graceful error handling when Apple Intelligence is unavailable

