### PR TITLE
Add latest OpenAI models and deprecate retired ones

### DIFF
--- a/Sources/SpeziLLMOpenAI/OpenAIPlatformDefinition.swift
+++ b/Sources/SpeziLLMOpenAI/OpenAIPlatformDefinition.swift
@@ -170,7 +170,7 @@ extension CredentialsTag {
 
 // swiftlint:disable identifier_name missing_docs
 extension OpenAIPlatformDefinition.ModelType {
-    public static let `default`: Self = .gpt4o
+    public static let `default`: Self = .gpt4_1
     
     /// The list of currently supported, non-deprecated models shown in model pickers.
     ///

--- a/Sources/SpeziLLMOpenAI/OpenAIPlatformDefinition.swift
+++ b/Sources/SpeziLLMOpenAI/OpenAIPlatformDefinition.swift
@@ -172,41 +172,82 @@ extension CredentialsTag {
 extension OpenAIPlatformDefinition.ModelType {
     public static let `default`: Self = .gpt4o
     
+    /// The list of currently supported, non-deprecated models shown in model pickers.
+    ///
+    /// Models that OpenAI has retired or scheduled for shutdown are intentionally excluded here; they remain
+    /// available as deprecated constants further below for source compatibility.
     public static let wellKnownModels: [Self] = [
-        .gpt5, .gpt5_mini, .gpt5_nano, .gpt5_chat,
+        .gpt5_6, .gpt5_6_sol, .gpt5_6_terra, .gpt5_6_luna,
+        .gpt5_5, .gpt5_5_pro,
+        .gpt5_4, .gpt5_4_pro, .gpt5_4_mini, .gpt5_4_nano,
+        .gpt5, .gpt5_mini, .gpt5_nano,
         .gpt4o, .gpt4o_mini,
-        .gpt4_turbo,
         .gpt4_1, .gpt4_1_mini, .gpt4_1_nano,
-        .o4_mini,
-        .o3, .o3_pro, .o3_mini, .o3_mini_high,
-        .o1_pro, .o1, .o1_mini,
+        .o3, .o3_pro,
+        .o1_pro,
         .gpt3_5_turbo
     ]
-    
+
+    // GPT-5.6 series (alias `gpt-5.6` routes to `gpt-5.6-sol`)
+    public static let gpt5_6 = Self(rawValue: "gpt-5.6")
+    public static let gpt5_6_sol = Self(rawValue: "gpt-5.6-sol")
+    public static let gpt5_6_terra = Self(rawValue: "gpt-5.6-terra")
+    public static let gpt5_6_luna = Self(rawValue: "gpt-5.6-luna")
+
+    // GPT-5.5 series
+    public static let gpt5_5 = Self(rawValue: "gpt-5.5")
+    public static let gpt5_5_pro = Self(rawValue: "gpt-5.5-pro")
+
+    // GPT-5.4 series
+    public static let gpt5_4 = Self(rawValue: "gpt-5.4")
+    public static let gpt5_4_pro = Self(rawValue: "gpt-5.4-pro")
+    public static let gpt5_4_mini = Self(rawValue: "gpt-5.4-mini")
+    public static let gpt5_4_nano = Self(rawValue: "gpt-5.4-nano")
+
     // GPT-5 series
     public static let gpt5 = Self(rawValue: "gpt-5")
     public static let gpt5_mini = Self(rawValue: "gpt-5-mini")
     public static let gpt5_nano = Self(rawValue: "gpt-5-nano")
-    public static let gpt5_chat = Self(rawValue: "gpt-5-chat-latest")
 
     // GPT-4 series
     public static let gpt4o = Self(rawValue: "gpt-4o")
     public static let gpt4o_mini = Self(rawValue: "gpt-4o-mini")
-    public static let gpt4_turbo = Self(rawValue: "gpt-4-turbo")
     public static let gpt4_1 = Self(rawValue: "gpt-4.1")
     public static let gpt4_1_mini = Self(rawValue: "gpt-4.1-mini")
     public static let gpt4_1_nano = Self(rawValue: "gpt-4.1-nano")
 
     // o-series
-    public static let o4_mini = Self(rawValue: "o4-mini")
     public static let o3 = Self(rawValue: "o3")
     public static let o3_pro = Self(rawValue: "o3-pro")
-    public static let o3_mini = Self(rawValue: "o3-mini")
-    public static let o3_mini_high = Self(rawValue: "o3-mini-high")
     public static let o1_pro = Self(rawValue: "o1-pro")
-    public static let o1 = Self(rawValue: "o1")
-    public static let o1_mini = Self(rawValue: "o1-mini")
 
     // Others
     public static let gpt3_5_turbo = Self(rawValue: "gpt-3.5-turbo")
+
+    // MARK: Deprecated & retired models
+    //
+    // OpenAI has retired these models or scheduled them for shutdown. They are kept here (and excluded from
+    // `wellKnownModels`) so existing code keeps compiling, but new code should use the suggested replacement.
+    // Reference: https://platform.openai.com/docs/deprecations
+
+    @available(*, deprecated, message: "OpenAI shuts down gpt-5-chat-latest on 2026-07-23; use `.gpt5_5`.")
+    public static let gpt5_chat = Self(rawValue: "gpt-5-chat-latest")
+
+    @available(*, deprecated, message: "OpenAI shuts down gpt-4-turbo on 2026-10-23; use `.gpt4o`.")
+    public static let gpt4_turbo = Self(rawValue: "gpt-4-turbo")
+
+    @available(*, deprecated, message: "OpenAI shuts down o4-mini on 2026-10-23; use `.gpt5_4_mini`.")
+    public static let o4_mini = Self(rawValue: "o4-mini")
+
+    @available(*, deprecated, message: "OpenAI shuts down o3-mini on 2026-10-23; use `.gpt5_5`.")
+    public static let o3_mini = Self(rawValue: "o3-mini")
+
+    @available(*, deprecated, message: "o3-mini-high is not a valid API model id (ChatGPT-only label); use `.o3_mini`.")
+    public static let o3_mini_high = Self(rawValue: "o3-mini-high")
+
+    @available(*, deprecated, message: "OpenAI shuts down o1 on 2026-10-23; use `.gpt5_5`.")
+    public static let o1 = Self(rawValue: "o1")
+
+    @available(*, deprecated, message: "OpenAI retired o1-mini on 2025-10-27; use `.gpt5_4_mini`.")
+    public static let o1_mini = Self(rawValue: "o1-mini")
 }

--- a/Sources/SpeziLLMOpenAI/OpenAIPlatformDefinition.swift
+++ b/Sources/SpeziLLMOpenAI/OpenAIPlatformDefinition.swift
@@ -170,23 +170,23 @@ extension CredentialsTag {
 
 // swiftlint:disable identifier_name missing_docs
 extension OpenAIPlatformDefinition.ModelType {
-    public static let `default`: Self = .gpt4_1
-    
+    public static let `default`: Self = .gpt5_6
+
     /// The list of currently supported, non-deprecated models shown in model pickers.
     ///
     /// Models that OpenAI has retired or scheduled for shutdown are intentionally excluded here; they remain
     /// available as deprecated constants further below for source compatibility.
     public static let wellKnownModels: [Self] = [
+        .gpt6_astra,
         .gpt5_6, .gpt5_6_sol, .gpt5_6_terra, .gpt5_6_luna,
         .gpt5_5, .gpt5_5_pro,
         .gpt5_4, .gpt5_4_pro, .gpt5_4_mini, .gpt5_4_nano,
-        .gpt5, .gpt5_mini, .gpt5_nano,
         .gpt4o, .gpt4o_mini,
-        .gpt4_1, .gpt4_1_mini, .gpt4_1_nano,
-        .o3, .o3_pro,
-        .o1_pro,
-        .gpt3_5_turbo
+        .gpt4_1, .gpt4_1_mini
     ]
+
+    // GPT-6 series
+    public static let gpt6_astra = Self(rawValue: "gpt-6-astra")
 
     // GPT-5.6 series (alias `gpt-5.6` routes to `gpt-5.6-sol`)
     public static let gpt5_6 = Self(rawValue: "gpt-5.6")
@@ -204,50 +204,70 @@ extension OpenAIPlatformDefinition.ModelType {
     public static let gpt5_4_mini = Self(rawValue: "gpt-5.4-mini")
     public static let gpt5_4_nano = Self(rawValue: "gpt-5.4-nano")
 
-    // GPT-5 series
-    public static let gpt5 = Self(rawValue: "gpt-5")
-    public static let gpt5_mini = Self(rawValue: "gpt-5-mini")
-    public static let gpt5_nano = Self(rawValue: "gpt-5-nano")
-
     // GPT-4 series
     public static let gpt4o = Self(rawValue: "gpt-4o")
     public static let gpt4o_mini = Self(rawValue: "gpt-4o-mini")
     public static let gpt4_1 = Self(rawValue: "gpt-4.1")
     public static let gpt4_1_mini = Self(rawValue: "gpt-4.1-mini")
-    public static let gpt4_1_nano = Self(rawValue: "gpt-4.1-nano")
-
-    // o-series
-    public static let o3 = Self(rawValue: "o3")
-    public static let o3_pro = Self(rawValue: "o3-pro")
-    public static let o1_pro = Self(rawValue: "o1-pro")
-
-    // Others
-    public static let gpt3_5_turbo = Self(rawValue: "gpt-3.5-turbo")
 
     // MARK: Deprecated & retired models
     //
     // OpenAI has retired these models or scheduled them for shutdown. They are kept here (and excluded from
     // `wellKnownModels`) so existing code keeps compiling, but new code should use the suggested replacement.
-    // Reference: https://platform.openai.com/docs/deprecations
+    // Reference: https://developers.openai.com/api/docs/deprecations
 
-    @available(*, deprecated, message: "OpenAI shuts down gpt-5-chat-latest on 2026-07-23; use `.gpt5_5`.")
+    @available(*, deprecated, message: "OpenAI retired gpt-5-chat-latest on 2026-07-23; use `.gpt5_6_sol`.")
     public static let gpt5_chat = Self(rawValue: "gpt-5-chat-latest")
 
-    @available(*, deprecated, message: "OpenAI shuts down gpt-4-turbo on 2026-10-23; use `.gpt4o`.")
+    @available(*, deprecated, message: "OpenAI shuts down gpt-5 on 2026-12-11; use `.gpt5_6_sol`.")
+    public static let gpt5 = Self(rawValue: "gpt-5")
+
+    @available(*, deprecated, message: "OpenAI shuts down gpt-5-mini on 2026-12-11; use `.gpt5_6_terra`.")
+    public static let gpt5_mini = Self(rawValue: "gpt-5-mini")
+
+    @available(*, deprecated, message: "OpenAI shuts down gpt-5-nano on 2026-12-11; use `.gpt5_6_luna`.")
+    public static let gpt5_nano = Self(rawValue: "gpt-5-nano")
+
+    @available(*, deprecated, message: "OpenAI shuts down gpt-4-turbo on 2026-10-23; use `.gpt5_6_sol`.")
     public static let gpt4_turbo = Self(rawValue: "gpt-4-turbo")
 
-    @available(*, deprecated, message: "OpenAI shuts down o4-mini on 2026-10-23; use `.gpt5_4_mini`.")
+    @available(*, deprecated, message: "OpenAI shuts down gpt-4.1-nano on 2026-10-23; use `.gpt5_6_luna`.")
+    public static let gpt4_1_nano = Self(rawValue: "gpt-4.1-nano")
+
+    @available(*, deprecated, message: "OpenAI shuts down o4-mini on 2026-10-23; use `.gpt5_6_terra`.")
     public static let o4_mini = Self(rawValue: "o4-mini")
 
-    @available(*, deprecated, message: "OpenAI shuts down o3-mini on 2026-10-23; use `.gpt5_5`.")
+    @available(*, deprecated, message: "OpenAI shuts down o3 on 2026-12-11; use `.gpt5_6_sol`.")
+    public static let o3 = Self(rawValue: "o3")
+
+    @available(*, deprecated, message: "OpenAI shuts down o3-pro on 2026-12-11; use `.gpt5_6_sol`.")
+    public static let o3_pro = Self(rawValue: "o3-pro")
+
+    @available(*, deprecated, message: "OpenAI shuts down o3-mini on 2026-10-23; use `.gpt5_6_sol`.")
     public static let o3_mini = Self(rawValue: "o3-mini")
 
     @available(*, deprecated, message: "o3-mini-high is not a valid API model id (ChatGPT-only label); use `.o3_mini`.")
     public static let o3_mini_high = Self(rawValue: "o3-mini-high")
 
-    @available(*, deprecated, message: "OpenAI shuts down o1 on 2026-10-23; use `.gpt5_5`.")
+    @available(*, deprecated, message: "OpenAI shuts down o1-pro on 2026-10-23; use `.gpt5_6_sol`.")
+    public static let o1_pro = Self(rawValue: "o1-pro")
+
+    @available(*, deprecated, message: "OpenAI shuts down o1 on 2026-10-23; use `.gpt5_6_sol`.")
     public static let o1 = Self(rawValue: "o1")
 
-    @available(*, deprecated, message: "OpenAI retired o1-mini on 2025-10-27; use `.gpt5_4_mini`.")
+    @available(*, deprecated, message: "OpenAI retired o1-mini on 2025-10-27; use `.gpt5_6_terra`.")
     public static let o1_mini = Self(rawValue: "o1-mini")
+
+    @available(*, deprecated, message: "OpenAI shuts down the gpt-3.5-turbo snapshots by 2026-10-23; use `.gpt5_6_terra`.")
+    public static let gpt3_5_turbo = Self(rawValue: "gpt-3.5-turbo")
+
+    public var acceptsSamplingParameters: Bool {
+        // The reasoning models answer a sampling parameter with a `400` instead of applying it, and every current
+        // family — the o-series, GPT-5.x and GPT-6 — reasons. `gpt-5-chat-latest` was the non-reasoning chat
+        // variant of its family and kept them.
+        guard rawValue != "gpt-5-chat-latest" else {
+            return true
+        }
+        return !["o1", "o3", "o4", "gpt-5", "gpt-6"].contains { rawValue.hasPrefix($0) }
+    }
 }

--- a/Sources/SpeziLLMOpenAI/OpenAIPlatformDefinition.swift
+++ b/Sources/SpeziLLMOpenAI/OpenAIPlatformDefinition.swift
@@ -170,7 +170,7 @@ extension CredentialsTag {
 
 // swiftlint:disable identifier_name missing_docs
 extension OpenAIPlatformDefinition.ModelType {
-    public static let `default`: Self = .gpt5_6
+    public static let `default`: Self = .gpt4o
 
     /// The list of currently supported, non-deprecated models shown in model pickers.
     ///

--- a/Tests/SpeziLLMTests/OpenAIInferenceTests/LLMOpenAIModelTypeTests.swift
+++ b/Tests/SpeziLLMTests/OpenAIInferenceTests/LLMOpenAIModelTypeTests.swift
@@ -18,18 +18,19 @@ struct LLMOpenAIModelTypeTests {
     /// Referenced by raw value on purpose so the test target does not trigger deprecation warnings.
     private static let deprecatedRawValues: Set<String> = [
         "gpt-5-chat-latest",
-        "gpt-4-turbo",
+        "gpt-5", "gpt-5-mini", "gpt-5-nano",
+        "gpt-4-turbo", "gpt-4.1-nano",
         "o4-mini",
-        "o3-mini",
-        "o3-mini-high",
-        "o1",
-        "o1-mini"
+        "o3", "o3-pro", "o3-mini", "o3-mini-high",
+        "o1-pro", "o1", "o1-mini",
+        "gpt-3.5-turbo"
     ]
 
 
     @Test("Newly added models map to the expected raw identifiers")
     func newModelRawValues() {
         let expected: [(OpenAIPlatformDefinition.ModelType, String)] = [
+            (.gpt6_astra, "gpt-6-astra"),
             (.gpt5_6, "gpt-5.6"),
             (.gpt5_6_sol, "gpt-5.6-sol"),
             (.gpt5_6_terra, "gpt-5.6-terra"),
@@ -51,6 +52,7 @@ struct LLMOpenAIModelTypeTests {
     func wellKnownModelsContainsNewModels() {
         let rawValues = Set(OpenAIPlatformDefinition.ModelType.wellKnownModels.map(\.rawValue))
         let newModels = [
+            "gpt-6-astra",
             "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
             "gpt-5.5", "gpt-5.5-pro",
             "gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini", "gpt-5.4-nano"
@@ -79,7 +81,7 @@ struct LLMOpenAIModelTypeTests {
     @Test("The default model is supported and non-deprecated")
     func defaultModelIsSupported() {
         let defaultModel = OpenAIPlatformDefinition.ModelType.default
-        #expect(defaultModel.rawValue == "gpt-4.1")
+        #expect(defaultModel.rawValue == "gpt-5.6")
         #expect(OpenAIPlatformDefinition.ModelType.wellKnownModels.contains(defaultModel))
         #expect(!Self.deprecatedRawValues.contains(defaultModel.rawValue))
     }
@@ -90,6 +92,21 @@ struct LLMOpenAIModelTypeTests {
         for rawValue in Self.deprecatedRawValues {
             #expect(OpenAIPlatformDefinition.ModelType(rawValue: rawValue).rawValue == rawValue)
         }
+    }
+
+    @Test("Reasoning models are marked as refusing sampling parameters")
+    func samplingParameterSupport() {
+        for model in [OpenAIPlatformDefinition.ModelType.gpt6_astra, .gpt5_6, .gpt5_6_sol, .gpt5_5, .gpt5_4_mini] {
+            #expect(!model.acceptsSamplingParameters, "\(model.rawValue) should refuse sampling parameters")
+        }
+        for rawValue in ["o1", "o3", "o4-mini"] {
+            #expect(!OpenAIPlatformDefinition.ModelType(rawValue: rawValue).acceptsSamplingParameters)
+        }
+        for model in [OpenAIPlatformDefinition.ModelType.gpt4o, .gpt4o_mini, .gpt4_1, .gpt4_1_mini] {
+            #expect(model.acceptsSamplingParameters, "\(model.rawValue) should still accept sampling parameters")
+        }
+        // The non-reasoning chat variant of its family kept them.
+        #expect(OpenAIPlatformDefinition.ModelType(rawValue: "gpt-5-chat-latest").acceptsSamplingParameters)
     }
 
     @Test("Arbitrary identifiers are accepted (open model set)")

--- a/Tests/SpeziLLMTests/OpenAIInferenceTests/LLMOpenAIModelTypeTests.swift
+++ b/Tests/SpeziLLMTests/OpenAIInferenceTests/LLMOpenAIModelTypeTests.swift
@@ -81,7 +81,7 @@ struct LLMOpenAIModelTypeTests {
     @Test("The default model is supported and non-deprecated")
     func defaultModelIsSupported() {
         let defaultModel = OpenAIPlatformDefinition.ModelType.default
-        #expect(defaultModel.rawValue == "gpt-5.6")
+        #expect(defaultModel.rawValue == "gpt-4o")
         #expect(OpenAIPlatformDefinition.ModelType.wellKnownModels.contains(defaultModel))
         #expect(!Self.deprecatedRawValues.contains(defaultModel.rawValue))
     }

--- a/Tests/SpeziLLMTests/OpenAIInferenceTests/LLMOpenAIModelTypeTests.swift
+++ b/Tests/SpeziLLMTests/OpenAIInferenceTests/LLMOpenAIModelTypeTests.swift
@@ -1,0 +1,110 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+@testable import SpeziLLMOpenAI
+import Testing
+
+
+@Suite("LLM OpenAI ModelType")
+struct LLMOpenAIModelTypeTests {
+    /// Raw model identifiers OpenAI has retired or scheduled for shutdown.
+    ///
+    /// Referenced by raw value on purpose so the test target does not trigger deprecation warnings.
+    private static let deprecatedRawValues: Set<String> = [
+        "gpt-5-chat-latest",
+        "gpt-4-turbo",
+        "o4-mini",
+        "o3-mini",
+        "o3-mini-high",
+        "o1",
+        "o1-mini"
+    ]
+
+
+    @Test("Newly added models map to the expected raw identifiers")
+    func newModelRawValues() {
+        let expected: [(OpenAIPlatformDefinition.ModelType, String)] = [
+            (.gpt5_6, "gpt-5.6"),
+            (.gpt5_6_sol, "gpt-5.6-sol"),
+            (.gpt5_6_terra, "gpt-5.6-terra"),
+            (.gpt5_6_luna, "gpt-5.6-luna"),
+            (.gpt5_5, "gpt-5.5"),
+            (.gpt5_5_pro, "gpt-5.5-pro"),
+            (.gpt5_4, "gpt-5.4"),
+            (.gpt5_4_pro, "gpt-5.4-pro"),
+            (.gpt5_4_mini, "gpt-5.4-mini"),
+            (.gpt5_4_nano, "gpt-5.4-nano")
+        ]
+
+        for (model, rawValue) in expected {
+            #expect(model.rawValue == rawValue)
+        }
+    }
+
+    @Test("wellKnownModels lists every newly added model")
+    func wellKnownModelsContainsNewModels() {
+        let rawValues = Set(OpenAIPlatformDefinition.ModelType.wellKnownModels.map(\.rawValue))
+        let newModels = [
+            "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+            "gpt-5.5", "gpt-5.5-pro",
+            "gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini", "gpt-5.4-nano"
+        ]
+
+        for model in newModels {
+            #expect(rawValues.contains(model), "wellKnownModels is missing \(model)")
+        }
+    }
+
+    @Test("wellKnownModels excludes deprecated and retired models")
+    func wellKnownModelsExcludesDeprecatedModels() {
+        let rawValues = Set(OpenAIPlatformDefinition.ModelType.wellKnownModels.map(\.rawValue))
+
+        for deprecated in Self.deprecatedRawValues {
+            #expect(!rawValues.contains(deprecated), "wellKnownModels should not offer the deprecated model \(deprecated)")
+        }
+    }
+
+    @Test("wellKnownModels does not contain duplicate identifiers")
+    func wellKnownModelsHasNoDuplicates() {
+        let rawValues = OpenAIPlatformDefinition.ModelType.wellKnownModels.map(\.rawValue)
+        #expect(rawValues.count == Set(rawValues).count)
+    }
+
+    @Test("The default model is supported and non-deprecated")
+    func defaultModelIsSupported() {
+        let defaultModel = OpenAIPlatformDefinition.ModelType.default
+        #expect(defaultModel.rawValue == "gpt-4o")
+        #expect(OpenAIPlatformDefinition.ModelType.wellKnownModels.contains(defaultModel))
+        #expect(!Self.deprecatedRawValues.contains(defaultModel.rawValue))
+    }
+
+    @Test("Deprecated models remain constructible for source compatibility")
+    func deprecatedModelsRemainConstructible() {
+        // Even though they are excluded from `wellKnownModels`, existing code passing these identifiers must keep working.
+        for rawValue in Self.deprecatedRawValues {
+            #expect(OpenAIPlatformDefinition.ModelType(rawValue: rawValue).rawValue == rawValue)
+        }
+    }
+
+    @Test("Arbitrary identifiers are accepted (open model set)")
+    func arbitraryIdentifiersAreAccepted() {
+        let viaRawValue = OpenAIPlatformDefinition.ModelType(rawValue: "some-future-model")
+        let viaStringLiteral: OpenAIPlatformDefinition.ModelType = "some-future-model"
+        #expect(viaRawValue == viaStringLiteral)
+        #expect(viaRawValue.rawValue == "some-future-model")
+    }
+
+    @Test("ModelType survives a Codable round-trip")
+    func modelTypeCodableRoundTrip() throws {
+        let model = OpenAIPlatformDefinition.ModelType.gpt5_6
+        let encoded = try JSONEncoder().encode(model)
+        let decoded = try JSONDecoder().decode(OpenAIPlatformDefinition.ModelType.self, from: encoded)
+        #expect(decoded == model)
+    }
+}

--- a/Tests/SpeziLLMTests/OpenAIInferenceTests/LLMOpenAIModelTypeTests.swift
+++ b/Tests/SpeziLLMTests/OpenAIInferenceTests/LLMOpenAIModelTypeTests.swift
@@ -79,7 +79,7 @@ struct LLMOpenAIModelTypeTests {
     @Test("The default model is supported and non-deprecated")
     func defaultModelIsSupported() {
         let defaultModel = OpenAIPlatformDefinition.ModelType.default
-        #expect(defaultModel.rawValue == "gpt-4o")
+        #expect(defaultModel.rawValue == "gpt-4.1")
         #expect(OpenAIPlatformDefinition.ModelType.wellKnownModels.contains(defaultModel))
         #expect(!Self.deprecatedRawValues.contains(defaultModel.rawValue))
     }

--- a/Tests/UITests/TestAppUITests/OpenAIUITests.swift
+++ b/Tests/UITests/TestAppUITests/OpenAIUITests.swift
@@ -28,15 +28,15 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         #if os(macOS)
         XCTAssert(app.popUpButtons["modelPicker"].waitForExistence(timeout: 2))
         app.popUpButtons["modelPicker"].tap()
-        XCTAssert(app.menuItems["gpt-5"].waitForExistence(timeout: 2))
-        app.menuItems["gpt-5"].tap()
-        XCTAssert(app.popUpButtons["gpt-5"].waitForExistence(timeout: 2))
+        XCTAssert(app.menuItems["gpt-4o"].waitForExistence(timeout: 2))
+        app.menuItems["gpt-4o"].tap()
+        XCTAssert(app.popUpButtons["gpt-4o"].waitForExistence(timeout: 2))
         #elseif os(visionOS)
         app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).swipeUp()
-        XCTAssert(app.pickerWheels["gpt-3.5-turbo"].waitForExistence(timeout: 2))     // swipe down to the gpt-3.5-turbo model
+        XCTAssert(app.pickerWheels["gpt-4.1-mini"].waitForExistence(timeout: 2))     // swipe down to the last model in the list
         #else
-        app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "gpt-5")
-        XCTAssert(app.pickerWheels["gpt-5"].waitForExistence(timeout: 2))
+        app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "gpt-4o")
+        XCTAssert(app.pickerWheels["gpt-4o"].waitForExistence(timeout: 2))
         #endif
         
         sleep(1)
@@ -49,9 +49,9 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         
         XCTAssertTrue(alert.waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
         #if os(visionOS)
-        XCTAssertTrue(alert.staticTexts["gpt-3.5-turbo"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert.staticTexts["gpt-4.1-mini"].exists, "The correct model was not registered.")
         #else
-        XCTAssertTrue(alert.staticTexts["gpt-5"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert.staticTexts["gpt-4o"].exists, "The correct model was not registered.")
         #endif
 
         let okButton = alert.buttons["OK"]
@@ -59,7 +59,7 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         okButton.tap()
         #else
         XCTAssertTrue(app.staticTexts["Model Selected"].waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(app.staticTexts["gpt-5"].exists, "The correct model was not registered.")
+        XCTAssertTrue(app.staticTexts["gpt-4o"].exists, "The correct model was not registered.")
         XCTAssert(app.buttons["OK"].firstMatch.waitForExistence(timeout: 2))
         app.buttons["OK"].firstMatch.tap()
         #endif
@@ -80,9 +80,9 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         app.buttons["Continue"].tap()
         
         #if !os(macOS)
-        XCTAssert(app.pickerWheels["gpt-4.1"].waitForExistence(timeout: 2))
+        XCTAssert(app.pickerWheels["gpt-5.6"].waitForExistence(timeout: 2))
         #else
-        XCTAssert(app.popUpButtons["gpt-4.1"].waitForExistence(timeout: 2))
+        XCTAssert(app.popUpButtons["gpt-5.6"].waitForExistence(timeout: 2))
         #endif
         app.buttons["Continue"].tap()
         
@@ -90,14 +90,14 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         let alert2 = app.alerts["Model Selected"]
 
         XCTAssertTrue(alert2.waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(alert2.staticTexts["gpt-4.1"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert2.staticTexts["gpt-5.6"].exists, "The correct model was not registered.")
 
         let okButton2 = alert.buttons["OK"]
         XCTAssertTrue(okButton2.exists, "The OK button on the alert was not found.")
         okButton.tap()
         #else
         XCTAssertTrue(app.staticTexts["Model Selected"].waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(app.staticTexts["gpt-5"].exists, "The correct model was not registered.")
+        XCTAssertTrue(app.staticTexts["gpt-4o"].exists, "The correct model was not registered.")
         XCTAssert(app.buttons["OK"].firstMatch.waitForExistence(timeout: 2))
         app.buttons["OK"].firstMatch.tap()
         #endif
@@ -117,9 +117,9 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         app.buttons["Continue"].tap()
         
         #if !os(macOS)
-        XCTAssert(app.pickerWheels["gpt-4.1"].waitForExistence(timeout: 2))
+        XCTAssert(app.pickerWheels["gpt-5.6"].waitForExistence(timeout: 2))
         #else
-        XCTAssert(app.popUpButtons["gpt-4.1"].waitForExistence(timeout: 2))
+        XCTAssert(app.popUpButtons["gpt-5.6"].waitForExistence(timeout: 2))
         #endif
     }
     

--- a/Tests/UITests/TestAppUITests/OpenAIUITests.swift
+++ b/Tests/UITests/TestAppUITests/OpenAIUITests.swift
@@ -28,15 +28,15 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         #if os(macOS)
         XCTAssert(app.popUpButtons["modelPicker"].waitForExistence(timeout: 2))
         app.popUpButtons["modelPicker"].tap()
-        XCTAssert(app.menuItems["gpt-4o"].waitForExistence(timeout: 2))
-        app.menuItems["gpt-4o"].tap()
-        XCTAssert(app.popUpButtons["gpt-4o"].waitForExistence(timeout: 2))
+        XCTAssert(app.menuItems["gpt-5.6"].waitForExistence(timeout: 2))
+        app.menuItems["gpt-5.6"].tap()
+        XCTAssert(app.popUpButtons["gpt-5.6"].waitForExistence(timeout: 2))
         #elseif os(visionOS)
         app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).swipeUp()
         XCTAssert(app.pickerWheels["gpt-4.1-mini"].waitForExistence(timeout: 2))     // swipe down to the last model in the list
         #else
-        app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "gpt-4o")
-        XCTAssert(app.pickerWheels["gpt-4o"].waitForExistence(timeout: 2))
+        app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "gpt-5.6")
+        XCTAssert(app.pickerWheels["gpt-5.6"].waitForExistence(timeout: 2))
         #endif
         
         sleep(1)
@@ -51,7 +51,7 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         #if os(visionOS)
         XCTAssertTrue(alert.staticTexts["gpt-4.1-mini"].exists, "The correct model was not registered.")
         #else
-        XCTAssertTrue(alert.staticTexts["gpt-4o"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert.staticTexts["gpt-5.6"].exists, "The correct model was not registered.")
         #endif
 
         let okButton = alert.buttons["OK"]
@@ -59,7 +59,7 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         okButton.tap()
         #else
         XCTAssertTrue(app.staticTexts["Model Selected"].waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(app.staticTexts["gpt-4o"].exists, "The correct model was not registered.")
+        XCTAssertTrue(app.staticTexts["gpt-5.6"].exists, "The correct model was not registered.")
         XCTAssert(app.buttons["OK"].firstMatch.waitForExistence(timeout: 2))
         app.buttons["OK"].firstMatch.tap()
         #endif
@@ -80,9 +80,9 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         app.buttons["Continue"].tap()
         
         #if !os(macOS)
-        XCTAssert(app.pickerWheels["gpt-5.6"].waitForExistence(timeout: 2))
+        XCTAssert(app.pickerWheels["gpt-4o"].waitForExistence(timeout: 2))
         #else
-        XCTAssert(app.popUpButtons["gpt-5.6"].waitForExistence(timeout: 2))
+        XCTAssert(app.popUpButtons["gpt-4o"].waitForExistence(timeout: 2))
         #endif
         app.buttons["Continue"].tap()
         
@@ -90,7 +90,7 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         let alert2 = app.alerts["Model Selected"]
 
         XCTAssertTrue(alert2.waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(alert2.staticTexts["gpt-5.6"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert2.staticTexts["gpt-4o"].exists, "The correct model was not registered.")
 
         let okButton2 = alert.buttons["OK"]
         XCTAssertTrue(okButton2.exists, "The OK button on the alert was not found.")
@@ -117,9 +117,9 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         app.buttons["Continue"].tap()
         
         #if !os(macOS)
-        XCTAssert(app.pickerWheels["gpt-5.6"].waitForExistence(timeout: 2))
+        XCTAssert(app.pickerWheels["gpt-4o"].waitForExistence(timeout: 2))
         #else
-        XCTAssert(app.popUpButtons["gpt-5.6"].waitForExistence(timeout: 2))
+        XCTAssert(app.popUpButtons["gpt-4o"].waitForExistence(timeout: 2))
         #endif
     }
     

--- a/Tests/UITests/TestAppUITests/OpenAIUITests.swift
+++ b/Tests/UITests/TestAppUITests/OpenAIUITests.swift
@@ -92,9 +92,9 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         XCTAssertTrue(alert2.waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
         XCTAssertTrue(alert2.staticTexts["gpt-4o"].exists, "The correct model was not registered.")
 
-        let okButton2 = alert.buttons["OK"]
+        let okButton2 = alert2.buttons["OK"]
         XCTAssertTrue(okButton2.exists, "The OK button on the alert was not found.")
-        okButton.tap()
+        okButton2.tap()
         #else
         XCTAssertTrue(app.staticTexts["Model Selected"].waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
         XCTAssertTrue(app.staticTexts["gpt-4o"].exists, "The correct model was not registered.")

--- a/Tests/UITests/TestAppUITests/OpenAIUITests.swift
+++ b/Tests/UITests/TestAppUITests/OpenAIUITests.swift
@@ -80,9 +80,9 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         app.buttons["Continue"].tap()
         
         #if !os(macOS)
-        XCTAssert(app.pickerWheels["gpt-4o"].waitForExistence(timeout: 2))
+        XCTAssert(app.pickerWheels["gpt-4.1"].waitForExistence(timeout: 2))
         #else
-        XCTAssert(app.popUpButtons["gpt-4o"].waitForExistence(timeout: 2))
+        XCTAssert(app.popUpButtons["gpt-4.1"].waitForExistence(timeout: 2))
         #endif
         app.buttons["Continue"].tap()
         
@@ -90,7 +90,7 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         let alert2 = app.alerts["Model Selected"]
 
         XCTAssertTrue(alert2.waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(alert2.staticTexts["gpt-4o"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert2.staticTexts["gpt-4.1"].exists, "The correct model was not registered.")
 
         let okButton2 = alert.buttons["OK"]
         XCTAssertTrue(okButton2.exists, "The OK button on the alert was not found.")
@@ -117,9 +117,9 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         app.buttons["Continue"].tap()
         
         #if !os(macOS)
-        XCTAssert(app.pickerWheels["gpt-4o"].waitForExistence(timeout: 2))
+        XCTAssert(app.pickerWheels["gpt-4.1"].waitForExistence(timeout: 2))
         #else
-        XCTAssert(app.popUpButtons["gpt-4o"].waitForExistence(timeout: 2))
+        XCTAssert(app.popUpButtons["gpt-4.1"].waitForExistence(timeout: 2))
         #endif
     }
     

--- a/Tests/UITests/TestAppUITests/OpenAIUITests.swift
+++ b/Tests/UITests/TestAppUITests/OpenAIUITests.swift
@@ -28,15 +28,15 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         #if os(macOS)
         XCTAssert(app.popUpButtons["modelPicker"].waitForExistence(timeout: 2))
         app.popUpButtons["modelPicker"].tap()
-        XCTAssert(app.menuItems["gpt-5-chat-latest"].waitForExistence(timeout: 2))
-        app.menuItems["gpt-5-chat-latest"].tap()
-        XCTAssert(app.popUpButtons["gpt-5-chat-latest"].waitForExistence(timeout: 2))
+        XCTAssert(app.menuItems["gpt-5"].waitForExistence(timeout: 2))
+        app.menuItems["gpt-5"].tap()
+        XCTAssert(app.popUpButtons["gpt-5"].waitForExistence(timeout: 2))
         #elseif os(visionOS)
         app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).swipeUp()
         XCTAssert(app.pickerWheels["gpt-3.5-turbo"].waitForExistence(timeout: 2))     // swipe down to the gpt-3.5-turbo model
         #else
-        app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "gpt-5-chat-latest")
-        XCTAssert(app.pickerWheels["gpt-5-chat-latest"].waitForExistence(timeout: 2))
+        app.pickers["modelPicker"].pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "gpt-5")
+        XCTAssert(app.pickerWheels["gpt-5"].waitForExistence(timeout: 2))
         #endif
         
         sleep(1)
@@ -51,7 +51,7 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         #if os(visionOS)
         XCTAssertTrue(alert.staticTexts["gpt-3.5-turbo"].exists, "The correct model was not registered.")
         #else
-        XCTAssertTrue(alert.staticTexts["gpt-5-chat-latest"].exists, "The correct model was not registered.")
+        XCTAssertTrue(alert.staticTexts["gpt-5"].exists, "The correct model was not registered.")
         #endif
 
         let okButton = alert.buttons["OK"]
@@ -59,7 +59,7 @@ final class TestAppLLMOpenAIUITests: TestAppTestCase {
         okButton.tap()
         #else
         XCTAssertTrue(app.staticTexts["Model Selected"].waitForExistence(timeout: 2), "The `Model Selected` alert did not appear.")
-        XCTAssertTrue(app.staticTexts["gpt-5-chat-latest"].exists, "The correct model was not registered.")
+        XCTAssertTrue(app.staticTexts["gpt-5"].exists, "The correct model was not registered.")
         XCTAssert(app.buttons["OK"].firstMatch.waitForExistence(timeout: 2))
         app.buttons["OK"].firstMatch.tap()
         #endif


### PR DESCRIPTION
## Overview

Brings `OpenAIPlatformDefinition` up to OpenAI's current catalog, and cleans up the models OpenAI has retired or scheduled for shutdown.

### Added
- **GPT-6**: `gpt-6-astra`
- **GPT-5.6**: `gpt-5.6` (alias → `gpt-5.6-sol`), `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
- **GPT-5.5**: `gpt-5.5`, `gpt-5.5-pro`
- **GPT-5.4**: `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.4-nano`

### Changed
- **Default model stays `gpt-4o`.** No behaviour change for callers who never set `modelType`. `gpt-4o` is not deprecated — the only entry in OpenAI's list is the dated `gpt-4o-2024-05-13` snapshot, while the bare alias resolves to `gpt-4o-2024-08-06` — and it supports Chat Completions, the only API this package speaks. It is also non-reasoning, so unlike every current model it still accepts sampling parameters. The current models are all in `wellKnownModels` for anyone who wants to opt in explicitly.
- `wellKnownModels` now lists only current, non-retired models: the GPT-6, 5.6, 5.5 and 5.4 families plus `gpt-4o`, `gpt-4o-mini`, `gpt-4.1` and `gpt-4.1-mini`.

### Deprecated (per [OpenAI deprecations](https://developers.openai.com/api/docs/deprecations))
Marked `@available(*, deprecated)` with the date and replacement, and removed from `wellKnownModels` so a picker stops offering models that are about to start failing. All constants are kept for source compatibility.

| Model | Status | Replacement |
|---|---|---|
| `o1-mini` | Retired 2025-10-27 | `.gpt5_6_terra` |
| `gpt-5-chat-latest` | Retired 2026-07-23 | `.gpt5_6_sol` |
| `gpt-3.5-turbo` | Snapshots shut down by 2026-10-23 | `.gpt5_6_terra` |
| `gpt-4-turbo` | Shutdown 2026-10-23 | `.gpt5_6_sol` |
| `gpt-4.1-nano` | Shutdown 2026-10-23 | `.gpt5_6_luna` |
| `o4-mini` | Shutdown 2026-10-23 | `.gpt5_6_terra` |
| `o3-mini` | Shutdown 2026-10-23 | `.gpt5_6_sol` |
| `o1` | Shutdown 2026-10-23 | `.gpt5_6_sol` |
| `o1-pro` | Shutdown 2026-10-23 | `.gpt5_6_sol` |
| `gpt-5` | Shutdown 2026-12-11 | `.gpt5_6_sol` |
| `gpt-5-mini` | Shutdown 2026-12-11 | `.gpt5_6_terra` |
| `gpt-5-nano` | Shutdown 2026-12-11 | `.gpt5_6_luna` |
| `o3` | Shutdown 2026-12-11 | `.gpt5_6_sol` |
| `o3-pro` | Shutdown 2026-12-11 | `.gpt5_6_sol` |
| `o3-mini-high` | Not a valid API model id (ChatGPT-only label) | `.o3_mini` |

### Sampling parameters

The o-series, GPT-5.x and GPT-6 families all reason, and a reasoning model answers `temperature`, `top_p`, the penalties and `logit_bias` with a `400` rather than applying them. `OpenAIPlatformDefinition.ModelType` now reports this through the `acceptsSamplingParameters` requirement added in #155 (already on `main`), so the request builder drops those parameters instead of sending a request that is guaranteed to fail. `gpt-5-chat-latest` was the non-reasoning chat variant of its family and kept them, so it's carved out.

### Tests
- `LLMOpenAIModelTypeTests` — raw-value mappings, `wellKnownModels` inclusion/exclusion, no duplicates, the default model, source compatibility of deprecated constants, a Codable round-trip, and which models report refusing sampling parameters.
- `OpenAIUITests` updated: the explicitly-picked model moves off `gpt-5` (now deprecated, so no longer in the picker) to `gpt-4o`, the visionOS "last model in the list" assertion moves from `gpt-3.5-turbo` to `gpt-4.1-mini`, and the explicitly-selected model becomes `gpt-5.6` (it has to differ from the default for the test to mean anything).

Full suite verified locally: **31 tests in 6 suites passing**, SwiftLint clean.
