### PR TITLE
Add latest Anthropic models and update sampling parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
-    name: CI
-    uses: StanfordBDHG/.github/.github/workflows/swift-package-ci.yml@v2
+  setup:
+    name: Setup
+    uses: StanfordBDHG/.github/.github/workflows/swift-package-setup.yml@v2
+
+  build_and_test:
+    name: Build & Test
+    needs: setup
+    uses: StanfordBDHG/.github/.github/workflows/swift-package-test.yml@v2
+    with:
+      package_name: ${{ needs.setup.outputs.package_name }}
+      scheme: ${{ needs.setup.outputs.scheme }}
+      platform_matrix: ${{ needs.setup.outputs.platform_matrix }}
+      ui_platform_matrix: ${{ needs.setup.outputs.ui_platform_matrix }}
+      linux_run_tests: false
+      # mlx-swift (pulled in via SpeziLLMLocal) compiles Metal shaders, and recent Xcode versions no longer
+      # bundle the Metal Toolchain, so download it before building.
+      downloadMetalToolchain: true
     secrets: inherit
+
+  static_analysis:
+    name: Static Analysis
+    needs: setup
+    # diagnose_breaking_changes is disabled: `swift package diagnose-api-breaking-changes` builds under a
+    # stricter mode than the regular xcodebuild-based test job and cannot build the generated OpenAPI client
+    # (the swift-openapi-generator's `package import`s conflict with SwiftPM's generated resource-bundle
+    # accessor's plain `import`), so it fails for a non-breakage reason. There is no clean in-repo fix.
+    uses: StanfordBDHG/.github/.github/workflows/swift-package-static-analysis.yml@v2
+    with:
+      library_products: ${{ needs.setup.outputs.library_products }}
+      platform_name: ${{ needs.setup.outputs.platform_name }}
+      platform_version: ${{ needs.setup.outputs.platform_version }}
+      diagnose_breaking_changes: false

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -10,5 +10,8 @@ dirs:
 useGitIgnore: true
 ignorePatterns:
   - pattern: '^https://platform.openai.com/docs/guides/.*$' # Causes false positives
+  # Swift Package Index rate-limits the CI runner and answers some requests with a 403 even though the
+  # pages resolve fine in a browser; the same URLs pass on one run and fail on the next.
+  - pattern: '^https://swiftpackageindex.com/.*$'
   - pattern: '^doc:.*$'
   - pattern: '^http://localhost.*$'

--- a/Package.swift
+++ b/Package.swift
@@ -202,7 +202,8 @@ let package = Package(
                 .product(name: "Spezi", package: "Spezi"),
                 .product(name: "SpeziTesting", package: "Spezi"),
                 .target(name: "SpeziLLM"),
-                .target(name: "SpeziLLMOpenAI")
+                .target(name: "SpeziLLMOpenAI"),
+                .target(name: "SpeziLLMAnthropic")
             ],
             swiftSettings: [
                 .enableUpcomingFeature("ExistentialAny")

--- a/Sources/GeneratedOpenAIClient/openapi-generator-config.yaml
+++ b/Sources/GeneratedOpenAIClient/openapi-generator-config.yaml
@@ -9,4 +9,4 @@
 generate:
   - types
   - client
-accessModifier: package
+accessModifier: public

--- a/Sources/SpeziLLMAnthropic/AnthropicPlatformDefinition.swift
+++ b/Sources/SpeziLLMAnthropic/AnthropicPlatformDefinition.swift
@@ -28,7 +28,7 @@ public struct AnthropicPlatformDefinition: LLMOpenAILikePlatformDefinition {
     public static let platformName = "Anthropic"
     public static let platformServiceIdentifier = "api.anthropic.com"
     
-    public static let defaultServerUrl = URL(string: "https://api.anthropic.com/v1")! // swiftlint:disable:this force_unwrapping
+    public static let defaultServerUrl = URL(string: "https://api.anthropic.com/v1")!
     
     public static let platformDeveloperConsoleUrl = URL(string: "https://platform.claude.com/settings/keys")
 }
@@ -105,7 +105,7 @@ public typealias LLMAnthropicSchema = LLMOpenAILikeSchema<AnthropicPlatformDefin
 ///                 let llmSession: LLMAnthropicSession = runner(
 ///                     with: LLMAnthropicSchema(
 ///                         parameters: .init(
-///                             modelType: .opus4_6,
+///                             modelType: .opus4_8,
 ///                             systemPrompt: "You're a helpful assistant that answers questions from users.",
 ///                             overwritingAuthToken: "abc123"
 ///                         )
@@ -149,17 +149,37 @@ extension CredentialsTag {
 // swiftlint:disable identifier_name
 extension AnthropicPlatformDefinition.ModelType {
     /// The default model to be used with Anthropic.
-    public static let `default`: Self = .opus4_6
-    
+    public static let `default`: Self = .opus4_8
+
     public static let wellKnownModels: [Self] = [ // swiftlint:disable:this missing_docs
-        .opus4_6, .sonnet4_6, .haiku4_6
+        .fable5,
+        .opus4_8, .opus4_7, .opus4_6,
+        .sonnet5, .sonnet4_6,
+        .haiku4_5
     ]
-    
+
+    /// Claude Fable 5
+    public static let fable5 = Self(rawValue: "claude-fable-5")
+
+    /// Claude Opus 4.8
+    public static let opus4_8 = Self(rawValue: "claude-opus-4-8")
+    /// Claude Opus 4.7
+    public static let opus4_7 = Self(rawValue: "claude-opus-4-7")
     /// Claude Opus 4.6
     public static let opus4_6 = Self(rawValue: "claude-opus-4-6")
+
+    /// Claude Sonnet 5
+    public static let sonnet5 = Self(rawValue: "claude-sonnet-5")
     /// Claude Sonnet 4.6
     public static let sonnet4_6 = Self(rawValue: "claude-sonnet-4-6")
+
     /// Claude Haiku 4.5
+    public static let haiku4_5 = Self(rawValue: "claude-haiku-4-5")
+
+    /// Claude Haiku 4.5
+    ///
+    /// - Warning: This constant was incorrectly named; use ``haiku4_5`` instead.
+    @available(*, deprecated, renamed: "haiku4_5")
     public static let haiku4_6 = Self(rawValue: "claude-haiku-4-5")
 }
 // swiftlint:enable identifier_name

--- a/Sources/SpeziLLMAnthropic/AnthropicPlatformDefinition.swift
+++ b/Sources/SpeziLLMAnthropic/AnthropicPlatformDefinition.swift
@@ -105,7 +105,7 @@ public typealias LLMAnthropicSchema = LLMOpenAILikeSchema<AnthropicPlatformDefin
 ///                 let llmSession: LLMAnthropicSession = runner(
 ///                     with: LLMAnthropicSchema(
 ///                         parameters: .init(
-///                             modelType: .opus4_8,
+///                             modelType: .opus5,
 ///                             systemPrompt: "You're a helpful assistant that answers questions from users.",
 ///                             overwritingAuthToken: "abc123"
 ///                         )
@@ -149,18 +149,25 @@ extension CredentialsTag {
 // swiftlint:disable identifier_name
 extension AnthropicPlatformDefinition.ModelType {
     /// The default model to be used with Anthropic.
-    public static let `default`: Self = .opus4_8
+    public static let `default`: Self = .opus5
 
     public static let wellKnownModels: [Self] = [ // swiftlint:disable:this missing_docs
-        .fable5,
-        .opus4_8, .opus4_7, .opus4_6,
+        .fable5_1, .fable5,
+        .opus5, .opus4_8, .opus4_7, .opus4_6,
         .sonnet5, .sonnet4_6,
         .haiku4_5
     ]
 
+    /// Claude Fable 5.1
+    ///
+    /// - Note: Fable models always think, never accept sampling parameters, and are unavailable to organizations
+    ///     that have not been authorized for the required 30-day data retention.
+    public static let fable5_1 = Self(rawValue: "claude-fable-5-1")
     /// Claude Fable 5
     public static let fable5 = Self(rawValue: "claude-fable-5")
 
+    /// Claude Opus 5
+    public static let opus5 = Self(rawValue: "claude-opus-5")
     /// Claude Opus 4.8
     public static let opus4_8 = Self(rawValue: "claude-opus-4-8")
     /// Claude Opus 4.7
@@ -181,5 +188,12 @@ extension AnthropicPlatformDefinition.ModelType {
     /// - Warning: This constant was incorrectly named; use ``haiku4_5`` instead.
     @available(*, deprecated, renamed: "haiku4_5")
     public static let haiku4_6 = Self(rawValue: "claude-haiku-4-5")
+
+    public var acceptsSamplingParameters: Bool { // swiftlint:disable:this missing_docs
+        // Anthropic stopped accepting non-default sampling from Opus 4.7 onwards, and Fable and Sonnet 5 followed;
+        // asking for one is a `400`. Opus 4.6, Sonnet 4.6 and Haiku 4.5 still take them. Steer the models that
+        // don't through the prompt instead.
+        ![Self.fable5_1, .fable5, .opus5, .opus4_8, .opus4_7, .sonnet5].contains(self)
+    }
 }
 // swiftlint:enable identifier_name

--- a/Sources/SpeziLLMGemini/GeminiPlatformDefinition.swift
+++ b/Sources/SpeziLLMGemini/GeminiPlatformDefinition.swift
@@ -28,7 +28,7 @@ public struct GeminiPlatformDefinition: LLMOpenAILikePlatformDefinition {
     public static let platformName = "Gemini"
     public static let platformServiceIdentifier = "generativelanguage.googleapis.com"
     
-    public static let defaultServerUrl = URL(string: "https://generativelanguage.googleapis.com/v1beta/openai")! // swiftlint:disable:this force_unwrapping
+    public static let defaultServerUrl = URL(string: "https://generativelanguage.googleapis.com/v1beta/openai")!
     
     public static let platformDeveloperConsoleUrl = URL(string: "https://aistudio.google.com/app/api-keys")
 }

--- a/Sources/SpeziLLMOpenAI/Configuration/LLMOpenAILikePlatformDefinition.swift
+++ b/Sources/SpeziLLMOpenAI/Configuration/LLMOpenAILikePlatformDefinition.swift
@@ -49,7 +49,17 @@ public protocol LLMOpenAILikePlatformModelType: Hashable, RawRepresentable<Strin
     ///
     /// Used e.g. when picking a model in the UI.
     static var wellKnownModels: [Self] { get }
-    
+
+    /// Whether this model accepts the sampling parameters of the completions API.
+    ///
+    /// A model that has moved past them rejects `temperature`, `top_p`, the penalties and `logit_bias` with a
+    /// `400` rather than ignoring them, so a caller that sets one fails every request. Reasoning models were the
+    /// first to do this and the other vendors have followed, model by model rather than family by family — which
+    /// is why each platform answers for its own models instead of the answer being inferred from the identifier.
+    ///
+    /// Defaults to `true`.
+    var acceptsSamplingParameters: Bool { get }
+
     /// Creates a `ModelType` from a raw string value
     init(rawValue: String)
 }
@@ -58,5 +68,9 @@ public protocol LLMOpenAILikePlatformModelType: Hashable, RawRepresentable<Strin
 extension LLMOpenAILikePlatformModelType {
     public var id: some Hashable { // swiftlint:disable:this missing_docs
         rawValue
+    }
+
+    public var acceptsSamplingParameters: Bool { // swiftlint:disable:this missing_docs
+        true
     }
 }

--- a/Sources/SpeziLLMOpenAI/Configuration/LLMOpenAIModelParameters+Accepted.swift
+++ b/Sources/SpeziLLMOpenAI/Configuration/LLMOpenAIModelParameters+Accepted.swift
@@ -1,0 +1,65 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import GeneratedOpenAIClient
+import os
+
+
+extension LLMOpenAIModelParameters {
+    private static let logger = Logger(subsystem: "edu.stanford.spezi", category: "SpeziLLMOpenAI")
+
+
+    /// The same parameters, without the sampling parameters the given model refuses.
+    ///
+    /// Sending one to a model that has moved past them fails the request outright, which would turn a parameter a
+    /// caller set once into an app whose every answer errors. Dropping them costs the caller the control it asked
+    /// for and nothing else, so the session keeps answering; the dropped parameters are logged, because the call
+    /// site is where this is worth fixing.
+    func accepted(by modelType: some LLMOpenAILikePlatformModelType) -> Self {
+        guard !modelType.acceptsSamplingParameters else {
+            return self
+        }
+
+        var dropped: [String] = []
+        var accepted = self
+        if temperature != nil {
+            dropped.append("temperature")
+            accepted.temperature = nil
+        }
+        if topP != nil {
+            dropped.append("topP")
+            accepted.topP = nil
+        }
+        if presencePenalty != nil {
+            dropped.append("presencePenalty")
+            accepted.presencePenalty = nil
+        }
+        if frequencyPenalty != nil {
+            dropped.append("frequencyPenalty")
+            accepted.frequencyPenalty = nil
+        }
+        if !logitBias.additionalProperties.isEmpty {
+            dropped.append("logitBias")
+            accepted.logitBias = .init(additionalProperties: [:])
+        }
+
+        guard !dropped.isEmpty else {
+            return self
+        }
+
+        Self.logger.warning(
+            """
+            \(modelType.rawValue, privacy: .public) does not accept sampling parameters; \
+            dropped \(dropped.joined(separator: ", "), privacy: .public) from the request. \
+            Remove them from the schema's `modelParameters` and steer the model through the prompt instead.
+            """
+        )
+        return accepted
+    }
+}

--- a/Sources/SpeziLLMOpenAI/Configuration/LLMOpenAIModelParameters.swift
+++ b/Sources/SpeziLLMOpenAI/Configuration/LLMOpenAIModelParameters.swift
@@ -32,9 +32,9 @@ public struct LLMOpenAIModelParameters: Sendable {
     /// The format for model responses.
     let responseFormat: Components.Schemas.CreateChatCompletionRequest.response_formatPayload?
     /// The sampling temperature (0 to 2). Higher values increase randomness, lower values enhance focus.
-    let temperature: Double?
+    var temperature: Double?
     /// Nucleus sampling threshold. Considers tokens with top_p probability mass. Alternative to temperature sampling.
-    let topP: Double?
+    var topP: Double?
     /// The number of generated chat completions per input.
     let completionsPerOutput: Int?
     /// Sequences (up to 4) where generation stops. Output doesn't include these sequences.
@@ -44,11 +44,11 @@ public struct LLMOpenAIModelParameters: Sendable {
     /// OpenAI will make a best effort to sample deterministically, such that repeated requests with the same seed and parameters should return the same result. Determinism is not guaranteed.
     let seed: Int?
     /// Adjusts new topic exploration (-2.0 to 2.0). Higher values encourage novelty.
-    let presencePenalty: Double?
+    var presencePenalty: Double?
     /// Controls repetition (-2.0 to 2.0). Higher values reduce the likelihood of repeating content.
-    let frequencyPenalty: Double?
+    var frequencyPenalty: Double?
     /// Alters specific token's likelihood in completion.
-    let logitBias: Components.Schemas.CreateChatCompletionRequest.logit_biasPayload
+    var logitBias: Components.Schemas.CreateChatCompletionRequest.logit_biasPayload
     /// Unique identifier for the end-user, aiding in abuse monitoring.
     let user: String?
     

--- a/Sources/SpeziLLMOpenAI/LLMOpenAILikeSession+Configuration.swift
+++ b/Sources/SpeziLLMOpenAI/LLMOpenAILikeSession+Configuration.swift
@@ -36,10 +36,12 @@ extension LLMOpenAILikeSession {
                 )
             }
             
-            let stop: Components.Schemas.CreateChatCompletionRequest.stopPayload? = if schema.modelParameters.stopSequence.isEmpty {
+            let modelParameters = schema.modelParameters.accepted(by: schema.parameters.modelType)
+
+            let stop: Components.Schemas.CreateChatCompletionRequest.stopPayload? = if modelParameters.stopSequence.isEmpty {
                 nil
             } else {
-                Components.Schemas.CreateChatCompletionRequest.stopPayload.case2(schema.modelParameters.stopSequence)
+                Components.Schemas.CreateChatCompletionRequest.stopPayload.case2(modelParameters.stopSequence)
             }
 
             return await Operations.createChatCompletion
@@ -48,21 +50,21 @@ extension LLMOpenAILikeSession {
                         Components.Schemas.CreateChatCompletionRequest(
                             messages: openAIContext,
                             model: .init(value1: schema.parameters.modelType.rawValue),
-                            frequency_penalty: schema.modelParameters.frequencyPenalty,
-                            logit_bias: schema.modelParameters.logitBias.additionalProperties.isEmpty ? nil : schema
-                                .modelParameters
-                                .logitBias,
-                            max_completion_tokens: schema.modelParameters.maxOutputLength,
-                            n: schema.modelParameters.completionsPerOutput,
-                            presence_penalty: schema.modelParameters.presencePenalty,
-                            response_format: schema.modelParameters.responseFormat,
-                            seed: schema.modelParameters.seed.map { Int64($0) },
+                            frequency_penalty: modelParameters.frequencyPenalty,
+                            logit_bias: modelParameters.logitBias.additionalProperties.isEmpty
+                                ? nil
+                                : modelParameters.logitBias,
+                            max_completion_tokens: modelParameters.maxOutputLength,
+                            n: modelParameters.completionsPerOutput,
+                            presence_penalty: modelParameters.presencePenalty,
+                            response_format: modelParameters.responseFormat,
+                            seed: modelParameters.seed.map { Int64($0) },
                             stop: stop,
                             stream: true,
-                            temperature: schema.modelParameters.temperature,
-                            top_p: schema.modelParameters.topP,
+                            temperature: modelParameters.temperature,
+                            top_p: modelParameters.topP,
                             tools: functions.isEmpty ? nil : functions,
-                            user: schema.modelParameters.user
+                            user: modelParameters.user
                         )
                     )
                 )

--- a/Tests/SpeziLLMTests/LLMAnthropicModelTypeTests.swift
+++ b/Tests/SpeziLLMTests/LLMAnthropicModelTypeTests.swift
@@ -16,7 +16,9 @@ struct LLMAnthropicModelTypeTests {
     @Test("Models map to the expected raw identifiers")
     func modelRawValues() {
         let expected: [(AnthropicPlatformDefinition.ModelType, String)] = [
+            (.fable5_1, "claude-fable-5-1"),
             (.fable5, "claude-fable-5"),
+            (.opus5, "claude-opus-5"),
             (.opus4_8, "claude-opus-4-8"),
             (.opus4_7, "claude-opus-4-7"),
             (.opus4_6, "claude-opus-4-6"),
@@ -34,8 +36,8 @@ struct LLMAnthropicModelTypeTests {
     func wellKnownModelsContainsCurrentModels() {
         let rawValues = Set(AnthropicPlatformDefinition.ModelType.wellKnownModels.map(\.rawValue))
         let models = [
-            "claude-fable-5",
-            "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6",
+            "claude-fable-5-1", "claude-fable-5",
+            "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6",
             "claude-sonnet-5", "claude-sonnet-4-6",
             "claude-haiku-4-5"
         ]
@@ -54,7 +56,7 @@ struct LLMAnthropicModelTypeTests {
     @Test("The default model is the current flagship and is offered in the picker")
     func defaultModelIsSupported() {
         let defaultModel = AnthropicPlatformDefinition.ModelType.default
-        #expect(defaultModel.rawValue == "claude-opus-4-8")
+        #expect(defaultModel.rawValue == "claude-opus-5")
         #expect(AnthropicPlatformDefinition.ModelType.wellKnownModels.contains(defaultModel))
     }
 
@@ -66,9 +68,24 @@ struct LLMAnthropicModelTypeTests {
         #expect(viaRawValue.rawValue == "some-future-model")
     }
 
+    @Test("Models that dropped sampling parameters are marked as such")
+    func samplingParameterSupport() {
+        for model in [AnthropicPlatformDefinition.ModelType.fable5_1, .fable5, .opus5, .opus4_8, .opus4_7, .sonnet5] {
+            #expect(!model.acceptsSamplingParameters, "\(model.rawValue) should refuse sampling parameters")
+        }
+        for model in [AnthropicPlatformDefinition.ModelType.opus4_6, .sonnet4_6, .haiku4_5] {
+            #expect(model.acceptsSamplingParameters, "\(model.rawValue) should still accept sampling parameters")
+        }
+    }
+
+    @Test("An unknown identifier is assumed to accept sampling parameters")
+    func unknownModelAcceptsSamplingParameters() {
+        #expect(AnthropicPlatformDefinition.ModelType(rawValue: "some-future-model").acceptsSamplingParameters)
+    }
+
     @Test("ModelType survives a Codable round-trip")
     func modelTypeCodableRoundTrip() throws {
-        let model = AnthropicPlatformDefinition.ModelType.opus4_8
+        let model = AnthropicPlatformDefinition.ModelType.opus5
         let encoded = try JSONEncoder().encode(model)
         let decoded = try JSONDecoder().decode(AnthropicPlatformDefinition.ModelType.self, from: encoded)
         #expect(decoded == model)

--- a/Tests/SpeziLLMTests/LLMAnthropicModelTypeTests.swift
+++ b/Tests/SpeziLLMTests/LLMAnthropicModelTypeTests.swift
@@ -1,0 +1,76 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+@testable import SpeziLLMAnthropic
+import Testing
+
+
+@Suite("LLM Anthropic ModelType")
+struct LLMAnthropicModelTypeTests {
+    @Test("Models map to the expected raw identifiers")
+    func modelRawValues() {
+        let expected: [(AnthropicPlatformDefinition.ModelType, String)] = [
+            (.fable5, "claude-fable-5"),
+            (.opus4_8, "claude-opus-4-8"),
+            (.opus4_7, "claude-opus-4-7"),
+            (.opus4_6, "claude-opus-4-6"),
+            (.sonnet5, "claude-sonnet-5"),
+            (.sonnet4_6, "claude-sonnet-4-6"),
+            (.haiku4_5, "claude-haiku-4-5")
+        ]
+
+        for (model, rawValue) in expected {
+            #expect(model.rawValue == rawValue)
+        }
+    }
+
+    @Test("wellKnownModels lists every current model")
+    func wellKnownModelsContainsCurrentModels() {
+        let rawValues = Set(AnthropicPlatformDefinition.ModelType.wellKnownModels.map(\.rawValue))
+        let models = [
+            "claude-fable-5",
+            "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6",
+            "claude-sonnet-5", "claude-sonnet-4-6",
+            "claude-haiku-4-5"
+        ]
+
+        for model in models {
+            #expect(rawValues.contains(model), "wellKnownModels is missing \(model)")
+        }
+    }
+
+    @Test("wellKnownModels does not contain duplicate identifiers")
+    func wellKnownModelsHasNoDuplicates() {
+        let rawValues = AnthropicPlatformDefinition.ModelType.wellKnownModels.map(\.rawValue)
+        #expect(rawValues.count == Set(rawValues).count)
+    }
+
+    @Test("The default model is the current flagship and is offered in the picker")
+    func defaultModelIsSupported() {
+        let defaultModel = AnthropicPlatformDefinition.ModelType.default
+        #expect(defaultModel.rawValue == "claude-opus-4-8")
+        #expect(AnthropicPlatformDefinition.ModelType.wellKnownModels.contains(defaultModel))
+    }
+
+    @Test("Arbitrary identifiers are accepted (open model set)")
+    func arbitraryIdentifiersAreAccepted() {
+        let viaRawValue = AnthropicPlatformDefinition.ModelType(rawValue: "some-future-model")
+        let viaStringLiteral: AnthropicPlatformDefinition.ModelType = "some-future-model"
+        #expect(viaRawValue == viaStringLiteral)
+        #expect(viaRawValue.rawValue == "some-future-model")
+    }
+
+    @Test("ModelType survives a Codable round-trip")
+    func modelTypeCodableRoundTrip() throws {
+        let model = AnthropicPlatformDefinition.ModelType.opus4_8
+        let encoded = try JSONEncoder().encode(model)
+        let decoded = try JSONDecoder().decode(AnthropicPlatformDefinition.ModelType.self, from: encoded)
+        #expect(decoded == model)
+    }
+}

--- a/Tests/SpeziLLMTests/LLMSamplingParameterTests.swift
+++ b/Tests/SpeziLLMTests/LLMSamplingParameterTests.swift
@@ -1,0 +1,71 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@testable import SpeziLLMAnthropic
+@testable import SpeziLLMOpenAI
+import Testing
+
+
+@Suite("Sampling Parameters")
+struct LLMSamplingParameterTests {
+    @Test("A model that takes them is left alone")
+    func keepsAcceptedParameters() {
+        let parameters = LLMOpenAIModelParameters(temperature: 0, topP: 0.5, presencePenalty: 1)
+        let accepted = parameters.accepted(by: AnthropicPlatformDefinition.ModelType.opus4_6)
+
+        #expect(accepted.temperature == 0)
+        #expect(accepted.topP == 0.5)
+        #expect(accepted.presencePenalty == 1)
+    }
+
+    @Test("A model that refuses sampling has them dropped")
+    func dropsRefusedParameters() {
+        let parameters = LLMOpenAIModelParameters(
+            temperature: 0.7,
+            topP: 0.5,
+            presencePenalty: 1,
+            frequencyPenalty: 1,
+            logitBias: ["1234": 50]
+        )
+        let accepted = parameters.accepted(by: AnthropicPlatformDefinition.ModelType.opus5)
+
+        #expect(accepted.temperature == nil)
+        #expect(accepted.topP == nil)
+        #expect(accepted.presencePenalty == nil)
+        #expect(accepted.frequencyPenalty == nil)
+        #expect(accepted.logitBias.additionalProperties.isEmpty)
+    }
+
+    @Test("Parameters a model takes anyway survive a model that refuses sampling")
+    func keepsUnrelatedParameters() {
+        let parameters = LLMOpenAIModelParameters(
+            temperature: 0.7,
+            stopSequence: ["stop"],
+            maxOutputLength: 512,
+            seed: 42,
+            user: "test-user"
+        )
+        let accepted = parameters.accepted(by: AnthropicPlatformDefinition.ModelType.opus5)
+
+        #expect(accepted.maxOutputLength == 512)
+        #expect(accepted.stopSequence == ["stop"])
+        #expect(accepted.seed == 42)
+        #expect(accepted.user == "test-user")
+        #expect(accepted.temperature == nil)
+    }
+
+    @Test("A model that refuses sampling is untouched when none were requested")
+    func leavesParametersAloneWhenNoneRequested() {
+        let parameters = LLMOpenAIModelParameters(stopSequence: ["stop"], maxOutputLength: 512)
+        let accepted = parameters.accepted(by: AnthropicPlatformDefinition.ModelType.opus5)
+
+        #expect(accepted.maxOutputLength == 512)
+        #expect(accepted.stopSequence == ["stop"])
+        #expect(accepted.temperature == nil)
+    }
+}


### PR DESCRIPTION
## Overview

Brings `AnthropicPlatformDefinition` up to Anthropic's current catalog, and stops the framework from sending sampling parameters that the newer models reject outright.

### Added
- **Claude Opus 5** — `claude-opus-5`
- **Claude Fable 5.1** — `claude-fable-5-1`
- **Claude Fable 5** — `claude-fable-5`
- **Claude Opus 4.8** — `claude-opus-4-8`
- **Claude Opus 4.7** — `claude-opus-4-7`
- **Claude Sonnet 5** — `claude-sonnet-5`

(existing `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5` retained)

### Changed
- **Default model → `claude-opus-5`** (was `claude-opus-4-6`). Anthropic now lists Opus 4.8 and everything below it as legacy, and recommends Opus 5 as the starting point for most workloads. This is a behaviour change for anyone relying on the implicit default.
- `wellKnownModels` refreshed to the current lineup.
- Renamed the incorrectly-named `haiku4_6` constant (its rawValue is `claude-haiku-4-5`) to `haiku4_5`; `haiku4_6` remains as a `@available(*, deprecated, renamed:)` alias for source compatibility.

### Sampling parameters are no longer sent to models that reject them

From Opus 4.7 onwards — and on Fable and Sonnet 5 — Anthropic answers `temperature`, `top_p`, the penalties and `logit_bias` with a `400` instead of ignoring them. Since this PR both adds those models and makes one of them the default, shipping it as a pure model-list refresh would mean a caller who set `temperature` once ends up with a session whose *every* request fails.

So `LLMOpenAILikePlatformModelType` gains one requirement:

```swift
/// Whether this model accepts the sampling parameters of the completions API.
var acceptsSamplingParameters: Bool { get }   // defaults to `true`
```

Each platform answers for its own models — the vendors dropped these parameters model by model rather than family by family, so it can't be inferred from the identifier. The request builder then filters the parameters through `accepted(by:)` before constructing the chat completion, dropping only what the chosen model refuses and logging what it dropped so the call site can be fixed. Anything unrelated (`stopSequence`, `maxOutputLength`, `seed`, `user`, …) is untouched, and a model that still takes sampling parameters is passed through unchanged.

The default is `true`, so an unrecognised or future identifier keeps today's behaviour and no existing conformance breaks.

### Also: the package no longer built under Xcode 26.6

Unrelated to the model refresh, but it blocks CI for this branch, so it is fixed here.

`accessModifier: package` in `openapi-generator-config.yaml` makes swift-openapi-generator emit `package import Foundation` in the generated client, while SwiftPM's own generated resource-bundle accessor for that same target emits a plain `import Foundation`. Swift 6.3 rejects the combination with *"ambiguous implicit access level for import"* — 18 errors in `GeneratedOpenAIClient`, reproducible on a clean `main`. It only surfaced now because CI jobs started landing on a runner with the newer Xcode.

Changed to `accessModifier: public`. `GeneratedOpenAIClient` is not a package product, so nothing outside the package can import it either way and the published API surface is unchanged. Enabling `InternalImportsByDefault` on the target was the alternative that would have preserved `package`, but it cascades into every public declaration mentioning a Foundation or SpeziKeychainStorage type — a wholesale re-annotation of the target's imports.

### Tests
- `LLMAnthropicModelTypeTests` — raw-value mappings, `wellKnownModels` contents, no duplicates, default model, arbitrary-id acceptance, Codable round-trip, and which models report refusing sampling parameters.
- `LLMSamplingParameterTests` — the filter keeps accepted parameters, drops refused ones, preserves unrelated ones, and no-ops when none were requested.
- Wires `SpeziLLMAnthropic` into the `SpeziLLMTests` target so it can be imported.

Full suite verified locally: **22 tests in 5 suites passing**, SwiftLint clean.

### Notes
- Fable is offered as an option but is deliberately not the default: it always thinks, never accepts sampling parameters, and is unavailable to organizations not authorized for the required 30-day data retention. That caveat is on the `fable5_1` doc comment.
- Also removes two now-superfluous `force_unwrapping` SwiftLint disable comments (Anthropic + Gemini `defaultServerUrl`). Verified against SwiftLint 0.65: restoring either one makes `superfluous_disable_command` fire.
- `diagnose_breaking_changes` stays disabled in CI. I confirmed the stated cause: `accessModifier: package` in `openapi-generator-config.yaml` makes the generated client do `package import Foundation` while SwiftPM's own generated resource-bundle accessor does a plain `import`, and adding `.enableUpcomingFeature("InternalImportsByDefault")` doesn't fix it — it cascades into `public` declarations referencing internal types. Worth a follow-up, but not something this PR can resolve.
