### PR TITLE
fix(stream): skip SSE keep-alive events instead of aborting the stream

### DIFF
--- a/Sources/SpeziLLMFog/LLMFogSession+Generation.swift
+++ b/Sources/SpeziLLMFog/LLMFogSession+Generation.swift
@@ -71,8 +71,13 @@ extension LLMFogSession {
                 }
                 
                 guard let choices = chatStreamResult.data?.choices else {
-                    Self.logger.error("SpeziLLMFog: Couldn't obtain choices from stream response.")
-                    return
+                    // Skip SSE events with no `choices` payload — keep-alive / comment events.
+                    // Returning here would abort the entire generation method on the first
+                    // empty event. See sibling change in LLMOpenAILikeSession+Generation.swift.
+                    Self.logger.debug(
+                        "SpeziLLMFog: skipping SSE event with no choices (likely a keep-alive)."
+                    )
+                    continue
                 }
 
                 // Only consider the first found assistant content result

--- a/Sources/SpeziLLMOpenAI/LLMOpenAILikeSession+Generation.swift
+++ b/Sources/SpeziLLMOpenAI/LLMOpenAILikeSession+Generation.swift
@@ -74,8 +74,17 @@ extension LLMOpenAILikeSession {
                     }
 
                     guard let choices = chatStreamResult.data?.choices else {
-                        Self.logger.error("SpeziLLMOpenAI: Couldn't obtain choices from stream response.")
-                        return
+                        // Skip SSE events with no `choices` payload — these are typically
+                        // keep-alive / comment events from OpenAI-compatible gateways.
+                        // For example, OpenRouter sends `: OPENROUTER PROCESSING` SSE
+                        // comment lines while the upstream provider warms up; the OpenAPI
+                        // runtime surfaces these as events whose `data` is nil. Returning
+                        // here would abort the entire generation method on the very first
+                        // keep-alive, leaving callers with no response.
+                        Self.logger.debug(
+                            "SpeziLLMOpenAI: skipping SSE event with no choices (likely a keep-alive)."
+                        )
+                        continue
                     }
 
                     // Important to iterate over all choices as LLM could choose to call multiple functions / generate multiple choices


### PR DESCRIPTION
## Summary

OpenAI-compatible gateways often send SSE comment lines as keep-alives while the upstream model warms up. The most visible case in 2026 is **OpenRouter**, which sends `: OPENROUTER PROCESSING` comment lines while it forwards the request to the underlying provider (Anthropic, Bedrock, Together, etc.). Self-hosted Fog deployments behind reverse proxies that emit comment-style heartbeats hit the same shape.

The OpenAPI runtime's SSE decoder surfaces these as events whose `data` is nil. The current code in `LLMOpenAILikeSession+Generation.swift` (and the parallel guard in `LLMFogSession+Generation.swift`) does:

```swift
guard let choices = chatStreamResult.data?.choices else {
    Self.logger.error("SpeziLLMOpenAI: Couldn't obtain choices from stream response.")
    return
}
```

The `return` exits the entire generation method on the **first** empty event, so consumers get no response and only a vague log line — even though the upstream is actively streaming. From the user's perspective the chat just hangs, indistinguishable from a network failure.

This PR replaces `return` with `continue`, so empty events are skipped and the stream is consumed normally. The log is also demoted from `error` to `debug` because empty events are routine on these gateways, not failures.

## Reproduction (before this change)

```swift
LLMOpenAIPlatform(
    configuration: .init(
        serverUrl: URL(string: "https://openrouter.ai/api/v1")!,
        authToken: .keychain(tag: .openAIKey, username: "...")
    )
)
// ... use LLMOpenAISchema with any OpenRouter model, e.g. anthropic/claude-sonnet-4
```

Console output:
```
SpeziLLMOpenAI: OpenAI LLM is being initialized
SpeziLLMOpenAI: OpenAI LLM finished initializing, now ready to use
SpeziLLMOpenAI: OpenAI GPT started a new inference
SpeziLLMOpenAI: Couldn't obtain choices from stream response.
```

The chat shows no response. `curl -N` against the same endpoint reveals the actual stream:

```
: OPENROUTER PROCESSING

: OPENROUTER PROCESSING

data: {"choices":[{"delta":{"content":"Hi"}}]}
...
```

The four `: OPENROUTER PROCESSING` keep-alives surface as four nil-data events; the first one trips the guard and aborts the method before the actual content events arrive.

## After this change

The keep-alives are silently skipped, the content events are processed normally, the chat responds.

## Scope

Symmetric fix applied to both call sites that share this guard pattern:
- `Sources/SpeziLLMOpenAI/LLMOpenAILikeSession+Generation.swift`
- `Sources/SpeziLLMFog/LLMFogSession+Generation.swift`

## Test plan

- [x] Built and ran on a real iPhone against OpenRouter with `anthropic/claude-sonnet-4` — chat now responds
- [ ] (suggested) Add a unit test that feeds the SSE decoder a mixed stream of comment-only events followed by data events and asserts `continue` behavior. Happy to follow up if maintainers want this in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)