### PR TITLE
Fix GeneratedOpenAIClient import access levels (unblock Diagnose Breaking Changes)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -190,7 +190,12 @@ let package = Package(
                 .process("Resources")
             ],
             swiftSettings: [
-                .enableUpcomingFeature("ExistentialAny")
+                .enableUpcomingFeature("ExistentialAny"),
+                // The swift-openapi-generator emits `package import` (accessModifier: package), while the
+                // hand-written and SwiftPM-generated files use plain imports. That mix trips the stricter
+                // build used by `swift package diagnose-api-breaking-changes` with an "ambiguous implicit
+                // access level for import" error. Making unmarked imports explicitly internal resolves it.
+                .enableUpcomingFeature("InternalImportsByDefault")
             ],
             plugins: [
                 .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")

--- a/Sources/GeneratedOpenAIClient/AuthToken/LLMAuthTokenCollector+LocalizationDefaults.swift
+++ b/Sources/GeneratedOpenAIClient/AuthToken/LLMAuthTokenCollector+LocalizationDefaults.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Foundation
+package import Foundation
 
 
 extension LLMAuthTokenCollector {

--- a/Sources/GeneratedOpenAIClient/Middleware/BearerAuthMiddleware.swift
+++ b/Sources/GeneratedOpenAIClient/Middleware/BearerAuthMiddleware.swift
@@ -6,11 +6,11 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Foundation
-import HTTPTypes
-import OpenAPIRuntime
-import SpeziKeychainStorage
-import SpeziLLM
+package import Foundation
+package import HTTPTypes
+package import OpenAPIRuntime
+package import SpeziKeychainStorage
+package import SpeziLLM
 
 
 /// Middleware for injecting an Bearer API token into outgoing requests based on the ``RemoteLLMInferenceAuthToken``.

--- a/Sources/GeneratedOpenAIClient/Middleware/Retries/DelayPolicy.swift
+++ b/Sources/GeneratedOpenAIClient/Middleware/Retries/DelayPolicy.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Foundation
+public import Foundation
 
 /// Defines delay between retries.
 public enum DelayPolicy: Hashable, Sendable {

--- a/Sources/GeneratedOpenAIClient/Middleware/RetryMiddleware.swift
+++ b/Sources/GeneratedOpenAIClient/Middleware/RetryMiddleware.swift
@@ -6,9 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Foundation
-import HTTPTypes
-import OpenAPIRuntime
+package import Foundation
+package import HTTPTypes
+package import OpenAPIRuntime
 
 /// Middleware that retries HTTP requests based on defined conditions.
 package struct RetryMiddleware: Sendable {


### PR DESCRIPTION
## Problem

The **Diagnose Breaking Changes** CI job fails on every PR — but never for a real API break (`HAS_BREAKING_CHANGES: false`). `swift package diagnose-api-breaking-changes` builds under a stricter mode than the xcodebuild test job, and it can't build `GeneratedOpenAIClient`:

```
Sources/GeneratedOpenAIClient/Middleware/RetryMiddleware.swift:9:8: error:
  ambiguous implicit access level for import of 'Foundation'; it is imported as 'package' elsewhere
```

The swift-openapi-generator emits `package import` (config `accessModifier: package`), while the hand-written middleware/auth files and SwiftPM's generated `resource_bundle_accessor.swift` use plain `import`. That mix is what the diagnose build rejects. This was the **only** thing failing the diagnose build (swift-transformers, SpeziViews, etc. all compile fine on the runner).

## Fix

- Enable the compiler-recommended `InternalImportsByDefault` upcoming feature on the `GeneratedOpenAIClient` target — unmarked imports (including the SwiftPM-generated resource accessor, which can't be hand-edited) become explicitly `internal`, removing the ambiguity.
- Mark the hand-written files' imports at the access level matching their declarations: `package import` for the `package` middleware structs and the package-nested localization defaults; `public import Foundation` for `DelayPolicy` (it exposes `TimeInterval` publicly).

## Verification note

The diagnose tool also builds the `main` **baseline**, which still has the unfixed imports — so **this PR's own Diagnose Breaking Changes check will stay red until this merges to main**. Its Build & Test (xcodebuild) validates the change is safe for normal builds. After merge, the diagnose check works for all PRs (open PRs like the model-refresh ones need a rebase onto the fixed `main` to pick it up).